### PR TITLE
Add cron job for link checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'addressable'
 gem 'faraday'
 gem 'faraday_middleware'
 
+gem 'mlanett-redis-lock', '0.2.7'
+gem 'redis-namespace', '1.5.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'faraday_middleware'
 gem 'mlanett-redis-lock', '0.2.7'
 gem 'redis-namespace', '1.5.2'
 
+gem 'whenever', require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mlanett-redis-lock (0.2.7)
+      redis
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -220,6 +222,9 @@ GEM
     rake (10.5.0)
     rdoc (4.2.2)
       json (~> 1.4)
+    redis (3.3.0)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     request_store (1.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -335,10 +340,12 @@ DEPENDENCIES
   gretel (= 3.0.8)
   jbuilder (~> 2.0)
   logstasher (= 0.6.2)
+  mlanett-redis-lock (= 0.2.7)
   pg
   plek (~> 1.10)
   pry-byebug
   rails (= 4.2.5.2)
+  redis-namespace (= 1.5.2)
   rspec-rails (~> 3.3)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.1)
     crack (0.4.3)
@@ -319,6 +320,8 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -357,6 +360,7 @@ DEPENDENCIES
   unicorn (~> 4.9.0)
   web-console (~> 2.0)
   webmock (~> 1.2)
+  whenever
 
 BUNDLED WITH
    1.10.6

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,3 +6,13 @@ job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv local-links-manager bun
 every :day, at: '2am' do
   rake 'check-links'
 end
+
+# Run the rake task to import all links to service interactions for local authorities into Local Links Manager every day
+every :day, at: '1am' do
+  rake 'import:links:import_all'
+end
+
+# Run the rake task to import all services and interactions into Local Links Manager on the 1st of each month
+every :month, on: '1st' do
+  rake 'import:service_interactions:import_all'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,8 @@
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv local-links-manager bundle exec rake :task :output'
+
+every :day, at: '2am' do
+  rake 'check-links'
+end

--- a/lib/local-links-manager/distributed_lock.rb
+++ b/lib/local-links-manager/distributed_lock.rb
@@ -8,13 +8,14 @@ module LocalLinksManager
       @lock_name = lock_name
     end
 
-    def lock
+    def lock(lock_obtained:, lock_not_obtained:)
       Services.redis.lock("local-links-manager:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
         Rails.logger.debug('Successfully got a lock. Running...')
-        yield if block_given?
+        lock_obtained.call
       end
     rescue Redis::Lock::LockNotAcquired => e
       Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
+      lock_not_obtained.call
     end
   end
 end

--- a/lib/local-links-manager/distributed_lock.rb
+++ b/lib/local-links-manager/distributed_lock.rb
@@ -1,0 +1,20 @@
+require 'redis-lock'
+
+module LocalLinksManager
+  class DistributedLock
+    LIFETIME = (60 * 60) # seconds
+
+    def initialize(lock_name)
+      @lock_name = lock_name
+    end
+
+    def lock
+      Services.redis.lock("local-links-manager:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
+        Rails.logger.debug('Successfully got a lock. Running...')
+        yield if block_given?
+      end
+    rescue Redis::Lock::LockNotAcquired => e
+      Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -20,4 +20,10 @@ module Services
       Redis.new(redis_config)
     end
   end
+
+  def self.icinga_check(service_desc, code, message)
+    unless Rails.env.development?
+      `/usr/local/bin/notify_passive_check "#{service_desc}" #{code} "#{message}"`
+    end
+  end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,3 +1,4 @@
+require 'redis'
 require 'gds_api/mapit'
 
 module Services
@@ -5,6 +6,18 @@ module Services
     @mapit ||= GdsApi::Mapit.new(
       Plek.new.find('mapit'),
       disable_cache: Rails.env.test?
-      )
+    )
+  end
+
+  def self.redis
+    @redis ||= begin
+      redis_config = {
+        host: ENV["REDIS_HOST"] || "127.0.0.1",
+        port: ENV["REDIS_PORT"] || 6379,
+        namespace: "local-links-manager",
+      }
+
+      Redis.new(redis_config)
+    end
   end
 end

--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -1,8 +1,11 @@
 require 'local-links-manager/check_links/homepage_status_updater'
 require 'local-links-manager/check_links/link_status_updater'
+require 'local-links-manager/distributed_lock'
 
 desc "Check links"
 task "check-links": :environment do
-  LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
-  LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
+  LocalLinksManager::DistributedLock.new('check-links').lock do
+    LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
+    LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
+  end
 end

--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -4,8 +4,21 @@ require 'local-links-manager/distributed_lock'
 
 desc "Check links"
 task "check-links": :environment do
-  LocalLinksManager::DistributedLock.new('check-links').lock do
-    LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
-    LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
-  end
+  service_desc = "Local Links Manager link checker rake task"
+  LocalLinksManager::DistributedLock.new('check-links').lock(
+    lock_obtained: ->() {
+      begin
+        LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
+        LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
+        # Flag nagios that this servers instance succeeded to stop lingering failures
+        Services.icinga_check(service_desc, true, "Success")
+      rescue StandardError => e
+        Services.icinga_check(service_desc, false, e.to_s)
+        raise e
+      end
+    },
+    lock_not_obtained: ->() {
+      Services.icinga_check(service_desc, true, "Unable to lock")
+    }
+  )
 end

--- a/lib/tasks/import/links.rake
+++ b/lib/tasks/import/links.rake
@@ -4,7 +4,22 @@ namespace :import do
   namespace :links do
     desc "Import local authority links for service (lgsl) and interaction (lgil) combinations from local DirectGov"
     task import_all: :environment do
-      LocalLinksManager::Import::LinksImporter.import
+      service_desc = 'Import links to service interactions for local authorities into local-links-manager'
+      LocalLinksManager::DistributedLock.new('check-links').lock(
+        lock_obtained: ->() {
+          begin
+            LocalLinksManager::Import::LinksImporter.import
+            # Flag nagios that this servers instance succeeded to stop lingering failures
+            Services.icinga_check(service_desc, true, "Success")
+          rescue StandardError => e
+            Services.icinga_check(service_desc, false, e.to_s)
+            raise e
+          end
+        },
+        lock_not_obtained: ->() {
+          Services.icinga_check(service_desc, true, "Unable to lock")
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
- Added Redis for doing distributed lock so that the rake task only runs on one machine.
- Added Whenever gem to schedule cron job to run the link checker task daily.
- Added notify_passive_check script to notify Icinga of success/failure.
- Moved all other import tasks to whenever (see: alphagov/govuk-puppet#4591)

[Trello card](https://trello.com/c/KBT9RC9q/406-check-the-status-code-of-links)

[Related PR](https://github.com/alphagov/govuk-puppet/pull/4587)
