### PR TITLE
Check link status code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'gretel', '3.0.8'
 
 gem 'addressable'
 
+gem 'faraday'
+gem 'faraday_middleware'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
@@ -60,6 +63,7 @@ end
 
 group :test do
   gem 'webmock', '~> 1.2'
+  gem 'timecop'
 end
 
 gem 'plek', '~> 1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
     gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
@@ -285,6 +287,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    timecop (0.8.0)
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -323,6 +326,8 @@ DEPENDENCIES
   capistrano-rails
   capybara (~> 2.7)
   factory_girl_rails (~> 4.7)
+  faraday
+  faraday_middleware
   gds-api-adapters (~> 30.2)
   gds-sso (~> 12.0)
   govuk-lint
@@ -340,6 +345,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
+  timecop
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
   web-console (~> 2.0)

--- a/db/migrate/20160620155419_add_status_and_link_last_checked_to_links.rb
+++ b/db/migrate/20160620155419_add_status_and_link_last_checked_to_links.rb
@@ -1,0 +1,6 @@
+class AddStatusAndLinkLastCheckedToLinks < ActiveRecord::Migration
+  def change
+    add_column :links, :status, :string
+    add_column :links, :link_last_checked, :datetime
+  end
+end

--- a/db/migrate/20160621090108_add_status_and_link_last_checked_to_local_authority.rb
+++ b/db/migrate/20160621090108_add_status_and_link_last_checked_to_local_authority.rb
@@ -1,0 +1,6 @@
+class AddStatusAndLinkLastCheckedToLocalAuthority < ActiveRecord::Migration
+  def change
+    add_column :local_authorities, :status, :string
+    add_column :local_authorities, :link_last_checked, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615155529) do
+ActiveRecord::Schema.define(version: 20160621090108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 20160615155529) do
     t.string   "url",                    null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.string   "status"
+    t.datetime "link_last_checked"
   end
 
   add_index "links", ["local_authority_id", "service_interaction_id"], name: "index_links_on_local_authority_id_and_service_interaction_id", unique: true, using: :btree
@@ -40,14 +42,16 @@ ActiveRecord::Schema.define(version: 20160615155529) do
   add_index "links", ["service_interaction_id"], name: "index_links_on_service_interaction_id", using: :btree
 
   create_table "local_authorities", force: :cascade do |t|
-    t.string   "gss",          null: false
+    t.string   "gss",               null: false
     t.string   "homepage_url"
-    t.string   "name",         null: false
-    t.string   "slug",         null: false
-    t.string   "snac",         null: false
-    t.string   "tier",         null: false
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.string   "name",              null: false
+    t.string   "slug",              null: false
+    t.string   "snac",              null: false
+    t.string   "tier",              null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.string   "status"
+    t.datetime "link_last_checked"
   end
 
   add_index "local_authorities", ["gss"], name: "index_local_authorities_on_gss", unique: true, using: :btree

--- a/lib/local-links-manager/check_links/homepage_status_updater.rb
+++ b/lib/local-links-manager/check_links/homepage_status_updater.rb
@@ -1,0 +1,32 @@
+require 'local-links-manager/check_links/link_checker'
+
+module LocalLinksManager
+  module CheckLinks
+    class HomepageStatusUpdater
+      attr_reader :column, :table, :url_checker
+
+      def initialize(url_checker = LinkChecker.new)
+        @table = LocalAuthority
+        @column = :homepage_url
+        @url_checker = url_checker
+      end
+
+      def update
+        links_responses = url_checker.check_links(links)
+        update_links(links_responses)
+      end
+
+    private
+
+      def links
+        table.distinct.pluck(column)
+      end
+
+      def update_links(links_responses)
+        links_responses.each do |k, v|
+          table.where(column => k).update_all(status: v.first, link_last_checked: v.last)
+        end
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/check_links/link_checker.rb
+++ b/lib/local-links-manager/check_links/link_checker.rb
@@ -1,0 +1,52 @@
+module LocalLinksManager
+  module CheckLinks
+    class LinkChecker
+      TIMEOUT = 5
+      REDIRECT_LIMIT = 10
+
+      attr_reader :link_responses
+
+      def initialize
+        @link_responses = {}
+      end
+
+      def check_links(links)
+        links.each do |link|
+          link_responses[link] = [fetch_status(link), Time.zone.now]
+        end
+        link_responses
+      end
+
+    private
+
+      def fetch_status(link)
+        begin
+          response = connection.get(URI.parse(link)) do |request|
+            request.options[:timeout] = TIMEOUT
+            request.options[:open_timeout] = TIMEOUT
+          end
+          response.status.to_s
+        rescue Faraday::ConnectionFailed
+          "Connection failed"
+        rescue Faraday::TimeoutError
+          "Timeout Error"
+        rescue Faraday::SSLError
+          "SSL Error"
+        rescue FaradayMiddleware::RedirectLimitReached
+          "Too many redirects"
+        rescue URI::InvalidURIError
+          "Invalid URI"
+        rescue => e
+          e.class.to_s
+        end
+      end
+
+      def connection
+        @connection ||= Faraday.new(headers: { accept_encoding: 'none' }) do |faraday|
+          faraday.use FaradayMiddleware::FollowRedirects, limit: REDIRECT_LIMIT
+          faraday.adapter Faraday.default_adapter
+        end
+      end
+    end
+  end
+end

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -1,0 +1,32 @@
+require 'local-links-manager/check_links/link_checker'
+
+module LocalLinksManager
+  module CheckLinks
+    class LinkStatusUpdater
+      attr_reader :column, :table, :url_checker
+
+      def initialize(url_checker = LinkChecker.new)
+        @table = Link
+        @column = :url
+        @url_checker = url_checker
+      end
+
+      def update
+        links_responses = url_checker.check_links(links)
+        update_links(links_responses)
+      end
+
+    private
+
+      def links
+        table.joins(:service).where(services: { enabled: true }).distinct.pluck(column)
+      end
+
+      def update_links(links_responses)
+        links_responses.each do |k, v|
+          table.where(column => k).update_all(status: v.first, link_last_checked: v.last)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -1,0 +1,8 @@
+require 'local-links-manager/check_links/homepage_status_updater'
+require 'local-links-manager/check_links/link_status_updater'
+
+desc "Check links"
+task "check-links": :environment do
+  LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
+  LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
+end

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -3,5 +3,7 @@ FactoryGirl.define do
     association :local_authority
     association :service_interaction
     url { "http://#{local_authority.slug}.example.com/#{service_interaction.service.slug}/#{service_interaction.interaction.label.parameterize}" }
+    status nil
+    link_last_checked nil
   end
 end

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -6,4 +6,10 @@ FactoryGirl.define do
     status nil
     link_last_checked nil
   end
+
+  factory :link_for_disabled_service, parent: :link do
+    after(:create) do |link|
+      link.service.update_attribute(:enabled, false)
+    end
+  end
 end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -6,5 +6,7 @@ FactoryGirl.define do
     tier "unitary"
     slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"
+    status nil
+    link_last_checked nil
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -3,6 +3,10 @@ FactoryGirl.define do
     sequence(:lgsl_code) { |n| n }
     sequence(:label) { |n| "Service Label #{n}" }
     slug { label.parameterize }
+    enabled true
+  end
+
+  factory :disabled_service, parent: :service do
     enabled false
   end
 end

--- a/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'local-links-manager/check_links/homepage_status_updater'
+
+describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
+  let(:link_checker) { double :link_checker, check_links: { local_authority_1.homepage_url => ['200', @time], local_authority_2.homepage_url  => ['200', @time] } }
+  let(:local_authority_1) { FactoryGirl.create(:local_authority) }
+  let(:local_authority_2) {
+    FactoryGirl.create(:local_authority,
+      gss: 'S12000042',
+      name: 'Lewisham Council',
+      snac: '00QD',
+      tier: 'unitary',
+      homepage_url: 'http://www.lewisham.gov.uk')
+  }
+  subject(:status_updater) { described_class.new(link_checker) }
+
+  before do
+    @time = Timecop.freeze('2016-06-21 09:26:56 +0100')
+  end
+
+  describe '#update' do
+    it 'updates the link\'s status code and link last checked time in the database' do
+      status_updater.update
+
+      expect(local_authority_1.reload.status).to eq('200')
+      expect(local_authority_2.reload.link_last_checked).to eq(@time)
+    end
+  end
+end

--- a/spec/lib/local-links-manager/check_links/link_checker_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_checker_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+require 'local-links-manager/check_links/link_checker'
+
+describe LocalLinksManager::CheckLinks::LinkChecker do
+  let(:link_1) { 'http://www.lewisham.gov.uk/education/Educating-your-child-at-home.aspx' }
+  let(:link_2) { 'http://www.lewisham.gov.uk/education/student-pupil-support/default.aspx' }
+  let(:links)  { [link_1, link_2] }
+
+  before do
+    @time = Timecop.freeze('2016-06-21 09:26:56 +0100')
+  end
+
+  subject(:link_checker) { LocalLinksManager::CheckLinks::LinkChecker.new }
+
+  after(:each) do
+    Timecop.return
+  end
+
+  describe '#check_links' do
+    it 'retrieves the status code for a link and the time it was checked' do
+      stub_request(:get, link_1).to_return(status: 200)
+      stub_request(:get, link_2).to_return(status: 200)
+
+      expect(link_checker.check_links(links)).to eq(
+        link_1 => ['200', @time],
+        link_2 => ['200', @time])
+    end
+
+    it 'follows redirected links' do
+      stub_request(:get, 'http://www.lewisham.gov.uk').to_return(status: 200)
+      stub_request(:get, link_1).to_return(status: 301, headers: { 'location' => 'http://www.lewisham.gov.uk' })
+      stub_request(:get, link_2).to_return(status: 200)
+
+      link_checker.check_links(links)
+
+      expect(link_checker.link_responses).to eq(
+        link_1 => ['200', @time],
+        link_2 => ['200', @time])
+    end
+
+    context 'error handling' do
+      let(:link) { "http://some-link.com" }
+      let(:connection) { double :connection }
+
+      it 'returns error message when connection fails' do
+        stub_request(:get, "http://some-link.com/").and_raise(Faraday::ConnectionFailed, "connection failed")
+
+        expect(subject.check_links([link])).to eq(link => ["Connection failed", @time])
+      end
+
+      it 'returns error message when request times out' do
+        stub_request(:get, "http://some-link.com/").to_timeout
+
+        expect(subject.check_links([link])).to eq(link => ["Timeout Error", @time])
+      end
+
+      it 'returns error message when SLL error occurs' do
+        stub_request(:get, "http://some-link.com/").and_raise(Faraday::SSLError, "ssl error")
+
+        expect(subject.check_links([link])).to eq(link => ["SSL Error", @time])
+      end
+
+      it 'returns error message when redirect limit is reached' do
+        stub_request(:get, "http://some-link.com/").and_raise(FaradayMiddleware::RedirectLimitReached, "redirect limit reached")
+
+        expect(subject.check_links([link])).to eq(link => ["Too many redirects", @time])
+      end
+
+      it 'returns error message when URI is invalid' do
+        stub_request(:get, "http://some-link.com/").and_raise(URI::InvalidURIError, "invalid URI")
+
+        expect(subject.check_links([link])).to eq(link => ["Invalid URI", @time])
+      end
+
+      it 'returns error message for any unexpected error' do
+        stub_request(:get, "http://some-link.com/").and_raise(StandardError, "some unknown error")
+
+        expect(subject.check_links([link])).to eq(link => ["StandardError", @time])
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+require 'local-links-manager/check_links/link_status_updater'
+
+describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
+  let(:link_checker) { double :link_checker }
+  subject(:status_updater) { described_class.new(link_checker) }
+
+  before do
+    @time = Timecop.freeze('2016-06-21 09:26:56 +0100')
+  end
+
+  after(:each) do
+    Timecop.return
+  end
+
+  describe '#update' do
+    context "with links for enabled Services" do
+      let(:link_1) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/schools/attendance/Pages/Educating-your-child-at-home.aspx') }
+      let(:link_2) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/student-pupil-support/Pages/default.aspx') }
+
+      it 'updates the link\'s status code and link last checked time in the database' do
+        expect(link_checker).to receive(:check_links)
+          .with([link_1.url, link_2.url])
+          .and_return(link_1.url => ['200', @time], link_2.url => ['200', @time])
+
+        status_updater.update
+
+        expect(link_1.reload.status).to eq('200')
+        expect(link_2.reload.link_last_checked).to eq(@time)
+      end
+
+      context "with duplicate links" do
+        let!(:duplicate_link) { FactoryGirl.create(:link, url: link_2.url) }
+
+        it 'updates links with non-unique URLs' do
+          expect(link_checker).to receive(:check_links)
+            .with([link_1.url, link_2.url])
+            .and_return(link_1.url => ['200', @time], link_2.url => ['200', @time])
+
+          status_updater.update
+
+          expect(duplicate_link.reload.status).to eq('200')
+          expect(duplicate_link.reload.link_last_checked).to eq(@time)
+        end
+      end
+    end
+  end
+
+  context "with links for disabled Services" do
+    let!(:disabled_service_link) { FactoryGirl.create(:link_for_disabled_service) }
+
+    it 'does not test links' do
+      expect(link_checker).to receive(:check_links).with([]).and_return({})
+
+      status_updater.update
+
+      expect(disabled_service_link.reload.status).to be_nil
+      expect(disabled_service_link.reload.link_last_checked).to be_nil
+    end
+  end
+end

--- a/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
+++ b/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
@@ -5,9 +5,9 @@ describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
   describe '#enabled_services' do
     let(:csv_downloader) { instance_double CsvDownloader }
     let(:csv_rows) { [{ "LGSL" => 1614 }, { "LGSL" => 13 }] }
-    let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
-    let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
-    let!(:service_2) { FactoryGirl.create(:service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
+    let!(:service_0) { FactoryGirl.create(:disabled_service, lgsl_code: 1614, label: "Bursary Fund Service") }
+    let!(:service_1) { FactoryGirl.create(:disabled_service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+    let!(:service_2) { FactoryGirl.create(:disabled_service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
 
     context 'when the csv is downloaded successfully' do
       before do
@@ -21,6 +21,7 @@ describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
       end
 
       it 'should not enable an unrequired service' do
+        LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader).enable_services
         expect(service_2.reload.enabled).to eq(false)
       end
     end

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,0 +1,1 @@
+require 'timecop'


### PR DESCRIPTION
We add a LinkChecker class that accepts an array of URL strings and returns an an array with the status and the time the link was checked. In the normal case, the status will be an HTTP status code like 200 or 404, but in various error cases, a custom error message will be returned such as 'Timeout Error' or 'SSL Error'. We use the [faraday gem](https://github.com/lostisland/faraday) to make the actual GET requests. We initially started with just the NetHttp library but found that redirects difficult to handle for all cases.

We add `LinkStatusUpdater` and `HomepageUpdater` classes which use the `LinkChecker` to make requests for the relevant URLs and write the results to the database.

For https://trello.com/c/KBT9RC9q/406-check-the-status-code-of-links

Mobbed with @klssmith and @emmabeynon 
