### PR TITLE
Breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'capistrano-rails', group: :development
 
 gem 'pg'
 
+# Provides breadcrumbs, see config/breadcrumbs.rb
+gem 'gretel', '3.0.8'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    gretel (3.0.8)
+      rails (>= 3.2.0)
     hashdiff (0.3.0)
     hashie (3.4.3)
     http-cookie (1.0.2)
@@ -315,6 +317,7 @@ DEPENDENCIES
   gds-sso (~> 12.0)
   govuk-lint
   govuk_admin_template (~> 4.2)
+  gretel (= 3.0.8)
   jbuilder (~> 2.0)
   logstasher (= 0.6.2)
   pg

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,5 +1,6 @@
 class InteractionsController < ApplicationController
   def index
+    @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
     @service = Service.find_by_slug!(params[:service_slug])
     @interactions = @service.interactions
   end

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_title, @service.label %>
+
+<% breadcrumb :interactions, @authority, @service %>
+
 <div class="page-title">
   <h1><%= @service.label %></h1>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,4 +3,11 @@
   <%= javascript_include_tag 'application' %>
 <% end %>
 
+<% content_for :content do %>
+
+  <%= breadcrumbs style: :bootstrap %>
+
+  <%= yield %>
+<% end %>
+
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_title, "Local Authorities" %>
+
+<% breadcrumb :local_authorities %>
+
 <div class="page-title">
   <h1>Local Authorities</h1>
 </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_title, @authority.name %>
+
+<% breadcrumb :services, @authority %>
+
 <div class="page-title">
   <h1><%= @authority.name %></h1>
 </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,3 @@
+crumb :root do
+  link 'Home', root_path
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,3 +1,13 @@
-crumb :root do
-  link 'Home', root_path
+crumb :local_authorities do
+  link "Local Authorities", local_authorities_path
+end
+
+crumb :services do |local_authority|
+  link local_authority.name, local_authority_services_path(local_authority.slug)
+  parent :local_authorities
+end
+
+crumb :interactions do |local_authority, service|
+  link service.label, local_authority_service_interactions_path(local_authority.slug, service.slug)
+  parent :services, local_authority
 end

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -8,6 +8,14 @@ feature "The interactions index page for a service provided by a local authority
     visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 
+  it 'has a list of breadcrumbs pointing back to the authority and service that lead us here' do
+    within '.breadcrumb' do
+      expect(page).to have_link 'Local Authorities', href: local_authorities_path
+      expect(page).to have_link 'Angus', href: local_authority_services_path(@local_authority.slug)
+      expect(page).to have_text 'Service 1'
+    end
+  end
+
   describe "with no interactions present" do
     it "shows a message that no interactions are present" do
       expect(page).to have_content("No local interactions found")

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -6,6 +6,10 @@ feature "The local authorities index page" do
     visit root_path
   end
 
+  it 'has no breadcrumb trail because this is the root' do
+    expect(page).to have_no_selector('.breadcrumb')
+  end
+
   describe "with no local authorities present" do
     it "shows a message if no local authorities are present" do
       expect(page).to have_content 'No local authorities found'

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -7,6 +7,13 @@ feature "The services index page for a local authority" do
     visit local_authority_services_path(local_authority_slug: @local_authority.slug)
   end
 
+  it 'has a list of breadcrumbs pointing back to the authority that lead us here' do
+    within '.breadcrumb' do
+      expect(page).to have_link 'Local Authorities', href: local_authorities_path
+      expect(page).to have_text 'Angus'
+    end
+  end
+
   describe "with no services present" do
     it "shows a message that no services are present" do
       expect(page).to have_content 'No local services found'


### PR DESCRIPTION
Add breadcrumbs to the app (like what @fofr asked for on #10).

![breadcrumbs](https://cloud.githubusercontent.com/assets/608/15431299/1aa05de0-1ea1-11e6-8c8b-7bc3a5c36d6a.gif)

We use the [gretel gem](https://github.com/lassebunk/gretel) following the lead of [transition](https://github.com/alphagov/transition), but instead of [manually rendering the crumbs](https://github.com/alphagov/transition/blob/master/app/views/layouts/application.html.erb#L76-L82), we configure gretel to render `bootstrap` styled crumbs and it all comes out ok.
