### PR TITLE
Restrict services for authority ui to those provided by tier

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,6 @@
 class ServicesController < ApplicationController
   def index
     @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
-    @services = Service.all
+    @services = @authority.provided_services
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,4 +4,8 @@ class LocalAuthority < ActiveRecord::Base
   validates :homepage_url, format: { with: URI.regexp }, allow_blank: true
   validates :tier, inclusion: { in: %w(county district unitary),
     message: "%{value} is not an allowed tier" }
+
+  def provided_services
+    Service.for_tier(self.tier)
+  end
 end

--- a/spec/controllers/interactions_controller_spec.rb
+++ b/spec/controllers/interactions_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe InteractionsController, type: :controller do
   before do
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
-    @service = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
+    @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
     @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
   end
 

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ServicesController, type: :controller do
   before do
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
-    @service = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
+    @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
   end
 
   describe "GET #index" do

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     gss "S12000041"
     snac "00QC"
     tier "unitary"
-    slug "angus"
+    slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :service do
     lgsl_code 1152
     label "Abandoned shopping trolleys"
-    slug "abandoned-shopping-trolleys"
+    slug { label.parameterize }
   end
 end

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -1,4 +1,6 @@
-describe "The interactions index page", type: :feature do
+require 'rails_helper'
+
+feature "The interactions index page for a service provided by a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
     @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 feature "The interactions index page for a service provided by a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
-    @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus', tier: 'county')
+    @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1, tier: 'county/unitary')
     visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 feature "The interactions index page for a service provided by a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus', tier: 'county')
-    @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1, tier: 'county/unitary')
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'county')
+    @service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1, tier: 'county/unitary')
     visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -14,8 +14,8 @@ feature "The local authorities index page" do
 
   describe "with local authorities present" do
     before do
-      @angus = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
-      @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', slug: 'zorro', gss: 'XXXXXXXXX', snac: 'ZZZZ')
+      @angus = FactoryGirl.create(:local_authority, name: 'Angus')
+      @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', gss: 'XXXXXXXXX', snac: 'ZZZZ')
       visit root_path
     end
 

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -1,4 +1,6 @@
-describe "The local authorities index page", type: :feature do
+require 'rails_helper'
+
+feature "The local authorities index page" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
     visit root_path

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature "The services index page for a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus', tier: 'district')
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'district')
     visit local_authority_services_path(local_authority_slug: @local_authority.slug)
   end
 
@@ -15,10 +15,10 @@ feature "The services index page for a local authority" do
 
   describe "with services present" do
     before do
-      @service_1 = FactoryGirl.create(:service, label: 'All councils', slug: 'service-1', lgsl_code: 1, tier: 'all')
-      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', slug: 'service-2', lgsl_code: 2, tier: 'county/unitary')
-      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', slug: 'service-3', lgsl_code: 3, tier: 'district/unitary')
-      @service_4 = FactoryGirl.create(:service, label: 'Unknown', slug: 'service-4', lgsl_code: 4, tier: nil)
+      @service_1 = FactoryGirl.create(:service, label: 'All councils', lgsl_code: 1, tier: 'all')
+      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', lgsl_code: 2, tier: 'county/unitary')
+      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', lgsl_code: 3, tier: 'district/unitary')
+      @service_4 = FactoryGirl.create(:service, label: 'Unknown', lgsl_code: 4, tier: nil)
       visit local_authority_services_path(@local_authority.slug)
     end
 

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -1,4 +1,6 @@
-feature "The services index page", type: :feature do
+require 'rails_helper'
+
+feature "The services index page for a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
     @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature "The services index page for a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus')
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', slug: 'angus', tier: 'district')
     visit local_authority_services_path(local_authority_slug: @local_authority.slug)
   end
 
@@ -15,21 +15,23 @@ feature "The services index page for a local authority" do
 
   describe "with services present" do
     before do
-      @service_1 = FactoryGirl.create(:service, label: 'Service 1', slug: 'service-1', lgsl_code: 1)
-      @service_2 = FactoryGirl.create(:service, label: 'Service 2', slug: 'service-2', lgsl_code: 2)
+      @service_1 = FactoryGirl.create(:service, label: 'All councils', slug: 'service-1', lgsl_code: 1, tier: 'all')
+      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', slug: 'service-2', lgsl_code: 2, tier: 'county/unitary')
+      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', slug: 'service-3', lgsl_code: 3, tier: 'district/unitary')
+      @service_4 = FactoryGirl.create(:service, label: 'Unknown', slug: 'service-4', lgsl_code: 4, tier: nil)
       visit local_authority_services_path(@local_authority.slug)
     end
 
-    it "shows the available services with links to their individual pages" do
+    it "shows only the services provided by the authority according to its' tier with links to their individual pages" do
       expect(page).to have_content 'Local Government Services (2)'
-      expect(page).to have_link('Service 1', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug))
-      expect(page).to have_link('Service 2', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_2.slug))
+      expect(page).to have_link('All councils', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug))
+      expect(page).to have_link('District and unitary only', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_3.slug))
     end
 
     it "shows each service's LGSL codes in the table" do
       expect(page).to have_content 'LGSL Code'
       expect(page).to have_css('td.lgsl_code', text: 1)
-      expect(page).to have_css('td.lgsl_code', text: 2)
+      expect(page).to have_css('td.lgsl_code', text: 3)
     end
   end
 end

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -6,8 +6,8 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter do
     let(:csv_downloader) { instance_double CsvDownloader }
 
     context 'when service interactions download is successful' do
-      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service", slug: "bursary-fund-service") }
-      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys", slug: "abandoned-shopping-trolleys") }
+      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
+      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
 
       let!(:interaction_0) { FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about") }
       let!(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact") }

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -8,19 +8,16 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'imports the tiers from the csv file and updates existing services' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: nil
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        slug: "arson-reduction",
         label: "Arson reduction",
         tier: nil
       )
       yellow_lines = FactoryGirl.create(:service,
         lgsl_code: 538,
-        slug: "yellow-lines",
         label: "Yellow lines",
         tier: nil
       )
@@ -69,7 +66,6 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'does not update tiers to be blank' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: 'all'
       )
@@ -91,19 +87,16 @@ describe LocalLinksManager::Import::ServicesTierImporter do
     it 'does not halt in the face of an error on a single row' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        slug: "abandoned-shopping-trolleys",
         label: "Abandoned shopping trolleys",
         tier: nil
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        slug: "arson-reduction",
         label: "Arson reduction",
         tier: nil
       )
       soil_excavation = FactoryGirl.create(:service,
         lgsl_code: 1419,
-        slug: "soil-excavation",
         label: "Soil excavation",
         tier: nil
       )

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -26,4 +26,33 @@ RSpec.describe LocalAuthority, type: :model do
       it { should_not allow_value('country').for(:tier) }
     end
   end
+
+  describe '#provided_services' do
+    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service', slug: 'all-service') }
+    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service', slug: 'county-service') }
+    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service', slug: 'district-service') }
+    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service', slug: 'nil-service') }
+    subject { FactoryGirl.build(:local_authority) }
+
+    context 'for a "district" LA' do
+      before { subject.tier = 'district' }
+      it 'returns all and district/unitary services' do
+        expect(subject.provided_services).to match_array([all_service, district_service])
+      end
+    end
+
+    context 'for a "county" LA' do
+      before { subject.tier = 'county' }
+      it 'returns all and county/unitary services' do
+        expect(subject.provided_services).to match_array([all_service, county_service])
+      end
+    end
+
+    context 'for a "unitary" LA' do
+      before { subject.tier = 'unitary' }
+      it 'returns all, district/unitary, and county/unitary services' do
+        expect(subject.provided_services).to match_array([all_service, county_service, district_service])
+      end
+    end
+  end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe LocalAuthority, type: :model do
   end
 
   describe '#provided_services' do
-    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service', slug: 'all-service') }
-    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service', slug: 'county-service') }
-    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service', slug: 'district-service') }
-    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service', slug: 'nil-service') }
+    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service') }
+    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service') }
+    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service') }
+    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service') }
     subject { FactoryGirl.build(:local_authority) }
 
     context 'for a "district" LA' do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Service, type: :model do
   it { is_expected.to have_many(:service_interactions) }
 
   describe '.for_tier' do
-    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, slug: 'all-service', label: 'all service', tier: 'all') }
-    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, slug: 'district-service', label: 'district service', tier: 'district/unitary') }
-    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, slug: 'county-service', label: 'county service', tier: 'county/unitary') }
-    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, slug: 'nil-service', label: 'nil service', tier: nil) }
+    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, label: 'all service', tier: 'all') }
+    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, label: 'district service', tier: 'district/unitary') }
+    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, label: 'county service', tier: 'county/unitary') }
+    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, label: 'nil service', tier: nil) }
 
     it 'returns all services with a tier when asked for "all"' do
       expect(described_class.for_tier('all')).to match_array([all_service, district_service, county_service])


### PR DESCRIPTION
For: https://trello.com/c/duUE8jPS/375-add-support-for-la-tiers-to-local-links-manager-3

When clicking through to a Local Authority show page we limit to show only those services that the LA should provide according to our tier data (see: #13).

We only have tier data for ~250 out of ~1000 services so there's now no way of seeing all those "un-tiered" services in the system UI.
