### PR TITLE
Add tiers to services

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,4 +3,21 @@ class Service < ActiveRecord::Base
   validates :tier, inclusion: { in: %w{all county/unitary district/unitary}, allow_nil: true }
 
   has_many :service_interactions
+
+  def provided_by?(authority)
+    case tier
+    when nil
+      false
+    when 'all'
+      true
+    else
+      tiers.include? authority.tier
+    end
+  end
+
+private
+
+  def tiers
+    tier.split('/')
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,6 +4,17 @@ class Service < ActiveRecord::Base
 
   has_many :service_interactions
 
+  scope :for_tier, ->(tier) {
+    case tier
+    when 'county', 'district'
+      where("services.tier = 'all' OR services.tier = '#{tier}/unitary'")
+    when 'unitary', 'all'
+      where.not(services: { tier: nil })
+    else
+      raise ArgumentError, "invalid tier '#{tier}'"
+    end
+  }
+
   def provided_by?(authority)
     case tier
     when nil

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,5 +1,6 @@
 class Service < ActiveRecord::Base
   validates :lgsl_code, :label, presence: true, uniqueness: true
+  validates :tier, inclusion: { in: %w{all county/unitary district/unitary}, allow_nil: true }
 
   has_many :service_interactions
 end

--- a/db/migrate/20160511144329_add_tier_to_services.rb
+++ b/db/migrate/20160511144329_add_tier_to_services.rb
@@ -1,0 +1,5 @@
+class AddTierToServices < ActiveRecord::Migration
+  def change
+    add_column :services, :tier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160504133456) do
+ActiveRecord::Schema.define(version: 20160511144329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20160504133456) do
     t.string   "label",      null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "tier"
   end
 
   add_index "services", ["label"], name: "index_services_on_label", unique: true, using: :btree

--- a/lib/local-links-manager/import/services_tier_importer.rb
+++ b/lib/local-links-manager/import/services_tier_importer.rb
@@ -1,0 +1,90 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class ServicesTierImporter
+      CSV_URL = "https://raw.githubusercontent.com/alphagov/publisher/master/data/local_services.csv"
+      FIELD_NAME_CONVERSIONS = {
+        'LGSL' => :lgsl_code,
+        'Providing Tier' => :tier,
+      }
+      class MissingRecordError < RuntimeError; end
+      class MissingIdentifierError < RuntimeError; end
+
+      def self.import
+        new.import_tiers
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+        @csv_downloader = csv_downloader
+        @csv_rows = 0
+        @missing_record_count = 0
+        @missing_id_count = 0
+        @invalid_record_count = 0
+        @updated_record_count = 0
+        @ignored_rows_count = 0
+      end
+
+      def import_tiers
+        with_each_csv_row do |row|
+          counting_errors do
+            if update_record(row)
+              @updated_record_count += 1
+            else
+              @ignored_rows_count += 1
+            end
+          end
+        end
+        Rails.logger.info import_summary
+      end
+
+    private
+
+      def import_summary
+        "ServicesTier Import complete\n"\
+        "Downloaded CSV rows: #{@csv_rows}\n"\
+        "Updated records: #{@updated_record_count}\n"\
+        "Ignored rows: #{@ignored_rows_count}\n"\
+        "Import errors with missing Identifier: #{@missing_id_count}\n"\
+        "Import errors with missing associated Record: #{@missing_record_count}\n"\
+        "Import errors with invalid values for updating record: #{@invalid_record_count}\n"
+      end
+
+      def update_record(row)
+        raise MissingIdentifierError if row[:lgsl_code].blank?
+        service = Service.find_by(lgsl_code: row[:lgsl_code])
+        raise MissingRecordError if service.nil?
+        Rails.logger.info("Updating service '#{service.label}' (lgsl #{service.lgsl_code})")
+
+        unless row[:tier].blank?
+          service.tier = row[:tier]
+          service.save!
+        end
+      end
+
+      def with_each_csv_row(&block)
+        @csv_downloader.download.each do |row|
+          @csv_rows += 1
+          block.call(row)
+        end
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} importing in #{self.class}\n#{e.backtrace.join("\n")}"
+      end
+
+      def counting_errors(&block)
+        block.call
+      rescue MissingRecordError => e
+        @missing_record_count += 1
+        Rails.logger.error e.message
+      rescue MissingIdentifierError => e
+        @missing_id_count += 1
+        Rails.logger.error e.message
+      rescue ActiveRecord::RecordInvalid => e
+        @invalid_record_count += 1
+        Rails.logger.error e.message
+      end
+    end
+  end
+end

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -1,6 +1,7 @@
 require 'local-links-manager/import/services_importer'
 require 'local-links-manager/import/interactions_importer'
 require 'local-links-manager/import/service_interactions_importer'
+require 'local-links-manager/import/services_tier_importer'
 
 namespace :import do
   namespace :service_interactions do
@@ -9,6 +10,7 @@ namespace :import do
       Rake::Task["import:service_interactions:import_services"].invoke
       Rake::Task["import:service_interactions:import_interactions"].invoke
       Rake::Task["import:service_interactions:import_service_interactions"].invoke
+      Rake::Task["import:service_interactions:add_service_tiers"].invoke
     end
 
     desc "Import Services from standards.esd.org.uk"
@@ -24,6 +26,11 @@ namespace :import do
     desc "Import ServicesInteractions from standards.esd.org.uk"
     task import_service_interactions: :environment do
       LocalLinksManager::Import::ServiceInteractionsImporter.import
+    end
+
+    desc "Add tiers from local_services.csv in publisher to the list of Services imported by `import_services`"
+    task add_service_tiers: :environment do
+      LocalLinksManager::Import::ServicesTierImporter.import
     end
   end
 end

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+require 'local-links-manager/import/services_tier_importer'
+
+describe LocalLinksManager::Import::ServicesTierImporter do
+  let(:csv_downloader) { instance_double CsvDownloader }
+  subject { described_class.new(csv_downloader) }
+  describe 'import_tiers' do
+    it 'imports the tiers from the csv file and updates existing services' do
+      abandoned_shopping_trolleys = FactoryGirl.create(:service,
+        lgsl_code: 1152,
+        label: "Abandoned shopping trolleys",
+        tier: nil
+      )
+      arson_reduction = FactoryGirl.create(:service,
+        lgsl_code: 800,
+        label: "Arson reduction",
+        tier: nil
+      )
+      yellow_lines = FactoryGirl.create(:service,
+        lgsl_code: 538,
+        label: "Yellow lines",
+        tier: nil
+      )
+
+      csv_rows = [
+        {
+          :lgsl_code => '1152',
+          'Description' => 'Abandoned shopping trolleys',
+          :tier => 'county/unitary'
+        },
+        {
+          :lgsl_code => '800',
+          'Description' => 'Arson reduction',
+          :tier => 'district/unitary'
+        },
+        {
+          :lgsl_code => '538',
+          'Description' => 'Yellow lines',
+          :tier => 'all'
+        },
+      ]
+      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+      subject.import_tiers
+
+      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
+      expect(arson_reduction.reload.tier).to eq('district/unitary')
+      expect(yellow_lines.reload.tier).to eq('all')
+    end
+
+    it 'does not create new services for rows in the csv without a matching Service instance' do
+      csv_rows = [
+        {
+          :lgsl_code => '1152',
+          'Description' => 'Abandoned shopping trolleys',
+          :tier => 'county/unitary'
+        },
+      ]
+      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+      subject.import_tiers
+
+      expect(Service.exists?(lgsl_code: 1152)).to be_falsey
+    end
+
+    it 'does not update tiers to be blank' do
+      abandoned_shopping_trolleys = FactoryGirl.create(:service,
+        lgsl_code: 1152,
+        label: "Abandoned shopping trolleys",
+        tier: 'all'
+      )
+
+      csv_rows = [
+        {
+          :lgsl_code => '1152',
+          'Description' => 'Abandoned shopping trolleys',
+          :tier => ''
+        },
+      ]
+      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+      subject.import_tiers
+
+      expect(abandoned_shopping_trolleys.reload.tier).not_to be_blank
+    end
+
+    it 'does not halt in the face of an error on a single row' do
+      abandoned_shopping_trolleys = FactoryGirl.create(:service,
+        lgsl_code: 1152,
+        label: "Abandoned shopping trolleys",
+        tier: nil
+      )
+      arson_reduction = FactoryGirl.create(:service,
+        lgsl_code: 800,
+        label: "Arson reduction",
+        tier: nil
+      )
+      soil_excavation = FactoryGirl.create(:service,
+        lgsl_code: 1419,
+        label: "Soil excavation",
+        tier: nil
+      )
+
+      csv_rows = [
+        {
+          :lgsl_code => '1152',
+          'Description' => 'Abandoned shopping trolleys',
+          :tier => 'county/unitary'
+        },
+        {
+          'Description' => 'No LGSL row',
+          :tier => 'all'
+        },
+        {
+          :lgsl_code => '800',
+          'Description' => 'Bad tier value row',
+          :tier => 'england'
+        },
+        {
+          :lgsl_code => '538',
+          'Description' => 'Missing service row',
+          :tier => 'district/unitary'
+        },
+        {
+          :lgsl_code => '1419',
+          'Description' => 'Soil excavation',
+          :tier => 'district/unitary'
+        },
+      ]
+      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+      subject.import_tiers
+
+      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
+      expect(arson_reduction.reload.tier).to be_blank
+      expect(soil_excavation.reload.tier).to eq('district/unitary')
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -14,6 +14,35 @@ RSpec.describe Service, type: :model do
 
   it { is_expected.to have_many(:service_interactions) }
 
+  describe '.for_tier' do
+    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, label: 'all service', tier: 'all') }
+    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, label: 'district service', tier: 'district/unitary') }
+    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, label: 'county service', tier: 'county/unitary') }
+    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, label: 'nil service', tier: nil) }
+
+    it 'returns all services with a tier when asked for "all"' do
+      expect(described_class.for_tier('all')).to match_array([all_service, district_service, county_service])
+    end
+
+    it 'returns all services with a tier when asked for "unitary"' do
+      expect(described_class.for_tier('unitary')).to match_array([all_service, district_service, county_service])
+    end
+
+    it 'returns services with an "all" or "district/unitary" tier when asked for "distrct"' do
+      expect(described_class.for_tier('district')).to match_array([all_service, district_service])
+    end
+
+    it 'returns services with an "all" or "county/unitary" tier when asked for "county"' do
+      expect(described_class.for_tier('county')).to match_array([all_service, county_service])
+    end
+
+    it 'raises an ArgumentError for any other requested tier' do
+      expect {
+        described_class.for_tier('hats')
+      }.to raise_error(ArgumentError, "invalid tier 'hats'")
+    end
+  end
+
   describe '#provided_by?' do
     let(:district) { FactoryGirl.build(:local_authority, tier: 'district') }
     let(:county) { FactoryGirl.build(:local_authority, tier: 'county') }

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Service, type: :model do
   it { is_expected.to validate_presence_of(:label) }
   it { is_expected.to validate_uniqueness_of(:lgsl_code) }
   it { is_expected.to validate_uniqueness_of(:label) }
+  it { is_expected.to validate_inclusion_of(:tier).in_array(%w{all county/unitary district/unitary}) }
+  it { is_expected.to allow_value(nil).for(:tier) }
 
   it { is_expected.to have_many(:service_interactions) }
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -13,4 +13,62 @@ RSpec.describe Service, type: :model do
   it { is_expected.to allow_value(nil).for(:tier) }
 
   it { is_expected.to have_many(:service_interactions) }
+
+  describe '#provided_by?' do
+    let(:district) { FactoryGirl.build(:local_authority, tier: 'district') }
+    let(:county) { FactoryGirl.build(:local_authority, tier: 'county') }
+    let(:unitary) { FactoryGirl.build(:local_authority, tier: 'unitary') }
+
+    context 'when the tier is blank' do
+      subject { FactoryGirl.build(:service, tier: nil) }
+      it 'is false for a district council' do
+        expect(subject).not_to be_provided_by(district)
+      end
+      it 'is false for a county council' do
+        expect(subject).not_to be_provided_by(county)
+      end
+      it 'is false for a unitary council' do
+        expect(subject).not_to be_provided_by(unitary)
+      end
+    end
+
+    context 'when the tier is all' do
+      subject { FactoryGirl.build(:service, tier: 'all') }
+      it 'is true for a district council' do
+        expect(subject).to be_provided_by(district)
+      end
+      it 'is true for a county council' do
+        expect(subject).to be_provided_by(county)
+      end
+      it 'is true for a unitary council' do
+        expect(subject).to be_provided_by(unitary)
+      end
+    end
+
+    context 'when the tier is district/unitary' do
+      subject { FactoryGirl.build(:service, tier: 'district/unitary') }
+      it 'is true for a district council' do
+        expect(subject).to be_provided_by(district)
+      end
+      it 'is false for a county council' do
+        expect(subject).not_to be_provided_by(county)
+      end
+      it 'is true for a unitary council' do
+        expect(subject).to be_provided_by(unitary)
+      end
+    end
+
+    context 'when the tier is county/unitary' do
+      subject { FactoryGirl.build(:service, tier: 'county/unitary') }
+      it 'is false for a district council' do
+        expect(subject).not_to be_provided_by(district)
+      end
+      it 'is true for a county council' do
+        expect(subject).to be_provided_by(county)
+      end
+      it 'is true for a unitary council' do
+        expect(subject).to be_provided_by(unitary)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/duUE8jPS/375-add-support-for-la-tiers-to-local-links-manager-3

`Service` now has a `tier` field that contains `"all"`, `"district/unitary"`, `"county/unitary"` or is `nil`.  We import values for this from the [`local_services.csv` that lives in publisher](https://github.com/alphagov/publisher/blob/master/data/local_services.csv).  As mentioned in the commits it seems very likely that this file originally came from https://data.gov.uk/dataset/local-directgov-url-instructions and has since been updated.  What's not hugely clear where the tier information in that dataset comes from.
