### PR TITLE
Import services, interactions and service interactions

### DIFF
--- a/lib/local-links-manager/import/csv_downloader.rb
+++ b/lib/local-links-manager/import/csv_downloader.rb
@@ -1,0 +1,29 @@
+require 'csv'
+
+class CsvDownloader
+  class Error < RuntimeError; end
+  class DownloadError < Error; end
+  class MalformedCSVError < Error; end
+
+  def initialize(csv_url)
+    @csv_url = csv_url
+  end
+
+  def download
+    CSV.parse(downloaded_csv, headers: true)
+  rescue CSV::MalformedCSVError => e
+    raise MalformedCSVError, "Error #{e.class} parsing CSV in #{self.class}"
+  end
+
+private
+
+  def downloaded_csv
+    response = Net::HTTP.get_response(URI.parse(@csv_url))
+
+    unless response.code_type == Net::HTTPOK
+      raise DownloadError, "Error downloading CSV in #{self.class}"
+    end
+
+    response.body
+  end
+end

--- a/lib/local-links-manager/import/interactions_importer.rb
+++ b/lib/local-links-manager/import/interactions_importer.rb
@@ -1,0 +1,43 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class InteractionsImporter
+      CSV_URL = "http://standards.esd.org.uk/csv?uri=list/interactions"
+
+      def self.import
+        new.import_records
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL))
+        @csv_downloader = csv_downloader
+      end
+
+      def import_records
+        @csv_downloader.download.each { |row| create_or_update_record(parsed_hash(row)) }
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} importing in #{self.class}\n#{e.backtrace.join("\n")}"
+      end
+
+    private
+
+      def parsed_hash(row)
+        {
+          label: row["Label"],
+          lgil_code: row["Identifier"]
+        }
+      end
+
+      def create_or_update_record(parsed_hash)
+        interaction = Interaction.where(lgil_code: parsed_hash[:lgil_code]).first_or_initialize
+        verb = interaction.persisted? ? "Updating" : "Creating"
+        Rails.logger.info("#{verb} interaction '#{parsed_hash[:label]}' (lgsl #{parsed_hash[:lgil_code]})")
+
+        interaction.label = parsed_hash[:label]
+        interaction.save!
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/import/service_interactions_importer.rb
+++ b/lib/local-links-manager/import/service_interactions_importer.rb
@@ -1,0 +1,75 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class ServiceInteractionsImporter
+      CSV_URL = "http://standards.esd.org.uk/csv?uri=list/englishAndWelshServices&mappedToUri=list/interactions"
+      class MissingRecordError < RuntimeError; end
+      class MissingIdentifierError < RuntimeError; end
+
+      def self.import
+        new.import_records
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL))
+        @csv_downloader = csv_downloader
+      end
+
+      def import_records
+        @csv_downloader.download.each do |row|
+          begin
+            create_or_update_record(find_associated_records(parsed_hash(row)))
+          rescue MissingRecordError, MissingIdentifierError => e
+            Rails.logger.error e.message
+          end
+        end
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} importing in #{self.class}\n#{e.backtrace.join("\n")}"
+      end
+
+    private
+
+      def parsed_hash(row)
+        raise MissingIdentifierError, missing_id_error_msg(Service) if row["Identifier"].nil?
+        raise MissingIdentifierError, missing_id_error_msg(Interaction) if row["Mapped identifier"].nil?
+
+        {
+          lgsl_code: row["Identifier"],
+          lgil_code: row["Mapped identifier"]
+        }
+      end
+
+      def find_associated_records(parsed_hash)
+        service = Service.find_by(lgsl_code: parsed_hash[:lgsl_code])
+        interaction = Interaction.find_by(lgil_code: parsed_hash[:lgil_code])
+
+        raise MissingRecordError, missing_record_error_msg(Service, :lgsl_code, parsed_hash[:lgsl_code]) unless service
+        raise MissingRecordError, missing_record_error_msg(Interaction, :lgil_code, parsed_hash[:lgil_code]) unless interaction
+
+        { service_id: service.id, interaction_id: interaction.id }
+      end
+
+      def missing_id_error_msg(klass)
+        "ServiceInteraction could not be created due to missing #{klass.name} identifier in CSV row"
+      end
+
+      def missing_record_error_msg(klass, id_type, id)
+        "ServiceInteraction could not be created due to missing #{klass.name} (#{id_type}: #{id})"
+      end
+
+      def create_or_update_record(parsed_hash)
+        service_interaction = ServiceInteraction.where(
+          service_id: parsed_hash[:service_id],
+          interaction_id: parsed_hash[:interaction_id]
+        ).first_or_initialize
+
+        verb = service_interaction.persisted? ? "Updating" : "Creating"
+        Rails.logger.info("#{verb} ServiceInteraction (service_id #{parsed_hash[:service_id]}, interaction_id: #{parsed_hash[:interaction_id]})")
+
+        service_interaction.save!
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/import/services_importer.rb
+++ b/lib/local-links-manager/import/services_importer.rb
@@ -1,0 +1,43 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class ServicesImporter
+      CSV_URL = "http://standards.esd.org.uk/csv?uri=list/englishAndWelshServices"
+
+      def self.import
+        new.import_records
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL))
+        @csv_downloader = csv_downloader
+      end
+
+      def import_records
+        @csv_downloader.download.each { |row| create_or_update_record(parsed_hash(row)) }
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} importing in #{self.class}\n#{e.backtrace.join("\n")}"
+      end
+
+    private
+
+      def parsed_hash(row)
+        {
+          label: row["Label"],
+          lgsl_code: row["Identifier"]
+        }
+      end
+
+      def create_or_update_record(parsed_hash)
+        service = Service.where(lgsl_code: parsed_hash[:lgsl_code]).first_or_initialize
+        verb = service.persisted? ? "Updating" : "Creating"
+        Rails.logger.info("#{verb} service '#{parsed_hash[:label]}' (lgsl #{parsed_hash[:lgsl_code]})")
+
+        service.label = parsed_hash[:label]
+        service.save!
+      end
+    end
+  end
+end

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -1,0 +1,29 @@
+require 'local-links-manager/import/services_importer'
+require 'local-links-manager/import/interactions_importer'
+require 'local-links-manager/import/service_interactions_importer'
+
+namespace :import do
+  namespace :service_interactions do
+    desc "Import ServiceInteractions and dependencies"
+    task import_all: :environment do
+      Rake::Task["import:service_interactions:import_services"].invoke
+      Rake::Task["import:service_interactions:import_interactions"].invoke
+      Rake::Task["import:service_interactions:import_service_interactions"].invoke
+    end
+
+    desc "Import Services from standards.esd.org.uk"
+    task import_services: :environment do
+      LocalLinksManager::Import::ServicesImporter.import
+    end
+
+    desc "Import Interactions from standards.esd.org.uk"
+    task import_interactions: :environment do
+      LocalLinksManager::Import::InteractionsImporter.import
+    end
+
+    desc "Import ServicesInteractions from standards.esd.org.uk"
+    task import_service_interactions: :environment do
+      LocalLinksManager::Import::ServiceInteractionsImporter.import
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/csv_downloader_spec.rb
+++ b/spec/lib/local-links-manager/import/csv_downloader_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+require 'local-links-manager/import/csv_downloader'
+
+describe CsvDownloader do
+  let(:csv_data) { File.read(fixture_file('sample.csv')) }
+  let(:malformed_csv_data) { File.read(fixture_file('sample_malformed.csv')) }
+
+  let(:url) { "http://standards.esd.org.uk/csv?uri=list/englishAndWelshServices" }
+  subject(:CsvDownloader) { described_class.new(url) }
+
+  def fixture_file(file)
+    File.expand_path("fixtures/" + file, File.dirname(__FILE__))
+  end
+
+  def stub_csv_download(data)
+    stub_request(:any, url)
+      .to_return(
+        body: data,
+        status: 200,
+        headers: { 'Content-Length' => data.length }
+    )
+  end
+
+  def stub_failed_csv_download
+    stub_request(:any, url)
+      .to_return(body: nil, status: 404)
+  end
+
+  describe '#download' do
+    context 'when download is successful' do
+      it 'returns the parsed rows' do
+        stub_csv_download(csv_data)
+
+        expected_rows = [
+          {
+            "Identifier" => "1614",
+            "Label" => "16 to 19 bursary fund",
+            "Description" => "They might struggle with the costs",
+          },
+          {
+            "Identifier" => "13",
+            "Label" => "Abandoned shopping trolleys",
+            "Description" => "Abandoned shopping trolleys have a negative impact",
+          }
+        ]
+
+        expect(subject.download.map { |r| r.to_h.compact }).to eq(expected_rows)
+      end
+    end
+
+    context 'when download is not successful' do
+      it 'raises the error for failed download' do
+        stub_failed_csv_download
+
+        expect { subject.download }.to raise_error(CsvDownloader::DownloadError)
+      end
+    end
+
+    context 'when CSV data is malformed' do
+      it 'raises the error for malformed CSV' do
+        stub_csv_download(malformed_csv_data)
+
+        expect { subject.download }.to raise_error(CsvDownloader::MalformedCSVError)
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/fixtures/sample.csv
+++ b/spec/lib/local-links-manager/import/fixtures/sample.csv
@@ -1,0 +1,3 @@
+Identifier,Label,Description,
+1614,16 to 19 bursary fund,"They might struggle with the costs",
+13,Abandoned shopping trolleys,"Abandoned shopping trolleys have a negative impact",

--- a/spec/lib/local-links-manager/import/fixtures/sample_malformed.csv
+++ b/spec/lib/local-links-manager/import/fixtures/sample_malformed.csv
@@ -1,0 +1,3 @@
+Identifier,Label,Description,
+1614,16 to 19 bursary fund,"They might struggle with the costs",
+13,"malformed"Abandoned shopping trolleys,"Abandoned shopping trolleys have a negative impact",

--- a/spec/lib/local-links-manager/import/interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/interactions_importer_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require 'local-links-manager/import/interactions_importer'
+
+describe LocalLinksManager::Import::InteractionsImporter do
+  describe '#import_records' do
+    let(:csv_downloader) { instance_double CsvDownloader }
+
+    context 'when interactions download is successful' do
+      it 'imports interactions' do
+        csv_rows = [
+          {
+            "Identifier" => "0",
+            "Label" => "Applications for service",
+          },
+          {
+            "Identifier" => "30",
+            "Label" => "Application for exemption",
+          }
+        ]
+
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        LocalLinksManager::Import::InteractionsImporter.new(csv_downloader).import_records
+
+        expect(Interaction.count).to eq(2)
+
+        interaction = Interaction.find_by(lgil_code: 30)
+        expect(interaction.label).to eq("Application for exemption")
+      end
+    end
+
+    context 'when interactions download is not successful' do
+      it 'logs the error on failed download' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
+
+        expect(Rails.logger).to receive(:error).with("Error downloading CSV")
+
+        LocalLinksManager::Import::InteractionsImporter.new(csv_downloader).import_records
+      end
+    end
+
+    context 'when CSV data is malformed' do
+      it 'logs an error that it failed importing' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
+
+        expect(Rails.logger).to receive(:error).with("Malformed CSV error")
+
+        LocalLinksManager::Import::InteractionsImporter.new(csv_downloader).import_records
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+require 'local-links-manager/import/service_interactions_importer'
+
+describe LocalLinksManager::Import::ServiceInteractionsImporter do
+  describe '#import_records' do
+    let(:csv_downloader) { instance_double CsvDownloader }
+
+    context 'when service interactions download is successful' do
+      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
+      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+
+      let!(:interaction_0) { FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about") }
+      let!(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact") }
+
+      let(:csv_rows) {
+        [
+          { "Identifier" => "1614", "Mapped identifier" => "0" },
+          { "Identifier" => "13", "Mapped identifier" => "30" },
+          { "Identifier" => "13", "Mapped identifier" => "0" },
+          { "Identifier" => "1614", "Mapped identifier" => "30" },
+        ]
+      }
+
+      let(:csv_rows_with_missing_entries) {
+        [
+          { "Identifier" => "1614", "Mapped identifier" => nil },
+          { "Identifier" => nil, "Mapped identifier" => "0" },
+        ]
+      }
+
+      let(:csv_rows_with_missing_associated_entries) {
+        [
+          { "Identifier" => "13", "Mapped identifier" => "999" },
+          { "Identifier" => "999", "Mapped identifier" => "30" },
+        ]
+      }
+
+      it 'imports service interactions' do
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        LocalLinksManager::Import::ServiceInteractionsImporter.new(csv_downloader).import_records
+
+        expect(ServiceInteraction.count).to eq(4)
+
+        service_interaction = ServiceInteraction.last
+        expect(service_interaction.service_id).to eq(service_0.id)
+        expect(service_interaction.interaction_id).to eq(interaction_1.id)
+      end
+
+      it 'raises error and logs a warning when Identifier or Mapped Identifier is empty' do
+        allow(csv_downloader).to receive(:download).and_return(csv_rows_with_missing_entries)
+
+        expect(Rails.logger).to receive(:error).with(/could not be created due to missing Service identifier/)
+        expect(Rails.logger).to receive(:error).with(/could not be created due to missing Interaction identifier/)
+
+        LocalLinksManager::Import::ServiceInteractionsImporter.new(csv_downloader).import_records
+
+        expect(ServiceInteraction.count).to eq(0)
+      end
+
+      it 'raises error and logs a warning when an associated Service or Interaction is missing' do
+        allow(csv_downloader).to receive(:download).and_return(csv_rows_with_missing_associated_entries)
+
+        expect(Rails.logger).to receive(:error).with(/could not be created due to missing Service/)
+        expect(Rails.logger).to receive(:error).with(/could not be created due to missing Interaction/)
+
+        LocalLinksManager::Import::ServiceInteractionsImporter.new(csv_downloader).import_records
+
+        expect(ServiceInteraction.count).to eq(0)
+      end
+    end
+
+    context 'when service interactions download is not successful' do
+      it 'logs the error on failed download' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
+
+        expect(Rails.logger).to receive(:error).with("Error downloading CSV")
+
+        LocalLinksManager::Import::ServiceInteractionsImporter.new(csv_downloader).import_records
+      end
+    end
+
+    context 'when CSV data is malformed' do
+      it 'logs an error that it failed importing' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
+
+        expect(Rails.logger).to receive(:error).with("Malformed CSV error")
+
+        LocalLinksManager::Import::ServiceInteractionsImporter.new(csv_downloader).import_records
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require 'local-links-manager/import/services_importer'
+
+describe LocalLinksManager::Import::ServicesImporter do
+  describe '#import_records' do
+    let(:csv_downloader) { instance_double CsvDownloader }
+
+    context 'when services download is successful' do
+      it 'imports services' do
+        csv_rows = [
+          {
+            "Identifier" => "1614",
+            "Label" => "16 to 19 bursary fund",
+          },
+          {
+            "Identifier" => "13",
+            "Label" => "Abandoned shopping trolleys",
+          }
+        ]
+
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        LocalLinksManager::Import::ServicesImporter.new(csv_downloader).import_records
+
+        expect(Service.count).to eq(2)
+
+        service = Service.find_by(lgsl_code: 1614)
+        expect(service.label).to eq("16 to 19 bursary fund")
+      end
+    end
+
+    context 'when services download is not successful' do
+      it 'logs the error on failed download' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
+
+        expect(Rails.logger).to receive(:error).with("Error downloading CSV")
+
+        LocalLinksManager::Import::ServicesImporter.new(csv_downloader).import_records
+      end
+    end
+
+    context 'when CSV data is malformed' do
+      it 'logs an error that it failed importing' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
+
+        expect(Rails.logger).to receive(:error).with("Malformed CSV error")
+
+        LocalLinksManager::Import::ServicesImporter.new(csv_downloader).import_records
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds importer classes and rake tasks to import Services, Interactions and ServiceInteractions from standards.esd website. The original files are in CSV format, so we download them with Net:HTTP's `get_response` method, parse them and store them as records in our local database. The order of the imports is important, as Services and Interactions have to be imported first, before ServiceInteractions (which acts as a join model between the two) can be imported successfully.

We split out a `CsvDownloader` class which we use in our importer classes as well as `LocalAuthorityUrlImporter`.

For ServiceInteractions we log a summary of imported rows, as there are a number of errors that can appear.

Worked with @klssmith and @emmabeynon on this story, just plastered my face on all commits as we were using my laptop :)
