### PR TITLE
Fix Northern Ireland blank homepage URL bug

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -12,6 +12,6 @@ module LinksHelper
   end
 
   def homepage_button_text(authority)
-    authority.homepage_url.empty? ? 'Add link' : 'Edit link'
+    authority.homepage_url.blank? ? 'Add link' : 'Edit link'
   end
 end

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,7 +1,7 @@
 <div class="page-title">
   <h1><%= authority.name %></h1>
   <p>
-    Homepage <%= link_to(nil, authority.homepage_url) %>
+    Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %>
     <%= link_to homepage_button_text(authority), edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %>
   </p>
 </div>

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -22,6 +22,16 @@ feature "The services index page for a local authority" do
       expect(page).to have_content('Homepage link has been saved.')
       expect(page).to have_link('Add link')
     end
+
+    it "renders the local authority services page successfully" do
+      ni_local_authority = FactoryGirl.create(:local_authority, name: 'Antrim and Newtownabbey Borough Council', gss: 'N09000001', snac: 'N09000001', tier: 'unitary', slug: 'antrim-newtownabbey', homepage_url: nil)
+      visit local_authority_services_path(local_authority_slug: ni_local_authority.slug)
+      expect(page.status_code).to eq(200)
+
+      within(:css, ".page-title") do
+        expect(page).not_to have_link("/local_authorities/#{ni_local_authority.slug}/services")
+      end
+    end
   end
 
   describe "with no services present" do


### PR DESCRIPTION
- Fixed bug that prevented services page rendering for NI local authorities due to homepage URL being blank
- Fixed bug that displayed the current page path as the homepage URL on the services page instead of displaying no URL
