### PR TITLE
Import and display links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'pg'
 # Provides breadcrumbs, see config/breadcrumbs.rb
 gem 'gretel', '3.0.8'
 
+gem 'addressable'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'gretel', '3.0.8'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.1)
     concurrent-ruby (1.0.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -140,6 +141,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -173,6 +175,13 @@ GEM
     pg (0.18.3)
     plek (1.12.0)
     powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -262,6 +271,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    slop (3.6.0)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -309,7 +319,6 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.2.1)
-  byebug
   capistrano-rails
   capybara (~> 2.7)
   factory_girl_rails (~> 4.7)
@@ -322,6 +331,7 @@ DEPENDENCIES
   logstasher (= 0.6.2)
   pg
   plek (~> 1.10)
+  pry-byebug
   rails (= 4.2.5.2)
   rspec-rails (~> 3.3)
   sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   airbrake (~> 4.2.1)
   capistrano-rails
   capybara (~> 2.7)

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -3,5 +3,7 @@ class InteractionsController < ApplicationController
     @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
     @service = Service.find_by_slug!(params[:service_slug])
     @interactions = @service.interactions
+    local_authority_links_for_service = @authority.links.for_service(@service)
+    @links = local_authority_links_for_service.map { |link| [link.interaction, link.url] }.to_h
   end
 end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,0 +1,9 @@
+module LinksHelper
+  def display_link_for(interaction)
+    if @links.key? interaction
+      link_to nil, @links[interaction]
+    else
+      'n/a'
+    end
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,11 @@
+class Link < ActiveRecord::Base
+  belongs_to :local_authority
+  belongs_to :service_interaction
+
+  has_one :service, through: :service_interaction
+  has_one :interaction, through: :service_interaction
+
+  validates :local_authority, :service_interaction, presence: true
+  validates :service_interaction_id, uniqueness: { scope: :local_authority_id }
+  validates :url, presence: true, non_blank_url: true
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -8,4 +8,10 @@ class Link < ActiveRecord::Base
   validates :local_authority, :service_interaction, presence: true
   validates :service_interaction_id, uniqueness: { scope: :local_authority_id }
   validates :url, presence: true, non_blank_url: true
+
+  scope :for_service, ->(service) {
+    includes(service_interaction: [:service, :interaction])
+      .references(:service_interactions)
+      .where(service_interactions: { service_id: service })
+  }
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -5,6 +5,8 @@ class LocalAuthority < ActiveRecord::Base
   validates :tier, inclusion: { in: %w(county district unitary),
     message: "%{value} is not an allowed tier" }
 
+  has_many :links
+
   def provided_services
     Service.for_tier(self.tier)
   end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,7 +1,7 @@
 class LocalAuthority < ActiveRecord::Base
   validates :gss, :snac, uniqueness: true
   validates :gss, :name, :snac, :tier, presence: true
-  validates :homepage_url, format: { with: URI.regexp }, allow_blank: true
+  validates :homepage_url, non_blank_url: true, allow_blank: true
   validates :tier, inclusion: { in: %w(county district unitary),
     message: "%{value} is not an allowed tier" }
 

--- a/app/models/service_interaction.rb
+++ b/app/models/service_interaction.rb
@@ -4,4 +4,10 @@ class ServiceInteraction < ActiveRecord::Base
 
   belongs_to :service
   belongs_to :interaction
+
+  def self.find_by_lgsl_and_lgil(lgsl_code, lgil_code)
+    includes(:service, :interaction)
+      .references(:service, :interaction)
+      .find_by(services: { lgsl_code: lgsl_code }, interactions: { lgil_code: lgil_code })
+  end
 end

--- a/app/validators/non_blank_url_validator.rb
+++ b/app/validators/non_blank_url_validator.rb
@@ -1,0 +1,12 @@
+class NonBlankUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    valid_url = begin
+      uri = Addressable::URI.parse(value)
+      !uri.scheme.blank? && !uri.host.blank? && uri.host.include?(".")
+    rescue Addressable::URI::InvalidURIError
+      false
+    end
+    record.errors.add attribute, (options[:message] || 'is not a URL') unless valid_url
+  end
+end

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -12,6 +12,7 @@
       <tr class="table-header">
         <th>LGIL Code</th>
         <th>Local Government Interactions (<%= @interactions.count %>)</th>
+        <th>Link</th>
       </tr>
       <%= render partial: "govuk_admin_template/table_filter",
       locals: {placeholder: "Filter list of local interactions"} %>
@@ -24,6 +25,9 @@
           </td>
           <td class="name">
             <%= interaction.label %>
+          </td>
+          <td>
+            <%= display_link_for(interaction) %>
           </td>
         </tr>
       <% end %>

--- a/db/migrate/20160517134617_create_links.rb
+++ b/db/migrate/20160517134617_create_links.rb
@@ -1,0 +1,13 @@
+class CreateLinks < ActiveRecord::Migration
+  def change
+    create_table :links do |t|
+      t.references :local_authority, index: true, foreign_key: true, null: false
+      t.references :service_interaction, index: true, foreign_key: true, null: false
+      t.string :url, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :links, [:local_authority_id, :service_interaction_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160513113110) do
+ActiveRecord::Schema.define(version: 20160517134617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,18 @@ ActiveRecord::Schema.define(version: 20160513113110) do
 
   add_index "interactions", ["label"], name: "index_interactions_on_label", unique: true, using: :btree
   add_index "interactions", ["lgil_code"], name: "index_interactions_on_lgil_code", unique: true, using: :btree
+
+  create_table "links", force: :cascade do |t|
+    t.integer  "local_authority_id",     null: false
+    t.integer  "service_interaction_id", null: false
+    t.string   "url",                    null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
+  add_index "links", ["local_authority_id", "service_interaction_id"], name: "index_links_on_local_authority_id_and_service_interaction_id", unique: true, using: :btree
+  add_index "links", ["local_authority_id"], name: "index_links_on_local_authority_id", using: :btree
+  add_index "links", ["service_interaction_id"], name: "index_links_on_service_interaction_id", using: :btree
 
   create_table "local_authorities", force: :cascade do |t|
     t.string   "gss"
@@ -74,6 +86,8 @@ ActiveRecord::Schema.define(version: 20160513113110) do
     t.datetime "updated_at",                              null: false
   end
 
+  add_foreign_key "links", "local_authorities"
+  add_foreign_key "links", "service_interactions"
   add_foreign_key "service_interactions", "interactions"
   add_foreign_key "service_interactions", "services"
 end

--- a/lib/local-links-manager/import/interactions_importer.rb
+++ b/lib/local-links-manager/import/interactions_importer.rb
@@ -13,12 +13,12 @@ module LocalLinksManager
         new.import_records
       end
 
-      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, header_conversions: FIELD_NAME_CONVERSIONS))
         @csv_downloader = csv_downloader
       end
 
       def import_records
-        @csv_downloader.download.each { |row| create_or_update_record(row) }
+        @csv_downloader.each_row { |row| create_or_update_record(row) }
       rescue CsvDownloader::Error => e
         Rails.logger.error e.message
       rescue => e

--- a/lib/local-links-manager/import/links_importer.rb
+++ b/lib/local-links-manager/import/links_importer.rb
@@ -1,0 +1,100 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class LinksImporter
+      CSV_URL = 'http://local.direct.gov.uk/Data/local_authority_service_details.csv'
+      FIELD_NAME_CONVERSIONS = {
+        'SNAC' => :snac,
+        'LGSL' => :lgsl_code,
+        'LGIL' => :lgil_code,
+        'Service URL' => :url
+      }
+
+      class MissingRecordError < RuntimeError; end
+      class MissingIdentifierError < RuntimeError; end
+
+      def self.import
+        new.import_records
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+        @csv_downloader = csv_downloader
+        @csv_rows = 0
+        @modified_record_count = 0
+        @ignored_rows_count = 0
+        @missing_record_count = 0
+        @missing_id_count = 0
+        @invalid_record_count = 0
+      end
+
+      def import_records
+        with_each_csv_row do |row|
+          counting_errors do
+            if create_or_update_record(row)
+              @modified_record_count += 1
+            else
+              @ignored_rows_count += 1
+            end
+          end
+        end
+        Rails.logger.info import_summary
+      end
+
+    private
+
+      def import_summary
+        "Links Import complete\n"\
+        "Downloaded CSV rows: #{@csv_rows}\n"\
+        "Modified records: #{@modified_record_count}\n"\
+        "Ignored rows: #{@ignored_rows_count}\n"\
+        "Import errors with missing Identifiers: #{@missing_id_count}\n"\
+        "Import errors with missing associated Records: #{@missing_record_count}\n"\
+        "Import errors with invalid values for modifying record: #{@invalid_record_count}\n"
+      end
+
+      def with_each_csv_row(&block)
+        @csv_downloader.download.each do |row|
+          @csv_rows += 1
+          block.call(row)
+        end
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} importing in #{self.class}\n#{e.backtrace.join("\n")}"
+        raise e
+      end
+
+      def counting_errors(&block)
+        block.call
+      rescue MissingRecordError => e
+        @missing_record_count += 1
+        Rails.logger.error e.message
+      rescue MissingIdentifierError => e
+        @missing_id_count += 1
+        Rails.logger.error e.message
+      rescue ActiveRecord::RecordInvalid => e
+        @invalid_record_count += 1
+        Rails.logger.error e.message
+      end
+
+      def create_or_update_record(row)
+        raise MissingIdentifierError if [:lgsl_code, :lgil_code, :snac].any? { |field| row[field].blank? }
+        service_interaction = ServiceInteraction.find_by_lgsl_and_lgil(row[:lgsl_code], row[:lgil_code])
+        local_authority = LocalAuthority.find_by(snac: row[:snac])
+        raise MissingRecordError if [service_interaction, local_authority].any?(&:nil?)
+
+        link = Link.where(
+          service_interaction_id: service_interaction.id,
+          local_authority_id: local_authority.id
+        ).first_or_initialize
+
+        verb = link.persisted? ? "Updating" : "Creating"
+        Rails.logger.info("#{verb} Link (lgsl #{row[:lgsl_code]}, lgil: #{row[:lgil_code]}, snac: #{row[:snac]})")
+
+        link.url = row[:url]
+        link.save!
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/import/links_importer.rb
+++ b/lib/local-links-manager/import/links_importer.rb
@@ -18,7 +18,7 @@ module LocalLinksManager
         new.import_records
       end
 
-      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, header_conversions: FIELD_NAME_CONVERSIONS, encoding: 'windows-1252'))
         @csv_downloader = csv_downloader
         @csv_rows = 0
         @modified_record_count = 0
@@ -54,7 +54,7 @@ module LocalLinksManager
       end
 
       def with_each_csv_row(&block)
-        @csv_downloader.download.each do |row|
+        @csv_downloader.each_row do |row|
           @csv_rows += 1
           block.call(row)
         end

--- a/lib/local-links-manager/import/local_authorities_url_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_url_importer.rb
@@ -14,7 +14,7 @@ module LocalLinksManager
       end
 
       def import_records
-        @csv_downloader.download.each do |row|
+        @csv_downloader.each_row do |row|
           begin
             process_row(row)
           rescue => e

--- a/lib/local-links-manager/import/services_importer.rb
+++ b/lib/local-links-manager/import/services_importer.rb
@@ -13,12 +13,12 @@ module LocalLinksManager
         new.import_records
       end
 
-      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, header_conversions: FIELD_NAME_CONVERSIONS))
         @csv_downloader = csv_downloader
       end
 
       def import_records
-        @csv_downloader.download.each { |row| create_or_update_record(row) }
+        @csv_downloader.each_row { |row| create_or_update_record(row) }
       rescue CsvDownloader::Error => e
         Rails.logger.error e.message
       rescue => e

--- a/lib/local-links-manager/import/services_tier_importer.rb
+++ b/lib/local-links-manager/import/services_tier_importer.rb
@@ -15,7 +15,7 @@ module LocalLinksManager
         new.import_tiers
       end
 
-      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, FIELD_NAME_CONVERSIONS))
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, header_conversions: FIELD_NAME_CONVERSIONS))
         @csv_downloader = csv_downloader
         @csv_rows = 0
         @missing_record_count = 0
@@ -63,7 +63,7 @@ module LocalLinksManager
       end
 
       def with_each_csv_row(&block)
-        @csv_downloader.download.each do |row|
+        @csv_downloader.each_row do |row|
           @csv_rows += 1
           block.call(row)
         end

--- a/lib/tasks/import/links.rake
+++ b/lib/tasks/import/links.rake
@@ -1,0 +1,10 @@
+require 'local-links-manager/import/links_importer'
+
+namespace :import do
+  namespace :links do
+    desc "Import local authority links for service (lgsl) and interaction (lgil) combinations from local DirectGov"
+    task import_all: :environment do
+      LocalLinksManager::Import::LinksImporter.import
+    end
+  end
+end

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :link do
+    association :local_authority
+    association :service_interaction
+    url { "http://#{local_authority.slug}.example.com/#{service_interaction.service.slug}/#{service_interaction.interaction.label.parameterize}" }
+  end
+end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+feature 'The links for a local authority' do
+  before do
+    User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'county')
+    @service = FactoryGirl.create(:service, label: 'Service', lgsl_code: 1, tier: 'county/unitary')
+    @interaction_1 = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+    @interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 4)
+    @service_interaction_1 = FactoryGirl.create(:service_interaction, service: @service, interaction: @interaction_1)
+    @service_interaction_2 = FactoryGirl.create(:service_interaction, service: @service, interaction: @interaction_2)
+  end
+
+  describe "when no links exist for the service interaction" do
+    before do
+      visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+    end
+
+    it "shows an empty cell for the link next to the interactions" do
+      expect(page).to have_table_row('3', 'Interaction 1', 'n/a')
+      expect(page).to have_table_row('4', 'Interaction 2', 'n/a')
+    end
+  end
+
+  describe "when links exist for the service interaction" do
+    before do
+      FactoryGirl.create(:link, url: 'http://angus.example.com/service-interaction-1', local_authority: @local_authority, service_interaction: @service_interaction_1)
+      FactoryGirl.create(:link, url: 'https://angus.example.com/service-interaction-2', local_authority: @local_authority, service_interaction: @service_interaction_2)
+      visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+    end
+
+    it "shows the url for the link next to the relevant interaction" do
+      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/service-interaction-1')
+      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2')
+    end
+
+    it "shows the urls as clickable links" do
+      expect(page).to have_link('http://angus.example.com/service-interaction-1', href: 'http://angus.example.com/service-interaction-1')
+      expect(page).to have_link('https://angus.example.com/service-interaction-2', href: 'https://angus.example.com/service-interaction-2')
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/fixtures/sample.csv
+++ b/spec/lib/local-links-manager/import/fixtures/sample.csv
@@ -1,3 +1,3 @@
-Identifier,Label,Description,
-1614,16 to 19 bursary fund,"They might struggle with the costs",
-13,Abandoned shopping trolleys,"Abandoned shopping trolleys have a negative impact",
+Identifier,Label,Description
+1614,16 to 19 bursary fund,"They might struggle with the costs"
+13,Abandoned shopping trolleys,"Abandoned shopping trolleys have a negative impact"

--- a/spec/lib/local-links-manager/import/interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/interactions_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'local-links-manager/import/interactions_importer'
 
-describe LocalLinksManager::Import::InteractionsImporter do
+describe LocalLinksManager::Import::InteractionsImporter, :csv_importer do
   describe '#import_records' do
     let(:csv_downloader) { instance_double CsvDownloader }
 
@@ -18,7 +18,7 @@ describe LocalLinksManager::Import::InteractionsImporter do
           }
         ]
 
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         LocalLinksManager::Import::InteractionsImporter.new(csv_downloader).import_records
 
@@ -31,7 +31,7 @@ describe LocalLinksManager::Import::InteractionsImporter do
 
     context 'when interactions download is not successful' do
       it 'logs the error on failed download' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
 
         expect(Rails.logger).to receive(:error).with("Error downloading CSV")
@@ -42,7 +42,7 @@ describe LocalLinksManager::Import::InteractionsImporter do
 
     context 'when CSV data is malformed' do
       it 'logs an error that it failed importing' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
 
         expect(Rails.logger).to receive(:error).with("Malformed CSV error")

--- a/spec/lib/local-links-manager/import/links_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/links_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'local-links-manager/import/links_importer'
 
-describe LocalLinksManager::Import::LinksImporter do
+describe LocalLinksManager::Import::LinksImporter, csv_importer: true do
   describe '#import_records' do
     let(:csv_downloader) { instance_double CsvDownloader }
     subject { described_class.new(csv_downloader) }
@@ -31,7 +31,7 @@ describe LocalLinksManager::Import::LinksImporter do
           }
         ]
 
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         subject.import_records
 
@@ -56,7 +56,7 @@ describe LocalLinksManager::Import::LinksImporter do
             url: 'http://www.example.com/123/0/apply',
           },
         ]
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         subject.import_records
 
@@ -76,7 +76,7 @@ describe LocalLinksManager::Import::LinksImporter do
             url: 'http://www.example.com/123/0/apply',
           },
         ]
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         subject.import_records
 
@@ -98,7 +98,7 @@ describe LocalLinksManager::Import::LinksImporter do
             url: 'http://www.example.com/this-is-now-different',
           },
         ]
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         subject.import_records
 
@@ -108,7 +108,7 @@ describe LocalLinksManager::Import::LinksImporter do
 
     context 'when links download is not successful' do
       it 'logs the error on failed download' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
 
         expect(Rails.logger).to receive(:error).with("Error downloading CSV")
@@ -119,7 +119,7 @@ describe LocalLinksManager::Import::LinksImporter do
 
     context 'when CSV data is malformed' do
       it 'logs an error that it failed importing' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
 
         expect(Rails.logger).to receive(:error).with("Malformed CSV error")

--- a/spec/lib/local-links-manager/import/links_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/links_importer_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+require 'local-links-manager/import/links_importer'
+
+describe LocalLinksManager::Import::LinksImporter do
+  describe '#import_records' do
+    let(:csv_downloader) { instance_double CsvDownloader }
+    subject { described_class.new(csv_downloader) }
+
+    context 'when links download is successful' do
+      it 'imports links' do
+        service = FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+        interaction_0 = FactoryGirl.create(:interaction, lgil_code: 0, label: 'Interaction 0')
+        interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+        FactoryGirl.create(:service_interaction, service: service, interaction: interaction_0)
+        FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1)
+        local_authority_1 = FactoryGirl.create(:local_authority, snac: '00AB', gss: '123')
+        local_authority_2 = FactoryGirl.create(:local_authority, snac: '00AD', gss: '456')
+
+        csv_rows = [
+          {
+            lgil_code: '0',
+            lgsl_code: '123',
+            snac: '00AD',
+            url: 'http://www.example.com/123/0/apply',
+          },
+          {
+            lgil_code: '1',
+            lgsl_code: '123',
+            snac: '00AB',
+            url: 'http://www.example.com/123/1/exemption',
+          }
+        ]
+
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        subject.import_records
+
+        expect(Link.count).to eq(2)
+        expect(local_authority_1.links.count).to eq(1)
+        expect(local_authority_1.links.first.url).to eq 'http://www.example.com/123/1/exemption'
+
+        expect(local_authority_2.links.count).to eq(1)
+        expect(local_authority_2.links.first.url).to eq 'http://www.example.com/123/0/apply'
+      end
+
+      it 'does not create new links for rows in the csv without a matching LocalAuthority instance' do
+        service = FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+        interaction = FactoryGirl.create(:interaction, lgil_code: 0, label: 'Interaction 0')
+        FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+
+        csv_rows = [
+          {
+            lgil_code: '0',
+            lgsl_code: '123',
+            snac: '00AB',
+            url: 'http://www.example.com/123/0/apply',
+          },
+        ]
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        subject.import_records
+
+        expect(Link.exists?(url: 'http://www.example.com/123/0/apply')).to be_falsey
+      end
+
+      it 'does not create new links for rows in the csv without a matching ServiceInteraction instance' do
+        FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+        FactoryGirl.create(:interaction, lgil_code: 0, label: 'Interaction 0')
+        FactoryGirl.create(:local_authority, snac: '00AB', gss: '123')
+
+        csv_rows = [
+          {
+            lgil_code: '0',
+            lgsl_code: '123',
+            snac: '00AB',
+            url: 'http://www.example.com/123/0/apply',
+          },
+        ]
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        subject.import_records
+
+        expect(Link.exists?(url: 'http://www.example.com/123/0/apply')).to be_falsey
+      end
+
+      it 'overwrites existing links' do
+        service = FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+        interaction = FactoryGirl.create(:interaction, lgil_code: 0, label: 'Interaction 0')
+        service_interaction = FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+        local_authority = FactoryGirl.create(:local_authority, snac: '00AB', gss: '123')
+        link = FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction, url: 'http://example.com/to-be-changed')
+
+        csv_rows = [
+          {
+            lgil_code: '0',
+            lgsl_code: '123',
+            snac: '00AB',
+            url: 'http://www.example.com/this-is-now-different',
+          },
+        ]
+        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+
+        subject.import_records
+
+        expect(link.reload.url).to eq 'http://www.example.com/this-is-now-different'
+      end
+    end
+
+    context 'when links download is not successful' do
+      it 'logs the error on failed download' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
+
+        expect(Rails.logger).to receive(:error).with("Error downloading CSV")
+
+        subject.import_records
+      end
+    end
+
+    context 'when CSV data is malformed' do
+      it 'logs an error that it failed importing' do
+        allow(csv_downloader).to receive(:download)
+          .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
+
+        expect(Rails.logger).to receive(:error).with("Malformed CSV error")
+
+        subject.import_records
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/local_authorities_url_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_url_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'local-links-manager/import/local_authorities_url_importer'
 
-describe LocalLinksManager::Import::LocalAuthoritiesURLImporter do
+describe LocalLinksManager::Import::LocalAuthoritiesURLImporter, :csv_importer do
   def fixture_file(file)
     File.expand_path("fixtures/" + file, File.dirname(__FILE__))
   end
@@ -21,7 +21,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesURLImporter do
 
       csv_file = File.read(fixture_file("local_contacts_sample.csv"))
 
-      allow(csv_downloader).to receive(:download).and_return(CSV.parse(csv_file, headers: true))
+      stub_csv_rows(CSV.parse(csv_file, headers: true))
 
       la_url_importer = LocalLinksManager::Import::LocalAuthoritiesURLImporter.new(csv_downloader)
       la_url_importer.import_records
@@ -39,7 +39,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesURLImporter do
                   Adur District Council,www.adur.gov.uk,,45UB,,,,,,,,,,,,,,,
                   Allerdale Borough Council,https://www.allerdale.gov.uk,,16UB,,,,,,,,,,,,,,,"
 
-      allow(csv_downloader).to receive(:download).and_return(CSV.parse(csv_stub, headers: true))
+      stub_csv_rows(CSV.parse(csv_stub, headers: true))
 
       la_url_importer = LocalLinksManager::Import::LocalAuthoritiesURLImporter.new(csv_downloader)
       la_url_importer.import_records

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'local-links-manager/import/services_importer'
 
-describe LocalLinksManager::Import::ServicesImporter do
+describe LocalLinksManager::Import::ServicesImporter, :csv_importer do
   describe '#import_records' do
     let(:csv_downloader) { instance_double CsvDownloader }
 
@@ -18,7 +18,7 @@ describe LocalLinksManager::Import::ServicesImporter do
           }
         ]
 
-        allow(csv_downloader).to receive(:download).and_return(csv_rows)
+        stub_csv_rows(csv_rows)
 
         LocalLinksManager::Import::ServicesImporter.new(csv_downloader).import_records
 
@@ -32,7 +32,7 @@ describe LocalLinksManager::Import::ServicesImporter do
 
     context 'when services download is not successful' do
       it 'logs the error on failed download' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Error downloading CSV")
 
         expect(Rails.logger).to receive(:error).with("Error downloading CSV")
@@ -43,7 +43,7 @@ describe LocalLinksManager::Import::ServicesImporter do
 
     context 'when CSV data is malformed' do
       it 'logs an error that it failed importing' do
-        allow(csv_downloader).to receive(:download)
+        allow(csv_downloader).to receive(:each_row)
           .and_raise(CsvDownloader::DownloadError, "Malformed CSV error")
 
         expect(Rails.logger).to receive(:error).with("Malformed CSV error")

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'local-links-manager/import/services_tier_importer'
 
-describe LocalLinksManager::Import::ServicesTierImporter do
+describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
   let(:csv_downloader) { instance_double CsvDownloader }
   subject { described_class.new(csv_downloader) }
   describe 'import_tiers' do
@@ -39,7 +39,7 @@ describe LocalLinksManager::Import::ServicesTierImporter do
           :tier => 'all'
         },
       ]
-      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+      stub_csv_rows(csv_rows)
 
       subject.import_tiers
 
@@ -56,7 +56,7 @@ describe LocalLinksManager::Import::ServicesTierImporter do
           :tier => 'county/unitary'
         },
       ]
-      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+      stub_csv_rows(csv_rows)
 
       subject.import_tiers
 
@@ -77,7 +77,7 @@ describe LocalLinksManager::Import::ServicesTierImporter do
           :tier => ''
         },
       ]
-      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+      stub_csv_rows(csv_rows)
 
       subject.import_tiers
 
@@ -127,7 +127,7 @@ describe LocalLinksManager::Import::ServicesTierImporter do
           :tier => 'district/unitary'
         },
       ]
-      allow(csv_downloader).to receive(:download).and_return(csv_rows)
+      stub_csv_rows(csv_rows)
 
       subject.import_tiers
 

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Link, type: :model do
+  describe 'validations' do
+    subject(:link) { FactoryGirl.create(:link) }
+
+    it { is_expected.to validate_presence_of(:local_authority) }
+    it { is_expected.to validate_presence_of(:service_interaction) }
+    it { is_expected.to validate_presence_of(:url) }
+    it { is_expected.to validate_uniqueness_of(:service_interaction_id).scoped_to(:local_authority_id) }
+
+    describe '#url' do
+      it 'disallows urls without schemes' do
+        is_expected.not_to allow_value('example.com').for(:url).with_message('is not a URL')
+      end
+
+      it 'disallows urls without a domain' do
+        is_expected.not_to allow_value('com').for(:url).with_message('is not a URL')
+      end
+
+      it 'allows http urls' do
+        is_expected.to allow_value('http://example.com').for(:url)
+      end
+
+      it 'allows https urls' do
+        is_expected.to allow_value('https://example.com').for(:url)
+      end
+    end
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:local_authority) }
+    it { is_expected.to belong_to(:service_interaction) }
+
+    it { is_expected.to have_one(:service).through(:service_interaction) }
+    it { is_expected.to have_one(:interaction).through(:service_interaction) }
+  end
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -35,4 +35,53 @@ RSpec.describe Link, type: :model do
     it { is_expected.to have_one(:service).through(:service_interaction) }
     it { is_expected.to have_one(:interaction).through(:service_interaction) }
   end
+
+  describe '.for_service' do
+    it 'fetches all the links for the supplied service' do
+      service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
+      service_2 = FactoryGirl.create(:service, label: 'Service 2', lgsl_code: 2)
+
+      interaction_1 = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1)
+      interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 2)
+
+      service_interaction_1_1 = FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_1)
+      service_interaction_1_2 = FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_2)
+      service_interaction_2_2 = FactoryGirl.create(:service_interaction, service: service_2, interaction: interaction_1)
+
+      local_authority_1 = FactoryGirl.create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1')
+      local_authority_2 = FactoryGirl.create(:local_authority, name: 'Aberdeenshire', gss: 'S100000002', snac: '00AB2')
+
+      link_1 = FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1)
+      link_2 = FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_2)
+      FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_2_2)
+      link_4 = FactoryGirl.create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1_1)
+
+      expect(Link.for_service(service_1)).to match_array([link_1, link_2, link_4])
+    end
+
+    context 'to avoid n+1 queries' do
+      let(:service) { FactoryGirl.create(:service) }
+
+      before do
+        interaction = FactoryGirl.create(:interaction)
+        service_interaction = FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+        local_authority = FactoryGirl.create(:local_authority)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction)
+      end
+
+      subject(:links) { Link.for_service(service) }
+
+      it 'preloads the service interaction on the fetched records' do
+        expect(links.first.association(:service_interaction)).to be_loaded
+      end
+
+      it 'preloads the service of the service interaction on the fetched records' do
+        expect(links.first.service_interaction.association(:service)).to be_loaded
+      end
+
+      it 'preloads the interaction of the service interaction on the fetched records' do
+        expect(links.first.service_interaction.association(:interaction)).to be_loaded
+      end
+    end
+  end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe LocalAuthority, type: :model do
       it { should allow_value('https://foo.com/path/file.html').for(:homepage_url) }
 
       it { should_not allow_value('foo.com').for(:homepage_url) }
+      it { is_expected.to allow_value(nil).for(:homepage_url) }
     end
 
     describe 'tier' do

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe LocalAuthority, type: :model do
     end
   end
 
+  describe 'associations' do
+    it { is_expected.to have_many(:links) }
+  end
+
   describe '#provided_services' do
     let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service') }
     let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service') }

--- a/spec/models/service_interaction_spec.rb
+++ b/spec/models/service_interaction_spec.rb
@@ -13,4 +13,57 @@ RSpec.describe ServiceInteraction, type: :model do
     it { is_expected.to belong_to(:service) }
     it { is_expected.to belong_to(:interaction) }
   end
+
+  describe '.find_by_lgsl_and_lgil' do
+    it 'returns the service interaction with a service matching the supplied lgsl_code and interaction matching the supplied lgil_code' do
+      service_100 = FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
+      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      service_interaction_100_1 = FactoryGirl.create(:service_interaction, service: service_100, interaction: interaction_1)
+
+      expect(described_class.find_by_lgsl_and_lgil(100, 1)).to eq(service_interaction_100_1)
+    end
+
+    it 'returns nil if no service interaction exists for the supplied lgsl and lgil codes' do
+      service_100 = FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
+      FactoryGirl.create(:service, lgsl_code: 200, label: 'Service 200')
+      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      FactoryGirl.create(:interaction, lgil_code: 2, label: 'Interaction 2')
+      FactoryGirl.create(:service_interaction, service: service_100, interaction: interaction_1)
+
+      # service interactions exist for service, but not interaction
+      expect(described_class.find_by_lgsl_and_lgil(100, 2)).to be_nil
+      # service interactions exist for interaction, but not service
+      expect(described_class.find_by_lgsl_and_lgil(200, 1)).to be_nil
+    end
+
+    it 'returns nil if the supplied lgsl is not a valid service' do
+      FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+
+      expect(described_class.find_by_lgsl_and_lgil(100, 1)).to be_nil
+    end
+
+    it 'returns nil if the supplied lgil is not a valid interaction' do
+      FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
+
+      expect(described_class.find_by_lgsl_and_lgil(100, 1)).to be_nil
+    end
+
+    context 'to avoid n+1 queries' do
+      let(:service) { FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100') }
+      let(:interaction) { FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1') }
+      before do
+        FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+      end
+
+      subject(:found_record) { ServiceInteraction.find_by_lgsl_and_lgil(100, 1) }
+
+      it 'preloads the service on the fetched record' do
+        expect(found_record.association(:service)).to be_loaded
+      end
+
+      it 'preloads the interaction on the fetched record' do
+        expect(found_record.association(:interaction)).to be_loaded
+      end
+    end
+  end
 end

--- a/spec/support/stub_csv_rows.rb
+++ b/spec/support/stub_csv_rows.rb
@@ -1,0 +1,13 @@
+module StubCSVRows
+  def stub_csv_rows(rows)
+    receive_each_row_and_yield = rows
+      .to_enum
+      .each
+      .with_object(receive(:each_row)) { |row, matcher|
+        matcher.and_yield(row)
+      }
+    allow(csv_downloader).to receive_each_row_and_yield
+  end
+end
+
+RSpec.configuration.include StubCSVRows, :csv_importer

--- a/spec/support/table_row_matcher.rb
+++ b/spec/support/table_row_matcher.rb
@@ -1,0 +1,51 @@
+module TableRowMatchers
+  class SimpleTableRowMatcher < Capybara::RSpecMatchers::Matcher
+    def initialize(*row_of_text)
+      @row_of_text = row_of_text
+    end
+
+    def matches?(actual)
+      rows_of_text_in_table(actual).include? @row_of_text
+    end
+
+    def does_not_match?(actual)
+      !rows_of_text_in_table(actual).include? @row_of_text
+    end
+
+    def description
+      "have a table row with cells #{@row_of_text.inspect}"
+    end
+
+    def failure_message
+      "Expected to find a table row with cells #{@row_of_text.inspect} in #{rows_of_text_in_table.inspect} but we didn't!"
+    end
+
+    def failure_message_when_negated
+      "Expected to not find a table row cells #{@row_of_text.inspect} in #{rows_of_text_in_table.inspect} but we did!"
+    end
+
+    def rows_in_table(actual = nil)
+      if actual.nil?
+        @rows_in_table
+      else
+        @rows_in_table = actual.all('tr')
+      end
+    end
+
+    def rows_of_text_in_table(actual = nil)
+      if actual.nil?
+        @rows_of_text_in_table
+      else
+        @rows_of_text_in_table ||= rows_in_table(actual).map { |row| row.all('th, td').map(&:text) }
+      end
+    end
+  end
+
+  def have_table_row(*row_of_text)
+    SimpleTableRowMatcher.new(*row_of_text)
+  end
+end
+
+RSpec.configure do |config|
+  config.include TableRowMatchers, type: :feature
+end


### PR DESCRIPTION
For: https://trello.com/c/Q0fMMggq/370-import-local-links-into-local-links-manager-5

In which we create a `Link` class to store the url that a given local authority uses for a given service interaction.  We display these links on the local authority service interactions index page as follows:

<img width="599" alt="aberdeen-homelessness-support" src="https://cloud.githubusercontent.com/assets/608/15398253/d3ad3ef6-1dda-11e6-8102-752cea0ceb0b.png">

They are imported from the same CSV that publisher uses.  Note that we're not currently: 
1. ignoring 'x' urls (although we do ignore those rows without matching snacs, lgsl, or lgil codes, so this might cover all of those - certainly no 'x' urls appear to have been imported locally).
2. doing anything to handle deletion (links removed in local direct gov admin no longer appear in the csv - see [Publisher's ghost detector](https://github.com/alphagov/publisher/blob/master/lib/local_authority_interaction_ghost_detector.rb))

Best reviewed commit-by-commit mostly because the last commit is very noisy and distorts the "full diff"
