### PR TITLE
Delete links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,8 @@
  *= require_self
  */
 @import 'govuk_admin_template';
+
+.no-gutter {
+  padding-right:0;
+  padding-left:0;
+}

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,20 +1,24 @@
 class LinksController < ApplicationController
   before_action :load_dependencies
 
-  def edit
-    @link = Link.retrieve(params)
-  end
+  def edit; end
 
   def update
-    @link = Link.retrieve(params)
     @link.url = params[:link][:url]
 
     if @link.save
-      flash[:success] = "Link has been saved."
-      flash[:lgil] = @interaction.lgil_code
-      redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
+      redirect
     else
-      flash.now[:bad_url] = "Please enter a valid link."
+      flash.now[:failed_action] = "Please enter a valid link."
+      render :edit
+    end
+  end
+
+  def destroy
+    if @link.destroy
+      redirect('deleted')
+    else
+      flash.now[:failed_action] = "Could not delete link."
       render :edit
     end
   end
@@ -25,5 +29,12 @@ private
     @local_authority = LocalAuthority.find_by(slug: params[:local_authority_slug])
     @interaction = Interaction.find_by(slug: params[:interaction_slug])
     @service = Service.find_by(slug: params[:service_slug])
+    @link = Link.retrieve(params)
+  end
+
+  def redirect(action = 'saved')
+    flash[:success_action] = "Link has been #{action}."
+    flash[:lgil] = @interaction.lgil_code
+    redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
   end
 end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -20,7 +20,7 @@ private
       flash[:success] = "Homepage link has been saved."
       redirect_to local_authority_services_path(local_authority_slug: params[:slug])
     else
-      flash.now[:bad_url] = "Please enter a valid link."
+      flash.now[:failed_action] = "Please enter a valid link."
       render :edit
     end
   end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -6,4 +6,12 @@ module LinksHelper
       'No link'
     end
   end
+
+  def interaction_button_text(interaction)
+    @links.key?(interaction) ? 'Edit link' : 'Add link'
+  end
+
+  def homepage_button_text(authority)
+    authority.homepage_url.empty? ? 'Add link' : 'Edit link'
+  end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -32,8 +32,4 @@ class Link < ActiveRecord::Base
       )
     )
   end
-
-  def display_url
-    url || 'No link'
-  end
 end

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -7,6 +7,11 @@
 <div class="page-title">
   <h2><%= @service.label %></h2>
 </div>
+
+<% if flash[:success_action] %>
+<div class="alert alert-success"><%= flash[:success_action] %></div>
+<% end %>
+
 <p><b>LGSL</b> <%= @service.lgsl_code %></p>
 
 <% if @interactions.any? %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -34,7 +34,7 @@
           <td>
           </td>
           <td class='text-center'>
-            <%= link_to('Edit link', edit_local_authority_service_interaction_links_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
+            <%= link_to(interaction_button_text(interaction), edit_local_authority_service_interaction_links_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
           </td>
         </tr>
       <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -6,22 +6,33 @@
   <h2><%= @interaction.label %></h2>
 </div>
 
-<% if flash[:bad_url] %>
-<div class="alert alert-danger">Please enter a valid link.</div>
+<% if flash[:failed_action] %>
+<div class="alert alert-danger"><%= flash[:failed_action] %></div>
 <% end %>
 
 <p><b>LGSL</b> <%= @service.lgsl_code %><b class="add-left-margin">LGIL</b> <%= @interaction.lgil_code %></p>
 
-<%= label_tag 'link', 'URL' %>
-
-<p class="text-muted">eg http://www.local-authority.gov.uk</p>
-
 <%= form_for @link, url: local_authority_service_interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
-  <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
-    <%= f.text_field :url, class: "form-control", value: @link.url%>
-    <div class='actions add-vertical-margins'>
+  <div class="form-group <% if flash[:failed_action] %>has-error<% end %>">
+    <div class='col-xs-12 no-gutter'>
+      <%= f.label :url, 'URL' %>
+
+      <p class="text-muted">eg http://www.local-authority.gov.uk</p>
+
+      <%= f.text_field :url, class: "form-control" %>
+    </div>
+
+    <div class='actions add-vertical-margins col-xs-6 no-gutter'>
       <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
       <button type='submit' class='btn btn-success'>Save</button>
     </div>
+  </div>
+<% end %>
+
+<% if @link.url %>
+  <div class='actions add-vertical-margins col-xs-6 no-gutter'>
+    <%= form_tag(local_authority_service_interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: :delete) do %>
+      <button name="submit" class="btn btn-danger pull-right">Delete</button>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -18,7 +18,7 @@
 
 <%= form_for @link, url: local_authority_service_interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
   <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
-    <%= f.text_field :url, class: "form-control", value: @link.display_url%>
+    <%= f.text_field :url, class: "form-control", value: @link.url%>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', local_authority_service_interactions_path(service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
       <button type='submit' class='btn btn-success'>Save</button>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -4,7 +4,7 @@
   <h1><%= @authority.name %></h1>
 </div>
 
-<% if flash[:bad_url] %>
+<% if flash[:failed_action] %>
 <div class="alert alert-danger">Please enter a valid link.</div>
 <% end %>
 
@@ -13,7 +13,7 @@
 <p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
 <%= form_for @authority, url: local_authority_path, method: "put" do |f| %>
-  <div class="form-group <% if flash[:bad_url] %>has-error<% end %>">
+  <div class="form-group <% if flash[:failed_action] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', local_authority_services_path(@authority.slug), { class: 'btn btn-default add-right-margin' } %>

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -2,6 +2,6 @@
   <h1><%= authority.name %></h1>
   <p>
     Homepage <%= link_to(nil, authority.homepage_url) %>
-    <%= link_to 'Edit link', edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %>
+    <%= link_to homepage_button_text(authority), edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %>
   </p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources "local_authorities", only: [:index, :edit, :update], param: :slug do
     resources "services", only: [:index], param: :slug do
       resources "interactions", only: [:index], param: :slug do
-        resource "links", only: [:edit, :update]
+        resource "links", only: [:edit, :update, :destroy]
       end
     end
   end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe LinksController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'delete links' do
+    it 'handles deletion of links that have already been deleted' do
+      login_as_stub_user
+      delete :destroy, local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug
+      expect(response).to have_http_status(302)
+      expect(flash[:failed_action]).not_to be_present
+    end
+  end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -21,9 +21,9 @@ feature 'The links for a local authority' do
       expect(page).to have_table_row('4', 'Interaction 2 No link', '', 'Add link')
     end
 
-    it "shows 'No link' when editing a blank link" do
+    it "shows an empty cell when editing a blank link" do
       within('.table') { click_on('Add link', match: :first) }
-      expect(page).to have_field('link_url', with: 'No link')
+      expect(page.find_by_id('link_url').value).to be_blank
     end
 
     it "allows us to save a new link and view it" do
@@ -48,6 +48,11 @@ feature 'The links for a local authority' do
 
       expect(Link.count).to eq(link_count)
       expect(page).to have_content('Please enter a valid link')
+    end
+
+    it "does not show a delete button after clicking on add" do
+      within('.table') { click_on('Add link', match: :first) }
+      expect(page).not_to have_button("Delete")
     end
   end
 
@@ -107,6 +112,19 @@ feature 'The links for a local authority' do
       expect(page).to have_content('Please enter a valid link')
       expect(page).to have_field('link_url', with: 'linky loo')
       expect(page).to have_css('.has-error')
+    end
+
+    it "allows us to delete a link" do
+      within('.table') { click_on('Edit link', match: :first) }
+      fill_in('link_url', with: 'http://angus.example.com/link-to-delete')
+      click_on('Save')
+
+      expect(page).to have_table_row('3', 'Interaction 1 http://angus.example.com/link-to-delete', '', 'Edit link')
+
+      within('.table') { click_on('Edit link', match: :first) }
+      click_on('Delete')
+
+      expect(page).to have_table_row('3', 'Interaction 1 No link', '', 'Add link')
     end
   end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -17,17 +17,17 @@ feature 'The links for a local authority' do
     end
 
     it "shows an empty cell for the link next to the interactions" do
-      expect(page).to have_table_row('3', 'Interaction 1 No link', '', 'Edit link')
-      expect(page).to have_table_row('4', 'Interaction 2 No link', '', 'Edit link')
+      expect(page).to have_table_row('3', 'Interaction 1 No link', '', 'Add link')
+      expect(page).to have_table_row('4', 'Interaction 2 No link', '', 'Add link')
     end
 
     it "shows 'No link' when editing a blank link" do
-      within('.table') { click_on('Edit link', match: :first) }
+      within('.table') { click_on('Add link', match: :first) }
       expect(page).to have_field('link_url', with: 'No link')
     end
 
     it "allows us to save a new link and view it" do
-      within('.table') { click_on('Edit link', match: :first) }
+      within('.table') { click_on('Add link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/new-link')
       click_on('Save')
 
@@ -36,14 +36,14 @@ feature 'The links for a local authority' do
     end
 
     it "shows the name of the local authority" do
-      within('.table') { click_on('Edit link', match: :first) }
+      within('.table') { click_on('Add link', match: :first) }
       expect(page).to have_css('h1', text: @local_authority.name)
       expect(page).to have_link(@local_authority.homepage_url)
     end
 
     it "does not save invalid links" do
       link_count = Link.count
-      within('.table') { click_on('Edit link', match: :first) }
+      within('.table') { click_on('Add link', match: :first) }
       click_on('Save')
 
       expect(Link.count).to eq(link_count)

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -14,6 +14,16 @@ feature "The services index page for a local authority" do
     end
   end
 
+  describe "with no local authority homepage url" do
+    it "shows the 'Add link' button" do
+      click_on('Edit link')
+      fill_in('local_authority_homepage_url', with: '')
+      click_on('Save')
+      expect(page).to have_content('Homepage link has been saved.')
+      expect(page).to have_link('Add link')
+    end
+  end
+
   describe "with no services present" do
     it "shows a message that no services are present" do
       expect(page).to have_content 'No local services found'


### PR DESCRIPTION
- Now able to delete all links
- Only show the Delete button if the link exists
- Show 'Edit link' button if link exists otherwise 'Add link'
- Added .no-gutter css to remove padding for editing form page
# Before

![screen shot 2016-06-07 at 12 32 16](https://cloud.githubusercontent.com/assets/3466862/15856215/26a51b08-2cac-11e6-9c06-21becfd0e362.png)
# After

![screen shot 2016-06-06 at 15 50 04](https://cloud.githubusercontent.com/assets/3466862/15856223/2c67ff42-2cac-11e6-93e9-46747de98e9b.png)

![screen shot 2016-06-07 at 12 32 46](https://cloud.githubusercontent.com/assets/3466862/15856226/2ebd047c-2cac-11e6-92b4-c32c3d658ffb.png)

![screen shot 2016-06-07 at 12 35 13](https://cloud.githubusercontent.com/assets/3466862/15856260/5a7b9628-2cac-11e6-8631-c61aed117962.png)

[Trello card](https://trello.com/c/XuQM5Zi7/400-enable-deleting-a-link)

Mobbed by @sihugh @brenetic @emmabeynon @klssmith @issyl0 
