### PR TITLE
Change LinkChecker class to check individual links

### DIFF
--- a/lib/local-links-manager/check_links/homepage_status_updater.rb
+++ b/lib/local-links-manager/check_links/homepage_status_updater.rb
@@ -12,8 +12,10 @@ module LocalLinksManager
       end
 
       def update
-        links_responses = url_checker.check_links(links)
-        update_links(links_responses)
+        links.each do |link|
+          link_response = url_checker.check_link(link)
+          update_link(link, link_response)
+        end
       end
 
     private
@@ -22,10 +24,11 @@ module LocalLinksManager
         table.distinct.pluck(column)
       end
 
-      def update_links(links_responses)
-        links_responses.each do |k, v|
-          table.where(column => k).update_all(status: v.first, link_last_checked: v.last)
-        end
+      def update_link(link, link_response)
+        table.where(column => link).update_all(
+          status: link_response[:status],
+          link_last_checked: link_response[:checked_at],
+        )
       end
     end
   end

--- a/lib/local-links-manager/check_links/link_checker.rb
+++ b/lib/local-links-manager/check_links/link_checker.rb
@@ -4,17 +4,11 @@ module LocalLinksManager
       TIMEOUT = 5
       REDIRECT_LIMIT = 10
 
-      attr_reader :link_responses
-
-      def initialize
-        @link_responses = {}
-      end
-
-      def check_links(links)
-        links.each do |link|
-          link_responses[link] = [fetch_status(link), Time.zone.now]
-        end
-        link_responses
+      def check_link(link)
+        {
+          status: fetch_status(link),
+          checked_at: Time.zone.now,
+        }
       end
 
     private

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -12,8 +12,10 @@ module LocalLinksManager
       end
 
       def update
-        links_responses = url_checker.check_links(links)
-        update_links(links_responses)
+        links.each do |link|
+          link_response = url_checker.check_link(link)
+          update_link(link, link_response)
+        end
       end
 
     private
@@ -22,10 +24,11 @@ module LocalLinksManager
         table.joins(:service).where(services: { enabled: true }).distinct.pluck(column)
       end
 
-      def update_links(links_responses)
-        links_responses.each do |k, v|
-          table.where(column => k).update_all(status: v.first, link_last_checked: v.last)
-        end
+      def update_link(link, link_response)
+        table.where(column => link).update_all(
+          status: link_response[:status],
+          link_last_checked: link_response[:checked_at],
+        )
       end
     end
   end

--- a/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
@@ -2,14 +2,11 @@ require 'rails_helper'
 require 'local-links-manager/check_links/homepage_status_updater'
 
 describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
-  let(:link_checker) { double :link_checker, check_links: { local_authority_1.homepage_url => ['200', @time], local_authority_2.homepage_url  => ['200', @time] } }
-  let(:local_authority_1) { FactoryGirl.create(:local_authority) }
-  let(:local_authority_2) {
+  let(:link_checker) { double :link_checker }
+  let!(:local_authority_1) { FactoryGirl.create(:local_authority) }
+  let!(:local_authority_2) {
     FactoryGirl.create(:local_authority,
-      gss: 'S12000042',
       name: 'Lewisham Council',
-      snac: '00QD',
-      tier: 'unitary',
       homepage_url: 'http://www.lewisham.gov.uk')
   }
   subject(:status_updater) { described_class.new(link_checker) }
@@ -20,6 +17,7 @@ describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
 
   describe '#update' do
     it 'updates the link\'s status code and link last checked time in the database' do
+      allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
       status_updater.update
 
       expect(local_authority_1.reload.status).to eq('200')

--- a/spec/lib/local-links-manager/check_links/link_checker_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_checker_spec.rb
@@ -3,8 +3,6 @@ require 'local-links-manager/check_links/link_checker'
 
 describe LocalLinksManager::CheckLinks::LinkChecker do
   let(:link_1) { 'http://www.lewisham.gov.uk/education/Educating-your-child-at-home.aspx' }
-  let(:link_2) { 'http://www.lewisham.gov.uk/education/student-pupil-support/default.aspx' }
-  let(:links)  { [link_1, link_2] }
 
   before do
     @time = Timecop.freeze('2016-06-21 09:26:56 +0100')
@@ -16,26 +14,18 @@ describe LocalLinksManager::CheckLinks::LinkChecker do
     Timecop.return
   end
 
-  describe '#check_links' do
+  describe '#check_link' do
     it 'retrieves the status code for a link and the time it was checked' do
       stub_request(:get, link_1).to_return(status: 200)
-      stub_request(:get, link_2).to_return(status: 200)
 
-      expect(link_checker.check_links(links)).to eq(
-        link_1 => ['200', @time],
-        link_2 => ['200', @time])
+      expect(link_checker.check_link(link_1)).to eq(status: '200', checked_at: @time)
     end
 
     it 'follows redirected links' do
       stub_request(:get, 'http://www.lewisham.gov.uk').to_return(status: 200)
       stub_request(:get, link_1).to_return(status: 301, headers: { 'location' => 'http://www.lewisham.gov.uk' })
-      stub_request(:get, link_2).to_return(status: 200)
 
-      link_checker.check_links(links)
-
-      expect(link_checker.link_responses).to eq(
-        link_1 => ['200', @time],
-        link_2 => ['200', @time])
+      expect(link_checker.check_link(link_1)).to eq(status: '200', checked_at: @time)
     end
 
     context 'error handling' do
@@ -45,37 +35,37 @@ describe LocalLinksManager::CheckLinks::LinkChecker do
       it 'returns error message when connection fails' do
         stub_request(:get, "http://some-link.com/").and_raise(Faraday::ConnectionFailed, "connection failed")
 
-        expect(subject.check_links([link])).to eq(link => ["Connection failed", @time])
+        expect(link_checker.check_link(link)).to eq(status: "Connection failed", checked_at: @time)
       end
 
       it 'returns error message when request times out' do
         stub_request(:get, "http://some-link.com/").to_timeout
 
-        expect(subject.check_links([link])).to eq(link => ["Timeout Error", @time])
+        expect(link_checker.check_link(link)).to eq(status: "Timeout Error", checked_at: @time)
       end
 
       it 'returns error message when SLL error occurs' do
         stub_request(:get, "http://some-link.com/").and_raise(Faraday::SSLError, "ssl error")
 
-        expect(subject.check_links([link])).to eq(link => ["SSL Error", @time])
+        expect(link_checker.check_link(link)).to eq(status: "SSL Error", checked_at: @time)
       end
 
       it 'returns error message when redirect limit is reached' do
         stub_request(:get, "http://some-link.com/").and_raise(FaradayMiddleware::RedirectLimitReached, "redirect limit reached")
 
-        expect(subject.check_links([link])).to eq(link => ["Too many redirects", @time])
+        expect(link_checker.check_link(link)).to eq(status: "Too many redirects", checked_at: @time)
       end
 
       it 'returns error message when URI is invalid' do
         stub_request(:get, "http://some-link.com/").and_raise(URI::InvalidURIError, "invalid URI")
 
-        expect(subject.check_links([link])).to eq(link => ["Invalid URI", @time])
+        expect(link_checker.check_link(link)).to eq(status: "Invalid URI", checked_at: @time)
       end
 
       it 'returns error message for any unexpected error' do
         stub_request(:get, "http://some-link.com/").and_raise(StandardError, "some unknown error")
 
-        expect(subject.check_links([link])).to eq(link => ["StandardError", @time])
+        expect(link_checker.check_link(link)).to eq(status: "StandardError", checked_at: @time)
       end
     end
   end

--- a/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
@@ -15,13 +15,11 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
 
   describe '#update' do
     context "with links for enabled Services" do
-      let(:link_1) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/schools/attendance/Pages/Educating-your-child-at-home.aspx') }
-      let(:link_2) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/student-pupil-support/Pages/default.aspx') }
+      let!(:link_1) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/schools/attendance/Pages/Educating-your-child-at-home.aspx') }
+      let!(:link_2) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/student-pupil-support/Pages/default.aspx') }
 
       it 'updates the link\'s status code and link last checked time in the database' do
-        expect(link_checker).to receive(:check_links)
-          .with([link_1.url, link_2.url])
-          .and_return(link_1.url => ['200', @time], link_2.url => ['200', @time])
+        allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
 
         status_updater.update
 
@@ -33,9 +31,7 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
         let!(:duplicate_link) { FactoryGirl.create(:link, url: link_2.url) }
 
         it 'updates links with non-unique URLs' do
-          expect(link_checker).to receive(:check_links)
-            .with([link_1.url, link_2.url])
-            .and_return(link_1.url => ['200', @time], link_2.url => ['200', @time])
+          allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
 
           status_updater.update
 
@@ -50,12 +46,9 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
     let!(:disabled_service_link) { FactoryGirl.create(:link_for_disabled_service) }
 
     it 'does not test links' do
-      expect(link_checker).to receive(:check_links).with([]).and_return({})
+      expect(link_checker).not_to receive(:check_link)
 
       status_updater.update
-
-      expect(disabled_service_link.reload.status).to be_nil
-      expect(disabled_service_link.reload.link_last_checked).to be_nil
     end
   end
 end


### PR DESCRIPTION
- Previously we could not see any output because the script was waiting until the very end before outputting.
- Changed LinkChecker class to check links one at a time.
- This lets the output of checked links be monitored earlier.
- Changed HomepageStatusUpdater and LinkStatusUpdater class to update links one at a time.
