### PR TITLE
UI for services and interactions

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,0 +1,6 @@
+class InteractionsController < ApplicationController
+  def index
+    @service = Service.find_by_slug!(params[:service_slug])
+    @interactions = @service.interactions
+  end
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,0 +1,6 @@
+class ServicesController < ApplicationController
+  def index
+    @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
+    @services = Service.all
+  end
+end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -2,4 +2,5 @@ class Interaction < ActiveRecord::Base
   validates :lgil_code, :label, presence: true, uniqueness: true
 
   has_many :service_interactions
+  has_many :services, through: :service_interactions
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,8 +1,9 @@
 class Service < ActiveRecord::Base
-  validates :lgsl_code, :label, presence: true, uniqueness: true
+  validates :lgsl_code, :label, :slug, presence: true, uniqueness: true
   validates :tier, inclusion: { in: %w{all county/unitary district/unitary}, allow_nil: true }
 
   has_many :service_interactions
+  has_many :interactions, through: :service_interactions
 
   scope :for_tier, ->(tier) {
     case tier

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, @service.label %>
+<div class="page-title">
+  <h1><%= @service.label %></h1>
+</div>
+
+<% if @interactions.any? %>
+  <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
+    <thead>
+      <tr class="table-header">
+        <th>LGIL Code</th>
+        <th>Local Government Interactions (<%= @interactions.count %>)</th>
+      </tr>
+      <%= render partial: "govuk_admin_template/table_filter",
+      locals: {placeholder: "Filter list of local interactions"} %>
+    </thead>
+    <tbody>
+      <% @interactions.each do |interaction| %>
+        <tr>
+          <td class="lgil_code">
+            <%= interaction.lgil_code %>
+          </td>
+          <td class="name">
+            <%= interaction.label %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+<% else %>
+  <h4>No local interactions found</h4>
+<% end %>

--- a/app/views/local_authorities/_local_authority.html.erb
+++ b/app/views/local_authorities/_local_authority.html.erb
@@ -1,3 +1,0 @@
-<tr>
-  <td><%= local_authority.name %></td>
-</tr>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -13,7 +13,13 @@
       locals: {placeholder: "Filter list of local authorities"} %>
     </thead>
     <tbody>
-      <%= render @authorities %>
+      <% @authorities.each do |authority| %>
+        <tr>
+          <td class="name">
+            <%= link_to authority.name, local_authority_services_path(authority.slug), class: 'js-open-on-submit' %>
+          </td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, @authority.name %>
+<div class="page-title">
+  <h1><%= @authority.name %></h1>
+</div>
+
+<% if @services.any? %>
+  <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
+    <thead>
+      <tr class="table-header">
+        <th>LGSL Code</th>
+        <th>Local Government Services (<%= @services.count %>)</th>
+      </tr>
+      <%= render partial: "govuk_admin_template/table_filter",
+      locals: {placeholder: "Filter list of local services"} %>
+    </thead>
+    <tbody>
+      <% @services.each do |service| %>
+        <tr>
+          <td class="lgsl_code">
+            <%= service.lgsl_code %>
+          </td>
+          <td class="name">
+            <%= link_to service.label, local_authority_service_interactions_path(service_slug: service.slug), class: 'js-open-on-submit' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+<% else %>
+  <h4>No local services found</h4>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,14 @@
+# http://local-links-manager.dev.gov.uk/local_authorities/aberdeen/services/name/interactions
 Rails.application.routes.draw do
   root to: 'local_authorities#index'
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
+
+  resources "local_authorities", only: [:index], param: :slug do
+    resources "services", only: [:index], param: :slug do
+      resources "interactions", only: [:index]
+    end
+  end
 
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"

--- a/db/migrate/20160513113110_add_slug_to_services.rb
+++ b/db/migrate/20160513113110_add_slug_to_services.rb
@@ -1,0 +1,16 @@
+class AddSlugToServices < ActiveRecord::Migration
+  def up
+    add_column :services, :slug, :string, unique: true
+
+    Service.all.each do |service|
+      service.slug = service.label.parameterize
+      service.save!
+    end
+
+    change_column_null :services, :slug, false
+  end
+
+  def down
+    remove_column :services, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160511144329) do
+ActiveRecord::Schema.define(version: 20160513113110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20160511144329) do
     t.string   "label",      null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "slug",       null: false
     t.string   "tier"
   end
 

--- a/lib/local-links-manager/import/services_importer.rb
+++ b/lib/local-links-manager/import/services_importer.rb
@@ -33,6 +33,7 @@ module LocalLinksManager
         Rails.logger.info("#{verb} service '#{row[:label]}' (lgsl #{row[:lgsl_code]})")
 
         service.label = row[:label]
+        service.slug = row[:label].parameterize
         service.save!
       end
     end

--- a/spec/controllers/interactions_controller_spec.rb
+++ b/spec/controllers/interactions_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe InteractionsController, type: :controller do
+  before do
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+    @service = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+    @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+  end
+
+  describe "GET #index" do
+    it "returns http success" do
+      login_as_stub_user
+      get :index, local_authority_slug: @local_authority.slug, service_slug: @service.slug
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ServicesController, type: :controller do
+  before do
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+    @service = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+  end
+
+  describe "GET #index" do
+    it "returns http success" do
+      login_as_stub_user
+      get :index, local_authority_slug: @local_authority.slug, service_slug: @service.slug
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :service do
     lgsl_code 1152
     label "Abandoned shopping trolleys"
+    slug "abandoned-shopping-trolleys"
   end
 end

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -1,0 +1,36 @@
+describe "The interactions index page", type: :feature do
+  before do
+    User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+    @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+    visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
+  end
+
+  describe "with no interactions present" do
+    it "shows a message that no interactions are present" do
+      expect(page).to have_content("No local interactions found")
+    end
+  end
+
+  describe "with interactions present" do
+    before do
+      @interaction_1 = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+      @interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 4)
+      FactoryGirl.create(:service_interaction, service_id: @service_1.id, interaction_id: @interaction_1.id)
+      visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
+    end
+
+    it "shows the available interactions for the service" do
+      expect(page).to have_content('Local Government Interactions (1)')
+      expect(page).to have_content('Interaction 1')
+      # Interaction 2 does not belong to service 1, so don't display it.
+      expect(page).not_to have_content('Interaction 2')
+    end
+
+    it "shows each service interaction's LGIL code" do
+      expect(page).to have_content 'LGIL Code'
+      expect(page).to have_css('td.lgil_code', text: 3)
+      expect(page).not_to have_css('td.lgil_code', text: 4)
+    end
+  end
+end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -1,22 +1,33 @@
-describe "The local authority index page", type: :feature do
-  before :each do
+describe "The local authorities index page", type: :feature do
+  before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
+    visit root_path
   end
 
-  it "shows a message if no local authorities are present" do
-    visit '/'
-
-    expect(page).to have_content 'No local authorities found'
+  describe "with no local authorities present" do
+    it "shows a message if no local authorities are present" do
+      expect(page).to have_content 'No local authorities found'
+    end
   end
 
-  it "shows the available local authorities" do
-    FactoryGirl.create(:local_authority, name: "Angus")
-    FactoryGirl.create(:local_authority, name: "Zorro Council", gss: "XXXXXXXXX", snac: "ZZZZ")
+  describe "with local authorities present" do
+    before do
+      @angus = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+      @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', slug: 'zorro', gss: 'XXXXXXXXX', snac: 'ZZZZ')
+      visit root_path
+    end
 
-    visit '/'
+    it "shows the available local authorities with links to their respective pages" do
+      expect(page).to have_content 'Local Authorities (2)'
+      expect(page).to have_link('Angus', href: local_authority_services_path(@angus.slug))
+      expect(page).to have_link('Zorro Council', href: local_authority_services_path(@zorro.slug))
+    end
 
-    expect(page).to have_content 'Local Authorities (2)'
-    expect(page).to have_content 'Angus'
-    expect(page).to have_content 'Zorro Council'
+    describe "clicking on the LA name on the index page" do
+      it "takes you to the show page for that LA" do
+        click_link('Angus')
+        expect(current_path).to eq(local_authority_services_path(@angus.slug))
+      end
+    end
   end
 end

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -1,0 +1,33 @@
+feature "The services index page", type: :feature do
+  before do
+    User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+    visit local_authority_services_path(local_authority_slug: @local_authority.slug)
+  end
+
+  describe "with no services present" do
+    it "shows a message that no services are present" do
+      expect(page).to have_content 'No local services found'
+    end
+  end
+
+  describe "with services present" do
+    before do
+      @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+      @service_2 = FactoryGirl.create(:service, label: 'Service 2', slug: 'service-2', lgsl_code: 2)
+      visit local_authority_services_path(@local_authority.slug)
+    end
+
+    it "shows the available services with links to their individual pages" do
+      expect(page).to have_content 'Local Government Services (2)'
+      expect(page).to have_link('Service 1', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug))
+      expect(page).to have_link('Service 2', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_2.slug))
+    end
+
+    it "shows each service's LGSL codes in the table" do
+      expect(page).to have_content 'LGSL Code'
+      expect(page).to have_css('td.lgsl_code', text: 1)
+      expect(page).to have_css('td.lgsl_code', text: 2)
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -6,8 +6,8 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter do
     let(:csv_downloader) { instance_double CsvDownloader }
 
     context 'when service interactions download is successful' do
-      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
-      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service", slug: "bursary-fund-service") }
+      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys", slug: "abandoned-shopping-trolleys") }
 
       let!(:interaction_0) { FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about") }
       let!(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact") }

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -26,6 +26,7 @@ describe LocalLinksManager::Import::ServicesImporter do
 
         service = Service.find_by(lgsl_code: 1614)
         expect(service.label).to eq("16 to 19 bursary fund")
+        expect(service.slug).to eq("16-to-19-bursary-fund")
       end
     end
 

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -8,16 +8,19 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'imports the tiers from the csv file and updates existing services' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
+        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: nil
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
+        slug: "arson-reduction",
         label: "Arson reduction",
         tier: nil
       )
       yellow_lines = FactoryGirl.create(:service,
         lgsl_code: 538,
+        slug: "yellow-lines",
         label: "Yellow lines",
         tier: nil
       )
@@ -66,6 +69,7 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'does not update tiers to be blank' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
+        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: 'all'
       )
@@ -87,16 +91,19 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'does not halt in the face of an error on a single row' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
+        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: nil
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
+        slug: "arson-reduction",
         label: "Arson reduction",
         tier: nil
       )
       soil_excavation = FactoryGirl.create(:service,
         lgsl_code: 1419,
+        slug: "soil-excavation",
         label: "Soil excavation",
         tier: nil
       )

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -7,18 +7,20 @@ RSpec.describe Service, type: :model do
 
   it { is_expected.to validate_presence_of(:lgsl_code) }
   it { is_expected.to validate_presence_of(:label) }
+  it { is_expected.to validate_presence_of(:slug) }
   it { is_expected.to validate_uniqueness_of(:lgsl_code) }
   it { is_expected.to validate_uniqueness_of(:label) }
+  it { is_expected.to validate_uniqueness_of(:slug) }
   it { is_expected.to validate_inclusion_of(:tier).in_array(%w{all county/unitary district/unitary}) }
   it { is_expected.to allow_value(nil).for(:tier) }
 
   it { is_expected.to have_many(:service_interactions) }
 
   describe '.for_tier' do
-    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, label: 'all service', tier: 'all') }
-    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, label: 'district service', tier: 'district/unitary') }
-    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, label: 'county service', tier: 'county/unitary') }
-    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, label: 'nil service', tier: nil) }
+    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, slug: 'all-service', label: 'all service', tier: 'all') }
+    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, slug: 'district-service', label: 'district service', tier: 'district/unitary') }
+    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, slug: 'county-service', label: 'county service', tier: 'county/unitary') }
+    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, slug: 'nil-service', label: 'nil service', tier: nil) }
 
     it 'returns all services with a tier when asked for "all"' do
       expect(described_class.for_tier('all')).to match_array([all_service, district_service, county_service])


### PR DESCRIPTION
- This means routes of the form
  `/local_authorities/aberdeen/services/16-to-19-bursary-fund/interactions`,
  using slugs as IDs to appear more nicely to users, and hence with
  nesting of services under local authorities, and interactions under
  services. To do the friendly URLs, we had to add a `slug` column to
  the Services table and generate the slug in the import script using
  `label.parameterize`.
- The interactions list only shows the applicable ones for the selected
  service. These aren't links yet - that's a separate story.
- Also a separate story is scoping the services list based on the ones
  that the Local Authority provides - now it just shows all 900.

Screenshots of now (2016-05-13):

<img width="1440" alt="screenshot 2016-05-13 16 26 08" src="https://cloud.githubusercontent.com/assets/355033/15252826/949d2706-1927-11e6-9551-2c7aff19ecc4.png">

<img width="1440" alt="screenshot 2016-05-13 16 26 20" src="https://cloud.githubusercontent.com/assets/355033/15252835/9b1476d4-1927-11e6-89d3-60d240b55443.png">

<img width="1440" alt="screenshot 2016-05-13 16 26 35" src="https://cloud.githubusercontent.com/assets/355033/15252841/a1858f08-1927-11e6-8b38-7fcb15557124.png">
