### PR TITLE
Add govuk-lint to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --format clang app spec lib"
+end


### PR DESCRIPTION
Inspired by similar setup in specialist-publisher-rebuild, this seems like a useful thing to do as it allows us to catch linting errors earlier
