### PR TITLE
Display enabled services for each authority

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -8,6 +8,6 @@ class LocalAuthority < ActiveRecord::Base
   has_many :links
 
   def provided_services
-    Service.for_tier(self.tier)
+    Service.for_tier(self.tier).enabled
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,6 +16,8 @@ class Service < ActiveRecord::Base
     end
   }
 
+  scope :enabled, -> { where(enabled: true) }
+
   def provided_by?(authority)
     case tier
     when nil

--- a/db/migrate/20160523155343_add_enabled_column_to_service.rb
+++ b/db/migrate/20160523155343_add_enabled_column_to_service.rb
@@ -1,0 +1,5 @@
+class AddEnabledColumnToService < ActiveRecord::Migration
+  def change
+    add_column :services, :enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160517134617) do
+ActiveRecord::Schema.define(version: 20160523155343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,12 +62,13 @@ ActiveRecord::Schema.define(version: 20160517134617) do
   add_index "service_interactions", ["service_id", "interaction_id"], name: "index_service_interactions_on_service_id_and_interaction_id", unique: true, using: :btree
 
   create_table "services", force: :cascade do |t|
-    t.integer  "lgsl_code",  null: false
-    t.string   "label",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string   "slug",       null: false
+    t.integer  "lgsl_code",                  null: false
+    t.string   "label",                      null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
     t.string   "tier"
+    t.string   "slug",                       null: false
+    t.boolean  "enabled",    default: false, null: false
   end
 
   add_index "services", ["label"], name: "index_services_on_label", unique: true, using: :btree

--- a/lib/local-links-manager/import/csv_downloader.rb
+++ b/lib/local-links-manager/import/csv_downloader.rb
@@ -5,7 +5,7 @@ class CsvDownloader
   class DownloadError < Error; end
   class MalformedCSVError < Error; end
 
-  def initialize(csv_url, header_conversions: {}, encoding: 'windows-1252')
+  def initialize(csv_url, header_conversions: {}, encoding: 'UTF-8')
     @csv_url = csv_url
     @header_conversions = header_conversions
     @encoding = encoding

--- a/lib/local-links-manager/import/enabled_service_checker.rb
+++ b/lib/local-links-manager/import/enabled_service_checker.rb
@@ -1,0 +1,40 @@
+require_relative 'csv_downloader'
+
+module LocalLinksManager
+  module Import
+    class EnabledServiceChecker
+      CSV_URL = "https://raw.githubusercontent.com/alphagov/publisher/master/data/local_services.csv"
+
+      def self.enable
+        new.enable_services
+      end
+
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL))
+        @csv_downloader = csv_downloader
+      end
+
+      def enable_services
+        @csv_downloader.each_row do |row|
+          set_enabled_service(row)
+        end
+      rescue CsvDownloader::Error => e
+        Rails.logger.error e.message
+      rescue => e
+        Rails.logger.error "Error #{e.class} enabling in #{self.class}\n#{e.backtrace.join("\n")}"
+      end
+
+    private
+
+      def set_enabled_service(row)
+        service = Service.find_by(lgsl_code: row["LGSL"])
+        if service.nil?
+          Rails.logger.warn("'#{row['LGSL']}' is not an imported Service")
+        else
+          service.enabled = true
+          Rails.logger.info("'#{row['LGSL']}' enabled")
+          service.save!
+        end
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/import/local_authorities_url_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_url_importer.rb
@@ -9,7 +9,7 @@ module LocalLinksManager
         new.import_records
       end
 
-      def initialize(csv_downloader = CsvDownloader.new(CSV_URL))
+      def initialize(csv_downloader = CsvDownloader.new(CSV_URL, encoding: 'windows-1252'))
         @csv_downloader = csv_downloader
       end
 

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -2,6 +2,7 @@ require 'local-links-manager/import/services_importer'
 require 'local-links-manager/import/interactions_importer'
 require 'local-links-manager/import/service_interactions_importer'
 require 'local-links-manager/import/services_tier_importer'
+require 'local-links-manager/import/enabled_service_checker'
 
 namespace :import do
   namespace :service_interactions do
@@ -11,6 +12,7 @@ namespace :import do
       Rake::Task["import:service_interactions:import_interactions"].invoke
       Rake::Task["import:service_interactions:import_service_interactions"].invoke
       Rake::Task["import:service_interactions:add_service_tiers"].invoke
+      Rake::Task["import:service_interactions:enable_services"].invoke
     end
 
     desc "Import Services from standards.esd.org.uk"
@@ -31,6 +33,11 @@ namespace :import do
     desc "Add tiers from local_services.csv in publisher to the list of Services imported by `import_services`"
     task add_service_tiers: :environment do
       LocalLinksManager::Import::ServicesTierImporter.import
+    end
+
+    desc "Enable services used on Gov.uk"
+    task enable_services: :environment do
+      LocalLinksManager::Import::EnabledServiceChecker.enable
     end
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     lgsl_code 1152
     label "Abandoned shopping trolleys"
     slug { label.parameterize }
+    enabled false
   end
 end

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -22,17 +22,19 @@ feature "The services index page for a local authority" do
 
   describe "with services present" do
     before do
-      @service_1 = FactoryGirl.create(:service, label: 'All councils', lgsl_code: 1, tier: 'all')
-      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', lgsl_code: 2, tier: 'county/unitary')
-      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', lgsl_code: 3, tier: 'district/unitary')
-      @service_4 = FactoryGirl.create(:service, label: 'Unknown', lgsl_code: 4, tier: nil)
+      @service_1 = FactoryGirl.create(:service, label: 'All councils', lgsl_code: 1, tier: 'all', enabled: true)
+      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', lgsl_code: 2, tier: 'county/unitary', enabled: true)
+      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', lgsl_code: 3, tier: 'district/unitary', enabled: true)
+      @service_4 = FactoryGirl.create(:service, label: 'Unknown', lgsl_code: 4, tier: nil, enabled: true)
+      @service_5 = FactoryGirl.create(:service, label: 'District and unitary disabled', lgsl_code: 5, tier: 'district/unitary', enabled: false)
       visit local_authority_services_path(@local_authority.slug)
     end
 
-    it "shows only the services provided by the authority according to its' tier with links to their individual pages" do
+    it "shows only the enabled services provided by the authority according to its tier with links to their individual pages" do
       expect(page).to have_content 'Local Government Services (2)'
       expect(page).to have_link('All councils', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug))
       expect(page).to have_link('District and unitary only', href: local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_3.slug))
+      expect(page).not_to have_link('District and unitary disabled')
     end
 
     it "shows each service's LGSL codes in the table" do

--- a/spec/lib/local-links-manager/import/csv_downloader_spec.rb
+++ b/spec/lib/local-links-manager/import/csv_downloader_spec.rb
@@ -89,7 +89,8 @@ describe CsvDownloader do
         windows_encoded_data.force_encoding('windows-1252')
         stub_csv_download(windows_encoded_data)
 
-        subject.download do |csv|
+        downloader = CsvDownloader.new(url, encoding: 'windows-1252')
+        downloader.download do |csv|
           row = csv.first
           expect(row['Currency'].encoding).to eq Encoding::UTF_8
           expect(row['Symbol'].encoding).to eq Encoding::UTF_8

--- a/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
+++ b/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'local-links-manager/import/enabled_service_checker'
+
+describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
+  describe '#enabled_services' do
+    let(:csv_downloader) { instance_double CsvDownloader }
+    let(:csv_rows) { [{ "LGSL" => 1614 }, { "LGSL" => 13 }] }
+    let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
+    let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+    let!(:service_2) { FactoryGirl.create(:service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
+
+    context 'when the csv is downloaded successfully' do
+      before do
+        stub_csv_rows(csv_rows)
+      end
+
+      it 'sets enabled to true for required services' do
+        LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader).enable_services
+        expect(service_0.reload.enabled).to eq(true)
+        expect(service_1.reload.enabled).to eq(true)
+      end
+
+      it 'should not enable an unrequired service' do
+        expect(service_2.reload.enabled).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -33,29 +33,30 @@ RSpec.describe LocalAuthority, type: :model do
   end
 
   describe '#provided_services' do
-    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service') }
-    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service') }
-    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service') }
-    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service') }
+    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service', enabled: true) }
+    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service', enabled: true) }
+    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service', enabled: true) }
+    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service', enabled: true) }
+    let!(:disabled_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 5, label: 'Disabled District Service', enabled: false) }
     subject { FactoryGirl.build(:local_authority) }
 
     context 'for a "district" LA' do
       before { subject.tier = 'district' }
-      it 'returns all and district/unitary services' do
+      it 'returns all and district/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, district_service])
       end
     end
 
     context 'for a "county" LA' do
       before { subject.tier = 'county' }
-      it 'returns all and county/unitary services' do
+      it 'returns all and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service])
       end
     end
 
     context 'for a "unitary" LA' do
       before { subject.tier = 'unitary' }
-      it 'returns all, district/unitary, and county/unitary services' do
+      it 'returns all, district/unitary, and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service, district_service])
       end
     end


### PR DESCRIPTION
- Added rake task to get the enabled services csv from Publisher and enable any Service currently imported.
- Log any enabled services that are in the csv but not currently imported.
- Changed the default encoding for csv importing to UTF-8.
- Change local authority services view to only show enabled services.

[Trello card](https://trello.com/c/LhMS1J3H/388-mark-services-to-be-enabled-for-use-on-gov-uk)

Mobbed by @emmabeynon @klssmith @brenetic @h-lame 
