### PR TITLE
Delete links that are no longer in the CSV

### DIFF
--- a/spec/factories/interactions.rb
+++ b/spec/factories/interactions.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :interaction do
-    lgil_code 0
-    label "Applications for service"
+    sequence(:lgil_code) { |n| n }
+    sequence(:label) { |n| "Interaction Label #{n}" }
     slug { label.parameterize }
   end
 end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :local_authority do
-    name "Angus Council"
-    gss "S12000041"
-    snac "00QC"
+    sequence(:name) { |n| "Local Authority Name #{n}" }
+    sequence(:gss) { |n| "S%08i" % n }
+    sequence(:snac) { |n| "%02iQC" % n }
     tier "unitary"
     slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :service do
-    lgsl_code 1152
-    label "Abandoned shopping trolleys"
+    sequence(:lgsl_code) { |n| n }
+    sequence(:label) { |n| "Service Label #{n}" }
     slug { label.parameterize }
     enabled false
   end


### PR DESCRIPTION
When a local authority deletes a link from local.direct.gov.uk we need to
ensure that we delete it from our dataset as well.

We already did this for the imports in publisher, but we need to also do this
in local links manager until we stop importing data.  An alternative would be
to drop the data and recreate it each time, but this creates a period of
instability where there are no records.

The Publisher work is around this point:
https://github.com/alphagov/publisher/pull/436/commits/b025051977c402d3ede788720a0814f62890540c

We have a fail-safe total to ensure that we don't purge all our links should we
somehow end up with an empty CSV file.  We currently have 80_000 links in
Local Links Manager, however work continues to ascertain which services and
interactions we support, so I 'guessed' at a safe total of 40_000 to begin
with.

https://trello.com/c/KuN7jtEr/394-imports-should-delete-things-sensibly-5
