### PR TITLE
Enable editing of links and homepage URLs

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,31 +1,25 @@
 class LinksController < ApplicationController
+  before_action :load_dependencies
+
   def edit
-    load_dependencies
-    @link = Link.get_link(params)
+    @link = Link.retrieve(params)
   end
 
   def update
-    @link = Link.get_link(params)
+    @link = Link.retrieve(params)
     @link.url = params[:link][:url]
     validate_and_save(@link)
   end
 
   def create
-    @link = Link.new
-    @link.local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
-    @link.service_interaction = ServiceInteraction.find_by(
-      service: Service.find_by(slug: params[:service_slug]),
-      interaction: Interaction.find_by(slug: params[:interaction_slug])
-    )
+    @link = Link.build(params)
     @link.url = params[:link][:url]
-
     validate_and_save(@link)
   end
 
 private
 
   def validate_and_save(link)
-    load_dependencies
     if link.save
       flash[:success] = "Link has been saved."
       flash[:lgil] = @interaction.lgil_code

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -5,10 +5,6 @@ class LinksController < ApplicationController
     @interaction = Interaction.find_by(slug: params[:interaction_slug])
 
     @link = Link.get_link(params)
-    if @link.nil?
-      @link = Link.new
-      @link.url = 'n/a'
-    end
   end
 
   def update

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,39 +1,43 @@
 class LinksController < ApplicationController
   def edit
-    @local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
-    @service = Service.find_by(slug: params[:service_slug])
-    @interaction = Interaction.find_by(slug: params[:interaction_slug])
-
+    load_dependencies
     @link = Link.get_link(params)
   end
 
   def update
-    link = Link.get_link(params)
-    link.url = params[:link][:url]
-    validate_and_save(link)
+    @link = Link.get_link(params)
+    @link.url = params[:link][:url]
+    validate_and_save(@link)
   end
 
   def create
-    link = Link.new
-    link.local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
-    link.service = Service.find_by(slug: params[:service_slug])
-    link.interaction = Interaction.find_by(slug: params[:interaction_slug])
-    link.service_interaction = ServiceInteraction.find_by(service: link.service, interaction: link.interaction)
-    link.url = params[:link][:url]
+    @link = Link.new
+    @link.local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
+    @link.service_interaction = ServiceInteraction.find_by(
+      service: Service.find_by(slug: params[:service_slug]),
+      interaction: Interaction.find_by(slug: params[:interaction_slug])
+    )
+    @link.url = params[:link][:url]
 
-    validate_and_save(link)
+    validate_and_save(@link)
   end
 
 private
 
   def validate_and_save(link)
-    if link.valid?
-      link.save!
+    if link.save
       flash[:success] = "Link has been saved."
       redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
     else
-      flash[:danger] = "Please enter a valid link."
-      redirect_to action: "edit"
+      load_dependencies
+      flash.now[:danger] = "Please enter a valid link."
+      render :edit
     end
+  end
+
+  def load_dependencies
+    @local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
+    @interaction = Interaction.find_by(slug: params[:interaction_slug])
+    @service = Service.find_by(slug: params[:service_slug])
   end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,5 +1,9 @@
 class LinksController < ApplicationController
   def edit
+    @local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
+    @service = Service.find_by(slug: params[:service_slug])
+    @interaction = Interaction.find_by(slug: params[:interaction_slug])
+
     @link = Link.get_link(params)
     if @link.nil?
       @link = Link.new

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,10 +1,39 @@
 class LinksController < ApplicationController
-
   def edit
     @link = Link.get_link(params)
     if @link.nil?
       @link = Link.new
       @link.url = 'n/a'
+    end
+  end
+
+  def update
+    link = Link.get_link(params)
+    link.url = params[:link][:url]
+    validate_and_save(link)
+  end
+
+  def create
+    link = Link.new
+    link.local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
+    link.service = Service.find_by(slug: params[:service_slug])
+    link.interaction = Interaction.find_by(slug: params[:interaction_slug])
+    link.service_interaction = ServiceInteraction.find_by(service: link.service, interaction: link.interaction)
+    link.url = params[:link][:url]
+
+    validate_and_save(link)
+  end
+
+private
+
+  def validate_and_save(link)
+    if link.valid?
+      link.save!
+      flash[:success] = "Link has been saved."
+      redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
+    else
+      flash[:danger] = "Please enter a valid link."
+      redirect_to action: "edit"
     end
   end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -31,7 +31,7 @@ private
       flash[:lgil] = @interaction.lgil_code
       redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
     else
-      flash.now[:danger] = "Please enter a valid link."
+      flash.now[:bad_url] = "Please enter a valid link."
       render :edit
     end
   end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -25,11 +25,12 @@ class LinksController < ApplicationController
 private
 
   def validate_and_save(link)
+    load_dependencies
     if link.save
       flash[:success] = "Link has been saved."
+      flash[:lgil] = @interaction.lgil_code
       redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
     else
-      load_dependencies
       flash.now[:danger] = "Please enter a valid link."
       render :edit
     end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -8,19 +8,8 @@ class LinksController < ApplicationController
   def update
     @link = Link.retrieve(params)
     @link.url = params[:link][:url]
-    validate_and_save(@link)
-  end
 
-  def create
-    @link = Link.build(params)
-    @link.url = params[:link][:url]
-    validate_and_save(@link)
-  end
-
-private
-
-  def validate_and_save(link)
-    if link.save
+    if @link.save
       flash[:success] = "Link has been saved."
       flash[:lgil] = @interaction.lgil_code
       redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
@@ -29,6 +18,8 @@ private
       render :edit
     end
   end
+
+private
 
   def load_dependencies
     @local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,0 +1,10 @@
+class LinksController < ApplicationController
+
+  def edit
+    @link = Link.get_link(params)
+    if @link.nil?
+      @link = Link.new
+      @link.url = 'n/a'
+    end
+  end
+end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -8,21 +8,20 @@ class LocalAuthoritiesController < ApplicationController
   end
 
   def update
-    authority = LocalAuthority.find_by(slug: params[:slug])
-    authority.homepage_url = params[:local_authority][:homepage_url]
-    validate_and_save(authority)
+    @authority = LocalAuthority.find_by(slug: params[:slug])
+    @authority.homepage_url = params[:local_authority][:homepage_url]
+    validate_and_save(@authority)
   end
 
 private
 
   def validate_and_save(authority)
-    if authority.valid?
-      authority.save!
+    if authority.save
       flash[:success] = "Homepage link has been saved."
       redirect_to local_authority_services_path(local_authority_slug: params[:slug])
     else
-      flash[:danger] = "Please enter a valid link."
-      redirect_to action: "edit"
+      flash.now[:danger] = "Please enter a valid link."
+      render :edit
     end
   end
 end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -2,4 +2,27 @@ class LocalAuthoritiesController < ApplicationController
   def index
     @authorities = LocalAuthority.all.order(name: :asc)
   end
+
+  def edit
+    @authority = LocalAuthority.find_by(slug: params[:slug])
+  end
+
+  def update
+    authority = LocalAuthority.find_by(slug: params[:slug])
+    authority.homepage_url = params[:local_authority][:homepage_url]
+    validate_and_save(authority)
+  end
+
+private
+
+  def validate_and_save(authority)
+    if authority.valid?
+      authority.save!
+      flash[:success] = "Homepage link has been saved."
+      redirect_to local_authority_services_path(local_authority_slug: params[:slug])
+    else
+      flash[:danger] = "Please enter a valid link."
+      redirect_to action: "edit"
+    end
+  end
 end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -20,7 +20,7 @@ private
       flash[:success] = "Homepage link has been saved."
       redirect_to local_authority_services_path(local_authority_slug: params[:slug])
     else
-      flash.now[:danger] = "Please enter a valid link."
+      flash.now[:bad_url] = "Please enter a valid link."
       render :edit
     end
   end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -3,7 +3,7 @@ module LinksHelper
     if @links.key? interaction
       link_to nil, @links[interaction]
     else
-      'n/a'
+      'No link'
     end
   end
 end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,5 +1,5 @@
 class Interaction < ActiveRecord::Base
-  validates :lgil_code, :label, presence: true, uniqueness: true
+  validates :lgil_code, :label, :slug, presence: true, uniqueness: true
 
   has_many :service_interactions
   has_many :services, through: :service_interactions

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -15,12 +15,22 @@ class Link < ActiveRecord::Base
       .where(service_interactions: { service_id: service })
   }
 
-  def self.get_link(params)
+  def self.retrieve(params)
     self.joins(:local_authority, :service, :interaction).find_by(
       local_authorities: { slug: params[:local_authority_slug] },
       services: { slug: params[:service_slug] },
       interactions: { slug: params[:interaction_slug] }
-    ) || Link.new
+    ) || build(params)
+  end
+
+  def self.build(params)
+    Link.new(
+      local_authority: LocalAuthority.find_by(slug: params[:local_authority_slug]),
+      service_interaction: ServiceInteraction.find_by(
+        service: Service.find_by(slug: params[:service_slug]),
+        interaction: Interaction.find_by(slug: params[:interaction_slug]),
+      )
+    )
   end
 
   def display_url

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -24,6 +24,6 @@ class Link < ActiveRecord::Base
   end
 
   def display_url
-    url || 'n/a'
+    url || 'No link'
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -20,6 +20,10 @@ class Link < ActiveRecord::Base
       local_authorities: { slug: params[:local_authority_slug] },
       services: { slug: params[:service_slug] },
       interactions: { slug: params[:interaction_slug] }
-    )
+    ) || Link.new
+  end
+
+  def display_url
+    url || 'n/a'
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -14,4 +14,12 @@ class Link < ActiveRecord::Base
       .references(:service_interactions)
       .where(service_interactions: { service_id: service })
   }
+
+  def self.get_link(params)
+    self.joins(:local_authority, :service, :interaction).find_by(
+      local_authorities: { slug: params[:local_authority_slug] },
+      services: { slug: params[:service_slug] },
+      interactions: { slug: params[:interaction_slug] }
+    )
+  end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -10,9 +10,4 @@ class LocalAuthority < ActiveRecord::Base
   def provided_services
     Service.for_tier(self.tier).enabled
   end
-
-  def friendly_url
-    uri = URI.parse(self.homepage_url)
-    "#{uri.host}#{uri.path}"
-  end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -11,7 +11,8 @@ class LocalAuthority < ActiveRecord::Base
     Service.for_tier(self.tier).enabled
   end
 
-  def hostname
-    URI.parse(self.homepage_url).host
+  def friendly_url
+    uri = URI.parse(self.homepage_url)
+    "#{uri.host}#{uri.path}"
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -10,4 +10,8 @@ class LocalAuthority < ActiveRecord::Base
   def provided_services
     Service.for_tier(self.tier).enabled
   end
+
+  def hostname
+    URI.parse(self.homepage_url).host
+  end
 end

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -34,7 +34,7 @@
           <td>
           </td>
           <td class='text-center'>
-            <%= link_to('Edit link', edit_local_authority_service_interaction_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
+            <%= link_to('Edit link', edit_local_authority_service_interaction_links_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
           </td>
         </tr>
       <% end %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -23,7 +23,7 @@
     </thead>
     <tbody>
       <% @interactions.each do |interaction| %>
-        <tr>
+        <tr <% if flash[:lgil] == interaction.lgil_code %>class="success"<% end %>>
           <td class="lgil_code text-center">
             <%= interaction.lgil_code %>
           </td>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -6,8 +6,8 @@
 
 <div class="page-title">
   <h2><%= @service.label %></h2>
-  <p>LGSL <%= @service.lgsl_code %></p>
 </div>
+<p><b>LGSL</b> <%= @service.lgsl_code %></p>
 
 <% if @interactions.any? %>
   <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -2,8 +2,11 @@
 
 <% breadcrumb :interactions, @authority, @service %>
 
+<%= render partial: "shared/local_authority_details", locals: {authority: @authority} %>
+
 <div class="page-title">
-  <h1><%= @service.label %></h1>
+  <h2><%= @service.label %></h2>
+  <p>LGSL <%= @service.lgsl_code %></p>
 </div>
 
 <% if @interactions.any? %>
@@ -12,8 +15,8 @@
       <tr class="table-header">
         <th>LGIL Code</th>
         <th>Local Government Interactions (<%= @interactions.count %>)</th>
-        <th>Link</th>
-        <th>Action</th>
+        <th>Description</th>
+        <th></th>
       </tr>
       <%= render partial: "govuk_admin_template/table_filter",
       locals: {placeholder: "Filter list of local interactions"} %>
@@ -26,9 +29,9 @@
           </td>
           <td class="name">
             <%= interaction.label %>
+            <p><%= display_link_for(interaction) %></p>
           </td>
           <td>
-            <%= display_link_for(interaction) %>
           </td>
           <td>
             <%= link_to('Edit link', edit_local_authority_service_interaction_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-xs") %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -24,7 +24,7 @@
     <tbody>
       <% @interactions.each do |interaction| %>
         <tr>
-          <td class="lgil_code">
+          <td class="lgil_code text-center">
             <%= interaction.lgil_code %>
           </td>
           <td class="name">
@@ -33,8 +33,8 @@
           </td>
           <td>
           </td>
-          <td>
-            <%= link_to('Edit link', edit_local_authority_service_interaction_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-xs") %>
+          <td class='text-center'>
+            <%= link_to('Edit link', edit_local_authority_service_interaction_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
           </td>
         </tr>
       <% end %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -13,6 +13,7 @@
         <th>LGIL Code</th>
         <th>Local Government Interactions (<%= @interactions.count %>)</th>
         <th>Link</th>
+        <th>Action</th>
       </tr>
       <%= render partial: "govuk_admin_template/table_filter",
       locals: {placeholder: "Filter list of local interactions"} %>
@@ -28,6 +29,9 @@
           </td>
           <td>
             <%= display_link_for(interaction) %>
+          </td>
+          <td>
+            <%= link_to('Edit link', edit_local_authority_service_interaction_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-xs") %>
           </td>
         </tr>
       <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -13,9 +13,11 @@
 <%= label_tag 'link', 'URL' %>
 
 <%= form_for @link, url: {action: "update"} do |f| %>
-  <%= f.text_field :url, class: "form-control" %>
-  <div class='actions add-vertical-margins'>
-    <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
-    <button type='submit' class='btn btn-success'>Save</button>
+  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
+    <%= f.text_field :url, class: "form-control" %>
+    <div class='actions add-vertical-margins'>
+      <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
+      <button type='submit' class='btn btn-success'>Save</button>
+    </div>
   </div>
 <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -14,7 +14,7 @@
 
 <%= form_for @link, url: {action: "update"} do |f| %>
   <div class="form-group <% if flash[:danger] %>has-error<% end %>">
-    <%= f.text_field :url, class: "form-control" %>
+    <%= f.text_field :url, class: "form-control", value: @link.display_url%>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
       <button type='submit' class='btn btn-success'>Save</button>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -16,7 +16,7 @@
 
 <p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
-<%= form_for @link, url: {action: "update"} do |f| %>
+<%= form_for @link, url: local_authority_service_interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
   <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
     <%= f.text_field :url, class: "form-control", value: @link.display_url%>
     <div class='actions add-vertical-margins'>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,8 +1,21 @@
 <% breadcrumb :links, @local_authority, @service, @interaction %>
 
-<%= label_tag 'link', 'Link' %>
+<%= render partial: "shared/local_authority_details", locals: {authority: @local_authority} %>
+
+<div class="page-title">
+  <h2><%= @interaction.label %></h2>
+</div>
+<b>LGSL</b> <%= @service.lgsl_code %>
+<hr>
+<b>LGIL</b> <%= @interaction.lgil_code %>
+<hr>
+
+<%= label_tag 'link', 'URL' %>
 
 <%= form_for @link, url: {action: "update"} do |f| %>
-  <%= f.text_field :url %>
-  <%= f.submit "Save" %>
+  <%= f.text_field :url, class: "form-control" %>
+  <div class='actions add-vertical-margins'>
+    <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
+    <button type='submit' class='btn btn-success'>Save</button>
+  </div>
 <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -5,6 +5,11 @@
 <div class="page-title">
   <h2><%= @interaction.label %></h2>
 </div>
+
+<% if flash[:bad_url] %>
+<div class="alert alert-danger">Please enter a valid link.</div>
+<% end %>
+
 <b>LGSL</b> <%= @service.lgsl_code %>
 <hr>
 <b>LGIL</b> <%= @interaction.lgil_code %>
@@ -12,10 +17,10 @@
 
 <%= label_tag 'link', 'URL' %>
 
-<p class="text-muted">eg http://www.barnet.gov.uk</p>
+<p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
 <%= form_for @link, url: {action: "update"} do |f| %>
-  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
+  <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
     <%= f.text_field :url, class: "form-control", value: @link.display_url%>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,0 +1,5 @@
+<%= label_tag 'link', 'Link' %>
+
+<%= text_field_tag 'link', @link.url %>
+
+<%= button_tag 'Save' %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,3 +1,5 @@
+<% breadcrumb :links, @local_authority, @service, @interaction %>
+
 <%= label_tag 'link', 'Link' %>
 
 <%= form_for @link, url: {action: "update"} do |f| %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,5 +1,6 @@
 <%= label_tag 'link', 'Link' %>
 
-<%= text_field_tag 'link', @link.url %>
-
-<%= button_tag 'Save' %>
+<%= form_for @link, url: {action: "update"} do |f| %>
+  <%= f.text_field :url %>
+  <%= f.submit "Save" %>
+<% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -12,6 +12,8 @@
 
 <%= label_tag 'link', 'URL' %>
 
+<p class="text-muted">eg http://www.barnet.gov.uk</p>
+
 <%= form_for @link, url: {action: "update"} do |f| %>
   <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <%= f.text_field :url, class: "form-control", value: @link.display_url%>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -10,10 +10,7 @@
 <div class="alert alert-danger">Please enter a valid link.</div>
 <% end %>
 
-<b>LGSL</b> <%= @service.lgsl_code %>
-<hr>
-<b>LGIL</b> <%= @interaction.lgil_code %>
-<hr>
+<p><b>LGSL</b> <%= @service.lgsl_code %><b class="add-left-margin">LGIL</b> <%= @interaction.lgil_code %></p>
 
 <%= label_tag 'link', 'URL' %>
 

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -12,7 +12,7 @@
 
 <p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
-<%= form_for @authority, url: {action: "update"} do |f| %>
+<%= form_for @authority, url: local_authority_path, method: "put" do |f| %>
   <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>
     <div class='actions add-vertical-margins'>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -1,0 +1,16 @@
+<% breadcrumb :local_authorities, @local_authority %>
+
+<div class="page-title">
+  <h1><%= @authority.name %></h1>
+</div>
+<hr>
+
+<%= label_tag 'link_url', 'Homepage URL' %>
+
+<%= form_for @authority, url: {action: "update"} do |f| %>
+  <%= f.text_field :homepage_url, class: "form-control" %>
+  <div class='actions add-vertical-margins'>
+    <%= link_to 'Cancel', :back, { class: 'btn btn-default add-right-margin' } %>
+    <button type='submit' class='btn btn-success'>Save</button>
+  </div>
+<% end %>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -7,6 +7,8 @@
 
 <%= label_tag 'link_url', 'Homepage URL' %>
 
+<p class="text-muted">eg http://www.local-authority.gov.uk</p>
+
 <%= form_for @authority, url: {action: "update"} do |f| %>
   <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -8,9 +8,11 @@
 <%= label_tag 'link_url', 'Homepage URL' %>
 
 <%= form_for @authority, url: {action: "update"} do |f| %>
-  <%= f.text_field :homepage_url, class: "form-control" %>
-  <div class='actions add-vertical-margins'>
-    <%= link_to 'Cancel', :back, { class: 'btn btn-default add-right-margin' } %>
-    <button type='submit' class='btn btn-success'>Save</button>
+  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
+    <%= f.text_field :homepage_url, class: "form-control" %>
+    <div class='actions add-vertical-margins'>
+      <%= link_to 'Cancel', :back, { class: 'btn btn-default add-right-margin' } %>
+      <button type='submit' class='btn btn-success'>Save</button>
+    </div>
   </div>
 <% end %>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -5,12 +5,16 @@
 </div>
 <hr>
 
+<% if flash[:bad_url] %>
+<div class="alert alert-danger">Please enter a valid link.</div>
+<% end %>
+
 <%= label_tag 'link_url', 'Homepage URL' %>
 
 <p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
 <%= form_for @authority, url: {action: "update"} do |f| %>
-  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
+  <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', :back, { class: 'btn btn-default add-right-margin' } %>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -1,9 +1,8 @@
-<% breadcrumb :local_authorities, @local_authority %>
+<% breadcrumb :services, @authority %>
 
 <div class="page-title">
   <h1><%= @authority.name %></h1>
 </div>
-<hr>
 
 <% if flash[:bad_url] %>
 <div class="alert alert-danger">Please enter a valid link.</div>
@@ -17,7 +16,7 @@
   <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>
     <div class='actions add-vertical-margins'>
-      <%= link_to 'Cancel', :back, { class: 'btn btn-default add-right-margin' } %>
+      <%= link_to 'Cancel', local_authority_services_path(@authority.slug), { class: 'btn btn-default add-right-margin' } %>
       <button type='submit' class='btn btn-success'>Save</button>
     </div>
   </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -2,9 +2,7 @@
 
 <% breadcrumb :services, @authority %>
 
-<div class="page-title">
-  <h1><%= @authority.name %></h1>
-</div>
+<%= render partial: "shared/local_authority_details", locals: {authority: @authority} %>
 
 <% if @services.any? %>
   <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,0 +1,5 @@
+<div class="page-title">
+  <h1><%= authority.name %></h1>
+  <p>Homepage <%= link_to(authority.hostname, authority.homepage_url) %></p>
+</div>
+<hr />

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,5 +1,6 @@
 <div class="page-title">
   <h1><%= authority.name %></h1>
-  <p>Homepage <%= link_to(authority.hostname, authority.homepage_url) %></p>
+  <p>Homepage <%= link_to(authority.friendly_url, authority.homepage_url) %></p>
+  <%= link_to 'Edit homepage link', edit_local_authority_path(slug: authority.slug) %>
 </div>
 <hr />

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,6 +1,7 @@
 <div class="page-title">
   <h1><%= authority.name %></h1>
-  <p>Homepage <%= link_to(authority.friendly_url, authority.homepage_url) %></p>
-  <%= link_to 'Edit homepage link', edit_local_authority_path(slug: authority.slug) %>
+  <p>
+    Homepage <%= link_to(authority.friendly_url, authority.homepage_url) %>
+    <%= link_to 'Edit link', edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %>
+  </p>
 </div>
-<hr />

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,7 +1,7 @@
 <div class="page-title">
   <h1><%= authority.name %></h1>
   <p>
-    Homepage <%= link_to(authority.friendly_url, authority.homepage_url) %>
+    Homepage <%= link_to(nil, authority.homepage_url) %>
     <%= link_to 'Edit link', edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %>
   </p>
 </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -11,3 +11,8 @@ crumb :interactions do |local_authority, service|
   link service.label, local_authority_service_interactions_path(local_authority.slug, service.slug)
   parent :services, local_authority
 end
+
+crumb :links do |local_authority, service, interaction|
+  link interaction.label, local_authority_service_interaction_link_path(local_authority.slug, service.slug, interaction.slug)
+  parent :interactions, local_authority, service
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -13,6 +13,6 @@ crumb :interactions do |local_authority, service|
 end
 
 crumb :links do |local_authority, service, interaction|
-  link interaction.label, local_authority_service_interaction_link_path(local_authority.slug, service.slug, interaction.slug)
+  link interaction.label, local_authority_service_interaction_links_path(local_authority.slug, service.slug, interaction.slug)
   parent :interactions, local_authority, service
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources "local_authorities", only: [:index], param: :slug do
     resources "services", only: [:index], param: :slug do
       resources "interactions", only: [:index], param: :slug do
-        resource "link", only: [:edit]
+        resource "link", only: [:edit, :create, :update]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources "local_authorities", only: [:index, :edit, :update], param: :slug do
     resources "services", only: [:index], param: :slug do
       resources "interactions", only: [:index], param: :slug do
-        resource "link", only: [:edit, :create, :update]
+        resource "links", only: [:edit, :update]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
-  resources "local_authorities", only: [:index], param: :slug do
+  resources "local_authorities", only: [:index, :edit, :update], param: :slug do
     resources "services", only: [:index], param: :slug do
       resources "interactions", only: [:index], param: :slug do
         resource "link", only: [:edit, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
 
   resources "local_authorities", only: [:index], param: :slug do
     resources "services", only: [:index], param: :slug do
-      resources "interactions", only: [:index]
+      resources "interactions", only: [:index], param: :slug do
+        resource "link", only: [:edit]
+      end
     end
   end
 

--- a/db/migrate/20160525152805_add_slug_to_interactions.rb
+++ b/db/migrate/20160525152805_add_slug_to_interactions.rb
@@ -1,0 +1,16 @@
+class AddSlugToInteractions < ActiveRecord::Migration
+  def up
+    add_column :interactions, :slug, :string, unique: true
+
+    Interaction.all.each do |interaction|
+      interaction.slug = interaction.label.parameterize
+      interaction.save!
+    end
+
+    change_column_null :interactions, :slug, false
+  end
+
+  def down
+    remove_column :interactions, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160523155343) do
+ActiveRecord::Schema.define(version: 20160525152805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20160523155343) do
     t.string   "label",      null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "slug",       null: false
   end
 
   add_index "interactions", ["label"], name: "index_interactions_on_label", unique: true, using: :btree

--- a/lib/local-links-manager/import/interactions_importer.rb
+++ b/lib/local-links-manager/import/interactions_importer.rb
@@ -33,6 +33,7 @@ module LocalLinksManager
         Rails.logger.info("#{verb} interaction '#{row[:label]}' (lgsl #{row[:lgil_code]})")
 
         interaction.label = row[:label]
+        interaction.slug = row[:label].parameterize
         interaction.save!
       end
     end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -1,4 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe LinksController, type: :controller do
+  before do
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
+    @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
+    @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+  end
+
+  describe 'GET edit' do
+    it 'retrieves HTTP success' do
+      login_as_stub_user
+
+      get :edit, local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe LinksController, type: :controller do
+end

--- a/spec/factories/interactions.rb
+++ b/spec/factories/interactions.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :interaction do
     lgil_code 0
     label "Applications for service"
+    slug { label.parameterize }
   end
 end

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -36,7 +36,7 @@ feature "The interactions index page for a service provided by a local authority
 
     it "shows the local authority name and homepage_url" do
       expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.friendly_url)
+      expect(page).to have_link(@local_authority.homepage_url)
     end
 
     it "shows the available interactions for the service" do

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -8,6 +8,10 @@ feature "The interactions index page for a service provided by a local authority
     visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 
+  it "displays the LGSL code" do
+    expect(page).to have_content("LGSL #{@service_1.lgsl_code}")
+  end
+
   it 'has a list of breadcrumbs pointing back to the authority and service that lead us here' do
     within '.breadcrumb' do
       expect(page).to have_link 'Local Authorities', href: local_authorities_path
@@ -28,6 +32,11 @@ feature "The interactions index page for a service provided by a local authority
       @interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 4)
       FactoryGirl.create(:service_interaction, service_id: @service_1.id, interaction_id: @interaction_1.id)
       visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
+    end
+
+    it "shows the local authority name and homepage_url" do
+      expect(page).to have_css('h1', text: @local_authority.name)
+      expect(page).to have_link(@local_authority.hostname)
     end
 
     it "shows the available interactions for the service" do

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -36,7 +36,7 @@ feature "The interactions index page for a service provided by a local authority
 
     it "shows the local authority name and homepage_url" do
       expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.hostname)
+      expect(page).to have_link(@local_authority.friendly_url)
     end
 
     it "shows the available interactions for the service" do

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -38,7 +38,7 @@ feature 'The links for a local authority' do
     it "shows the name of the local authority" do
       click_on('Edit link', match: :first)
       expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.hostname)
+      expect(page).to have_link(@local_authority.friendly_url)
     end
 
     it "does not save 'n/a' links" do

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -22,12 +22,12 @@ feature 'The links for a local authority' do
     end
 
     it "shows 'n/a' when editing a blank link" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       expect(page).to have_field('link_url', with: 'n/a')
     end
 
     it "allows us to save a new link and view it" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/new-link')
       click_on('Save')
 
@@ -36,14 +36,14 @@ feature 'The links for a local authority' do
     end
 
     it "shows the name of the local authority" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       expect(page).to have_css('h1', text: @local_authority.name)
       expect(page).to have_link(@local_authority.friendly_url)
     end
 
     it "does not save 'n/a' links" do
       link_count = Link.count
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       click_on('Save')
 
       expect(Link.count).to eq(link_count)
@@ -76,13 +76,13 @@ feature 'The links for a local authority' do
           interaction_slug: @interaction_1.slug
         )
       )
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       expect(page).to have_field('link_url', with: 'http://angus.example.com/service-interaction-1')
       expect(page).to have_button('Save')
     end
 
     it "allows us to save an edited link and view it" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/changed-link')
       click_on('Save')
 
@@ -92,7 +92,7 @@ feature 'The links for a local authority' do
     end
 
     it "does not save an edited link when 'Cancel' is clicked" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/changed-link')
       click_on('Cancel')
 
@@ -100,7 +100,7 @@ feature 'The links for a local authority' do
     end
 
     it "shows a warning if the URL is not a valid URL" do
-      click_on('Edit link', match: :first)
+      within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'linky loo')
       click_on('Save')
 

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -105,6 +105,7 @@ feature 'The links for a local authority' do
       click_on('Save')
 
       expect(page).to have_content('Please enter a valid link')
+      expect(page).to have_css('.has-error')
     end
   end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -70,7 +70,7 @@ feature 'The links for a local authority' do
 
     it "allows us to edit a link" do
       expect(page).to have_link('Edit link',
-        href: edit_local_authority_service_interaction_link_path(
+        href: edit_local_authority_service_interaction_links_path(
           local_authority_slug: @local_authority.slug,
           service_slug: @service.slug,
           interaction_slug: @interaction_1.slug

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -38,7 +38,7 @@ feature 'The links for a local authority' do
     it "shows the name of the local authority" do
       within('.table') { click_on('Edit link', match: :first) }
       expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.friendly_url)
+      expect(page).to have_link(@local_authority.homepage_url)
     end
 
     it "does not save invalid links" do

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -17,13 +17,13 @@ feature 'The links for a local authority' do
     end
 
     it "shows an empty cell for the link next to the interactions" do
-      expect(page).to have_table_row('3', 'Interaction 1 n/a', '', 'Edit link')
-      expect(page).to have_table_row('4', 'Interaction 2 n/a', '', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 No link', '', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2 No link', '', 'Edit link')
     end
 
-    it "shows 'n/a' when editing a blank link" do
+    it "shows 'No link' when editing a blank link" do
       within('.table') { click_on('Edit link', match: :first) }
-      expect(page).to have_field('link_url', with: 'n/a')
+      expect(page).to have_field('link_url', with: 'No link')
     end
 
     it "allows us to save a new link and view it" do
@@ -41,7 +41,7 @@ feature 'The links for a local authority' do
       expect(page).to have_link(@local_authority.friendly_url)
     end
 
-    it "does not save 'n/a' links" do
+    it "does not save invalid links" do
       link_count = Link.count
       within('.table') { click_on('Edit link', match: :first) }
       click_on('Save')

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -101,10 +101,11 @@ feature 'The links for a local authority' do
 
     it "shows a warning if the URL is not a valid URL" do
       click_on('Edit link', match: :first)
-      fill_in('link_url', with: 'n/a')
+      fill_in('link_url', with: 'linky loo')
       click_on('Save')
 
       expect(page).to have_content('Please enter a valid link')
+      expect(page).to have_field('link_url', with: 'linky loo')
       expect(page).to have_css('.has-error')
     end
   end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -17,8 +17,8 @@ feature 'The links for a local authority' do
     end
 
     it "shows an empty cell for the link next to the interactions" do
-      expect(page).to have_table_row('3', 'Interaction 1', 'n/a', 'Edit link')
-      expect(page).to have_table_row('4', 'Interaction 2', 'n/a', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 n/a', '', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2 n/a', '', 'Edit link')
     end
 
     it "shows 'n/a' when editing a blank link" do
@@ -31,8 +31,14 @@ feature 'The links for a local authority' do
       fill_in('link_url', with: 'http://angus.example.com/new-link')
       click_on('Save')
 
-      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/new-link', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 http://angus.example.com/new-link', '', 'Edit link')
       expect(page).to have_content('Link has been saved.')
+    end
+
+    it "shows the name of the local authority" do
+      click_on('Edit link', match: :first)
+      expect(page).to have_css('h1', text: @local_authority.name)
+      expect(page).to have_link(@local_authority.hostname)
     end
 
     it "does not save 'n/a' links" do
@@ -53,8 +59,8 @@ feature 'The links for a local authority' do
     end
 
     it "shows the url for the link next to the relevant interaction" do
-      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/service-interaction-1', 'Edit link')
-      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 http://angus.example.com/service-interaction-1', '', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2 https://angus.example.com/service-interaction-2', '', 'Edit link')
     end
 
     it "shows the urls as clickable links" do
@@ -80,9 +86,17 @@ feature 'The links for a local authority' do
       fill_in('link_url', with: 'http://angus.example.com/changed-link')
       click_on('Save')
 
-      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/changed-link', 'Edit link')
-      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 http://angus.example.com/changed-link', '', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2 https://angus.example.com/service-interaction-2', '', 'Edit link')
       expect(page).to have_content('Link has been saved.')
+    end
+
+    it "does not save an edited link when 'Cancel' is clicked" do
+      click_on('Edit link', match: :first)
+      fill_in('link_url', with: 'http://angus.example.com/changed-link')
+      click_on('Cancel')
+
+      expect(page).to have_link('http://angus.example.com/service-interaction-1', href: 'http://angus.example.com/service-interaction-1')
     end
 
     it "shows a warning if the URL is not a valid URL" do

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -17,8 +17,13 @@ feature 'The links for a local authority' do
     end
 
     it "shows an empty cell for the link next to the interactions" do
-      expect(page).to have_table_row('3', 'Interaction 1', 'n/a')
-      expect(page).to have_table_row('4', 'Interaction 2', 'n/a')
+      expect(page).to have_table_row('3', 'Interaction 1', 'n/a', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2', 'n/a', 'Edit link')
+    end
+
+    it "shows 'n/a' when editing a blank link" do
+      click_on('Edit link', match: :first)
+      expect(page).to have_field('link', with: 'n/a')
     end
   end
 
@@ -30,13 +35,23 @@ feature 'The links for a local authority' do
     end
 
     it "shows the url for the link next to the relevant interaction" do
-      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/service-interaction-1')
-      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2')
+      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/service-interaction-1', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2', 'Edit link')
     end
 
     it "shows the urls as clickable links" do
       expect(page).to have_link('http://angus.example.com/service-interaction-1', href: 'http://angus.example.com/service-interaction-1')
       expect(page).to have_link('https://angus.example.com/service-interaction-2', href: 'https://angus.example.com/service-interaction-2')
+    end
+
+    it "allows us to edit a link" do
+      expect(page).to have_link('Edit link',
+        href: edit_local_authority_service_interaction_link_path(
+          local_authority_slug: @local_authority.slug,
+          service_slug: @service.slug,
+          interaction_slug: @interaction_1.slug
+        )
+      )
     end
   end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -23,7 +23,25 @@ feature 'The links for a local authority' do
 
     it "shows 'n/a' when editing a blank link" do
       click_on('Edit link', match: :first)
-      expect(page).to have_field('link', with: 'n/a')
+      expect(page).to have_field('link_url', with: 'n/a')
+    end
+
+    it "allows us to save a new link and view it" do
+      click_on('Edit link', match: :first)
+      fill_in('link_url', with: 'http://angus.example.com/new-link')
+      click_on('Save')
+
+      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/new-link', 'Edit link')
+      expect(page).to have_content('Link has been saved.')
+    end
+
+    it "does not save 'n/a' links" do
+      link_count = Link.count
+      click_on('Edit link', match: :first)
+      click_on('Save')
+
+      expect(Link.count).to eq(link_count)
+      expect(page).to have_content('Please enter a valid link')
     end
   end
 
@@ -52,6 +70,27 @@ feature 'The links for a local authority' do
           interaction_slug: @interaction_1.slug
         )
       )
+      click_on('Edit link', match: :first)
+      expect(page).to have_field('link_url', with: 'http://angus.example.com/service-interaction-1')
+      expect(page).to have_button('Save')
+    end
+
+    it "allows us to save an edited link and view it" do
+      click_on('Edit link', match: :first)
+      fill_in('link_url', with: 'http://angus.example.com/changed-link')
+      click_on('Save')
+
+      expect(page).to have_table_row('3', 'Interaction 1', 'http://angus.example.com/changed-link', 'Edit link')
+      expect(page).to have_table_row('4', 'Interaction 2', 'https://angus.example.com/service-interaction-2', 'Edit link')
+      expect(page).to have_content('Link has been saved.')
+    end
+
+    it "shows a warning if the URL is not a valid URL" do
+      click_on('Edit link', match: :first)
+      fill_in('link_url', with: 'n/a')
+      click_on('Save')
+
+      expect(page).to have_content('Please enter a valid link')
     end
   end
 end

--- a/spec/features/local_authorities/local_authority_edit_spec.rb
+++ b/spec/features/local_authorities/local_authority_edit_spec.rb
@@ -21,4 +21,13 @@ feature "The local authorities edit page" do
     expect(page).to have_current_path(local_authority_services_path(local_authority_slug: @local_authority.slug))
     expect(page).to have_link(@local_authority.friendly_url)
   end
+
+  it 'displays the link again when validation fails' do
+    click_on('Edit homepage link')
+    fill_in('local_authority_homepage_url', with: 'invalid URL')
+    click_on('Save')
+    expect(page).to have_content('Please enter a valid link')
+    expect(page).to have_field('local_authority_homepage_url', with: 'invalid URL')
+    expect(page).to have_css('.has-error')
+  end
 end

--- a/spec/features/local_authorities/local_authority_edit_spec.rb
+++ b/spec/features/local_authorities/local_authority_edit_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature "The local authorities edit page" do
+  before do
+    FactoryGirl.create(:user)
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'district')
+    visit local_authority_services_path(local_authority_slug: @local_authority.slug)
+  end
+
+  it 'allows us to edit the homepage url' do
+    click_on('Edit homepage link')
+    fill_in('local_authority_homepage_url', with: 'http://angus.example.com/changed-link')
+    click_on('Save')
+    expect(page).to have_content('Homepage link has been saved.')
+    expect(page).to have_link('angus.example.com/changed-link')
+  end
+
+  it 'allows us to cancel editing the homepage url' do
+    click_on('Edit homepage link')
+    click_on('Cancel')
+    expect(page).to have_current_path(local_authority_services_path(local_authority_slug: @local_authority.slug))
+    expect(page).to have_link(@local_authority.friendly_url)
+  end
+end

--- a/spec/features/local_authorities/local_authority_edit_spec.rb
+++ b/spec/features/local_authorities/local_authority_edit_spec.rb
@@ -8,7 +8,7 @@ feature "The local authorities edit page" do
   end
 
   it 'allows us to edit the homepage url' do
-    click_on('Edit homepage link')
+    click_on('Edit link')
     fill_in('local_authority_homepage_url', with: 'http://angus.example.com/changed-link')
     click_on('Save')
     expect(page).to have_content('Homepage link has been saved.')
@@ -16,14 +16,14 @@ feature "The local authorities edit page" do
   end
 
   it 'allows us to cancel editing the homepage url' do
-    click_on('Edit homepage link')
+    click_on('Edit link')
     click_on('Cancel')
     expect(page).to have_current_path(local_authority_services_path(local_authority_slug: @local_authority.slug))
     expect(page).to have_link(@local_authority.friendly_url)
   end
 
   it 'displays the link again when validation fails' do
-    click_on('Edit homepage link')
+    click_on('Edit link')
     fill_in('local_authority_homepage_url', with: 'invalid URL')
     click_on('Save')
     expect(page).to have_content('Please enter a valid link')

--- a/spec/features/local_authorities/local_authority_edit_spec.rb
+++ b/spec/features/local_authorities/local_authority_edit_spec.rb
@@ -19,7 +19,7 @@ feature "The local authorities edit page" do
     click_on('Edit link')
     click_on('Cancel')
     expect(page).to have_current_path(local_authority_services_path(local_authority_slug: @local_authority.slug))
-    expect(page).to have_link(@local_authority.friendly_url)
+    expect(page).to have_link(@local_authority.homepage_url)
   end
 
   it 'displays the link again when validation fails' do

--- a/spec/lib/local-links-manager/import/interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/interactions_importer_spec.rb
@@ -26,6 +26,7 @@ describe LocalLinksManager::Import::InteractionsImporter, :csv_importer do
 
         interaction = Interaction.find_by(lgil_code: 30)
         expect(interaction.label).to eq("Application for exemption")
+        expect(interaction.slug).to eq("application-for-exemption")
       end
     end
 

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Interaction, type: :model do
 
   it { is_expected.to validate_presence_of(:lgil_code) }
   it { is_expected.to validate_presence_of(:label) }
+  it { is_expected.to validate_presence_of(:slug) }
   it { is_expected.to validate_uniqueness_of(:lgil_code) }
   it { is_expected.to validate_uniqueness_of(:label) }
+  it { is_expected.to validate_uniqueness_of(:slug) }
 
   it { is_expected.to have_many(:service_interactions) }
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -84,4 +84,31 @@ RSpec.describe Link, type: :model do
       end
     end
   end
+
+  describe '.get_link' do
+
+    let!(:service_1) { FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1) }
+
+    let!(:interaction_1) { FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1) }
+
+    let!(:service_interaction_1_1) { FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_1) }
+
+    let!(:local_authority_1) { FactoryGirl.create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
+
+    let!(:expected_link) { FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1) }
+
+    let(:params) {
+      {
+        local_authority_slug: local_authority_1.slug,
+        service_slug: service_1.slug,
+        interaction_slug: interaction_1.slug
+      }
+    }
+
+    subject(:link) { Link.get_link(params) }
+
+    it 'fetches the correct link for the service' do
+      expect(link.url).to eq(expected_link.url)
+    end
+  end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe Link, type: :model do
   end
 
   describe '.get_link' do
-
     let!(:service_1) { FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1) }
 
     let!(:interaction_1) { FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1) }

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Link, type: :model do
     end
   end
 
-  describe '.get_link' do
+  describe '.retrieve' do
     let!(:service_1) { FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1) }
 
     let!(:interaction_1) { FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1) }
@@ -104,7 +104,7 @@ RSpec.describe Link, type: :model do
       }
     }
 
-    subject(:link) { Link.get_link(params) }
+    subject(:link) { Link.retrieve(params) }
 
     it 'fetches the correct link for the service' do
       expect(link.url).to eq(expected_link.url)


### PR DESCRIPTION
- Added ability to edit homepage URL's
- Enable the editing of links
# Screenshots

<img width="1483" alt="screen shot 2016-06-03 at 10 57 59" src="https://cloud.githubusercontent.com/assets/3466862/15775602/ab76a1ce-297a-11e6-8ea9-b062c2b7e358.png">

<img width="1484" alt="screen shot 2016-06-03 at 11 01 01" src="https://cloud.githubusercontent.com/assets/3466862/15775607/aeddc518-297a-11e6-9b67-f6f85de16ae0.png">

<img width="1464" alt="screen shot 2016-06-03 at 10 55 45" src="https://cloud.githubusercontent.com/assets/3466862/15775610/b3b4f0d4-297a-11e6-8122-61ff4f29f209.png">

<img width="1481" alt="screen shot 2016-06-03 at 10 55 32" src="https://cloud.githubusercontent.com/assets/3466862/15775618/bf8c7210-297a-11e6-9373-00979dae9d7b.png">

<img width="1454" alt="screen shot 2016-06-03 at 10 56 00" src="https://cloud.githubusercontent.com/assets/3466862/15775623/c4db748c-297a-11e6-95d5-8ed30d86aa01.png">

[Trello editing links](https://trello.com/c/qtpaquan/389-enable-editing-of-links)
[Trello editing homepage url](https://trello.com/c/DfDlIIRc/390-make-the-homepage-url-for-each-local-authority-editable)

Mobbed by: @emmabeynon @sihugh @klssmith @brenetic @issyl0 
