### PR TITLE
Change flash messages

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -9,7 +9,7 @@ class LinksController < ApplicationController
     if @link.save
       redirect
     else
-      flash.now[:failed_action] = "Please enter a valid link."
+      flash.now[:danger] = "Please enter a valid link."
       render :edit
     end
   end
@@ -18,7 +18,7 @@ class LinksController < ApplicationController
     if @link.destroy
       redirect('deleted')
     else
-      flash.now[:failed_action] = "Could not delete link."
+      flash.now[:danger] = "Could not delete link."
       render :edit
     end
   end
@@ -33,7 +33,7 @@ private
   end
 
   def redirect(action = 'saved')
-    flash[:success_action] = "Link has been #{action}."
+    flash[:success] = "Link has been #{action}."
     flash[:lgil] = @interaction.lgil_code
     redirect_to local_authority_service_interactions_path(service_slug: params[:service_slug])
   end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -4,7 +4,7 @@ class LinksController < ApplicationController
   def edit; end
 
   def update
-    @link.url = params[:link][:url]
+    @link.url = params[:link][:url].strip
 
     if @link.save
       redirect

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -20,7 +20,7 @@ private
       flash[:success] = "Homepage link has been saved."
       redirect_to local_authority_services_path(local_authority_slug: params[:slug])
     else
-      flash.now[:failed_action] = "Please enter a valid link."
+      flash.now[:danger] = "Please enter a valid link."
       render :edit
     end
   end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -9,7 +9,7 @@ class LocalAuthoritiesController < ApplicationController
 
   def update
     @authority = LocalAuthority.find_by(slug: params[:slug])
-    @authority.homepage_url = params[:local_authority][:homepage_url]
+    @authority.homepage_url = params[:local_authority][:homepage_url].strip
     validate_and_save(@authority)
   end
 

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -8,8 +8,8 @@
   <h2><%= @service.label %></h2>
 </div>
 
-<% if flash[:success_action] %>
-<div class="alert alert-success"><%= flash[:success_action] %></div>
+<% if flash[:success] %>
+<div class="alert alert-success"><%= flash[:success] %></div>
 <% end %>
 
 <p><b>LGSL</b> <%= @service.lgsl_code %></p>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -6,14 +6,14 @@
   <h2><%= @interaction.label %></h2>
 </div>
 
-<% if flash[:failed_action] %>
-<div class="alert alert-danger"><%= flash[:failed_action] %></div>
+<% if flash[:danger] %>
+<div class="alert alert-danger"><%= flash[:danger] %></div>
 <% end %>
 
 <p><b>LGSL</b> <%= @service.lgsl_code %><b class="add-left-margin">LGIL</b> <%= @interaction.lgil_code %></p>
 
 <%= form_for @link, url: local_authority_service_interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
-  <div class="form-group <% if flash[:failed_action] %>has-error<% end %>">
+  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <div class='col-xs-12 no-gutter'>
       <%= f.label :url, 'URL' %>
 

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -4,7 +4,7 @@
   <h1><%= @authority.name %></h1>
 </div>
 
-<% if flash[:failed_action] %>
+<% if flash[:danger] %>
 <div class="alert alert-danger">Please enter a valid link.</div>
 <% end %>
 
@@ -13,7 +13,7 @@
 <p class="text-muted">eg http://www.local-authority.gov.uk</p>
 
 <%= form_for @authority, url: local_authority_path, method: "put" do |f| %>
-  <div class="form-group <% if flash[:failed_action] %>has-error<% end %>">
+  <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <%= f.text_field :homepage_url, class: "form-control" %>
     <div class='actions add-vertical-margins'>
       <%= link_to 'Cancel', local_authority_services_path(@authority.slug), { class: 'btn btn-default add-right-margin' } %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :page_title, @authority.name %>
 
+<% if flash[:success] %>
+<div class="alert alert-success"><%= flash[:success] %></div>
+<% end %>
+
 <% breadcrumb :services, @authority %>
 
 <%= render partial: "shared/local_authority_details", locals: {authority: @authority} %>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,5 +1,5 @@
 GovukAdminTemplate.configure do |c|
   c.app_title = "Local Links Manager"
-  c.show_flash = true
+  c.show_flash = false
   c.show_signout = true
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LinksController, type: :controller do
       login_as_stub_user
       delete :destroy, local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug
       expect(response).to have_http_status(302)
-      expect(flash[:failed_action]).not_to be_present
+      expect(flash[:danger]).not_to be_present
     end
   end
 end


### PR DESCRIPTION
- Set govuk_admin_template showing of flash messages to false in order to allow Local Links Manager to control where the flash message will appear.
- Remove custom flash messages and use the govuk_admin_template defaults.
- Strip leading and trailing whitespace when saving urls for both homepage urls and for service interaction links.
