### PR TITLE
Use CSV header converters

### DIFF
--- a/lib/local-links-manager/import/csv_downloader.rb
+++ b/lib/local-links-manager/import/csv_downloader.rb
@@ -5,12 +5,16 @@ class CsvDownloader
   class DownloadError < Error; end
   class MalformedCSVError < Error; end
 
-  def initialize(csv_url)
+  def initialize(csv_url, header_conversions = {})
     @csv_url = csv_url
+    @header_conversions = header_conversions
   end
 
   def download
-    CSV.parse(downloaded_csv, headers: true)
+    CSV.parse(downloaded_csv,
+              headers: true,
+              header_converters: field_name_converter)
+
   rescue CSV::MalformedCSVError => e
     raise MalformedCSVError, "Error #{e.class} parsing CSV in #{self.class}"
   end
@@ -25,5 +29,11 @@ private
     end
 
     response.body
+  end
+
+  def field_name_converter
+    lambda do |field|
+      @header_conversions.key?(field) ? @header_conversions[field] : field
+    end
   end
 end

--- a/spec/lib/local-links-manager/import/csv_downloader_spec.rb
+++ b/spec/lib/local-links-manager/import/csv_downloader_spec.rb
@@ -46,6 +46,32 @@ describe CsvDownloader do
 
         expect(subject.download.map { |r| r.to_h.compact }).to eq(expected_rows)
       end
+
+      it 'optionally converts the headers' do
+        stub_csv_download(csv_data)
+
+        header_conversions = {
+          "Identifier" => :lgsl_code,
+          "Label" => :label,
+          "Description" => :description,
+        }
+
+        downloader = CsvDownloader.new(url, header_conversions)
+
+        expected_rows = [
+          {
+            lgsl_code: "1614",
+            label: "16 to 19 bursary fund",
+            description: "They might struggle with the costs",
+          },
+          {
+            lgsl_code: "13",
+            label: "Abandoned shopping trolleys",
+            description: "Abandoned shopping trolleys have a negative impact",
+          }
+        ]
+        expect(downloader.download.map { |r| r.to_h.compact }).to eq(expected_rows)
+      end
     end
 
     context 'when download is not successful' do

--- a/spec/lib/local-links-manager/import/interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/interactions_importer_spec.rb
@@ -9,12 +9,12 @@ describe LocalLinksManager::Import::InteractionsImporter do
       it 'imports interactions' do
         csv_rows = [
           {
-            "Identifier" => "0",
-            "Label" => "Applications for service",
+            lgil_code: "0",
+            label: "Applications for service",
           },
           {
-            "Identifier" => "30",
-            "Label" => "Application for exemption",
+            lgil_code: "30",
+            label: "Application for exemption",
           }
         ]
 

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -14,24 +14,24 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter do
 
       let(:csv_rows) {
         [
-          { "Identifier" => "1614", "Mapped identifier" => "0" },
-          { "Identifier" => "13", "Mapped identifier" => "30" },
-          { "Identifier" => "13", "Mapped identifier" => "0" },
-          { "Identifier" => "1614", "Mapped identifier" => "30" },
+          { lgsl_code: "1614", lgil_code: "0" },
+          { lgsl_code: "13", lgil_code: "30" },
+          { lgsl_code: "13", lgil_code: "0" },
+          { lgsl_code: "1614", lgil_code: "30" },
         ]
       }
 
       let(:csv_rows_with_missing_entries) {
         [
-          { "Identifier" => "1614", "Mapped identifier" => nil },
-          { "Identifier" => nil, "Mapped identifier" => "0" },
+          { lgsl_code: "1614", lgil_code: nil },
+          { lgsl_code: nil, lgil_code: "0" },
         ]
       }
 
       let(:csv_rows_with_missing_associated_entries) {
         [
-          { "Identifier" => "13", "Mapped identifier" => "999" },
-          { "Identifier" => "999", "Mapped identifier" => "30" },
+          { lgsl_code: "13", lgil_code: "999" },
+          { lgsl_code: "999", lgil_code: "30" },
         ]
       }
 

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -9,12 +9,12 @@ describe LocalLinksManager::Import::ServicesImporter do
       it 'imports services' do
         csv_rows = [
           {
-            "Identifier" => "1614",
-            "Label" => "16 to 19 bursary fund",
+            lgsl_code: "1614",
+            label: "16 to 19 bursary fund",
           },
           {
-            "Identifier" => "13",
-            "Label" => "Abandoned shopping trolleys",
+            lgsl_code: "13",
+            label: "Abandoned shopping trolleys",
           }
         ]
 


### PR DESCRIPTION
In the Importer classes (Service, Interaction, ServiceInteraction), we previously converted some header names to more readable names (such as "Mapped identifier" -> :lgil_code). This forced another level of indirection for imported CSV rows, having to call the `parsed_hash` method on a row first before it could get passed to the `create_or_update_method`.

This commit makes use of the `CSV` library's support for [converters](http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/CSV.html#method-i-header_convert), so we can pass a hash of conversions to the `CsvDownloader` class, and the conversions are applied as the CSV rows are imported. This helps to declutter the Importer classes, makes the `CsvDownloader` (rightfully) responsible for the conversions and makes the tests more readable.
