### PR TITLE
Alert when missing service or interaction

### DIFF
--- a/lib/local-links-manager/import/import_comparer.rb
+++ b/lib/local-links-manager/import/import_comparer.rb
@@ -1,0 +1,55 @@
+class ImportComparer
+  def initialize(import_type)
+    @import_type = import_type
+    @records_in_source = Set.new
+    @missing = Set.new
+  end
+
+  def add_source_record(record_key)
+    @records_in_source.add(record_key)
+  end
+
+  def check_missing_records(saved_records)
+    saved_records.each do |record|
+      record_key = yield(record)
+      unless @records_in_source.include? record_key
+        @missing.add(record_key)
+      end
+    end
+
+    notify_record_status
+  end
+
+private
+
+  def notify_record_status
+    @service_desc = "Import #{@import_type.pluralize} into Local Links Manager"
+
+    if @missing.empty?
+      confirm_records_are_present
+    else
+      alert_missing_records
+    end
+  end
+
+  def confirm_records_are_present
+    Services.icinga_check(@service_desc, true, "Success")
+  end
+
+  def alert_missing_records
+    Services.icinga_check(@service_desc, false, error_message(@missing))
+  end
+
+  def error_message(missing)
+    suffix = "no longer in the import source."
+    if missing.count == 1
+      "1 #{@import_type} is #{suffix}"
+    else
+      "#{missing.count} #{@import_type.pluralize} are #{suffix}\n#{list_missing(missing)}\n"
+    end
+  end
+
+  def list_missing(missing)
+    missing.to_a.sort.join("\n")
+  end
+end

--- a/lib/local-links-manager/import/local_authorities_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_importer.rb
@@ -19,6 +19,10 @@ module LocalLinksManager
         new.authorities_from_mapit
       end
 
+      def initialize(import_comparer = ImportComparer.new("local authority"))
+        @comparer = import_comparer
+      end
+
       def authorities_from_mapit
         mapit_las = mapit_authorities
 
@@ -28,8 +32,10 @@ module LocalLinksManager
             next
           end
 
-          create_or_update_la(mapit_la)
+          la = create_or_update_la(mapit_la)
+          @comparer.add_source_record(la.gss)
         end
+        @comparer.check_missing_records(LocalAuthority.all, &:gss)
       end
 
     private
@@ -44,6 +50,7 @@ module LocalLinksManager
         la.slug = mapit_la[:slug]
         la.tier = mapit_la[:tier]
         la.save!
+        la
       end
 
       def mapit_authorities

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -22,7 +22,7 @@ module Services
   end
 
   def self.icinga_check(service_desc, code, message)
-    unless Rails.env.development?
+    if Rails.env.production?
       `/usr/local/bin/notify_passive_check "#{service_desc}" #{code} "#{message}"`
     end
   end

--- a/spec/lib/local-links-manager/import/import_comparer_spec.rb
+++ b/spec/lib/local-links-manager/import/import_comparer_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'local-links-manager/import/import_comparer'
+
+describe ImportComparer do
+  let(:destination_records) { (1..8).map { |num| RaceCompetitor.new(num) } }
+  subject(:ImportComparer) { described_class.new("racer") }
+
+  context 'when records that are in the destination are missing from the source' do
+    let(:incomplete_source_records) { (1..5).map { |num| RaceCompetitor.new(num) } }
+
+    it 'detects them and alerts Icinga' do
+      expect(Services).to receive(:icinga_check).with(
+        "Import racers into Local Links Manager",
+        false,
+        "3 racers are no longer in the import source.\n6\n7\n8\n")
+
+      incomplete_source_records.each do |racer|
+        subject.add_source_record(racer.number)
+      end
+
+      subject.check_missing_records(destination_records, &:number)
+    end
+  end
+
+  context 'when all destination records are still present in the source' do
+    let(:complete_source_records) { (1..9).map { |num| RaceCompetitor.new(num) } }
+
+    it 'tells Icinga that everything is fine!' do
+      expect(Services).to receive(:icinga_check).with(
+        "Import racers into Local Links Manager",
+        true,
+        "Success")
+
+      complete_source_records.each do |racer|
+        subject.add_source_record(racer.number)
+      end
+
+      subject.check_missing_records(destination_records, &:number)
+    end
+  end
+end
+
+class RaceCompetitor
+  attr_accessor :number
+
+  def initialize(race_number)
+    @number = race_number
+  end
+end

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -4,6 +4,7 @@ require 'local-links-manager/import/services_importer'
 describe LocalLinksManager::Import::ServicesImporter, :csv_importer do
   describe '#import_records' do
     let(:csv_downloader) { instance_double CsvDownloader }
+    let(:import_comparer) { ImportComparer.new("service") }
 
     context 'when services download is successful' do
       it 'imports services' do
@@ -49,6 +50,51 @@ describe LocalLinksManager::Import::ServicesImporter, :csv_importer do
         expect(Rails.logger).to receive(:error).with("Malformed CSV error")
 
         LocalLinksManager::Import::ServicesImporter.new(csv_downloader).import_records
+      end
+    end
+
+    context 'check imported data' do
+      let(:import_comparer) { ImportComparer.new("local authority") }
+      let(:importer) { LocalLinksManager::Import::ServicesImporter.new(csv_downloader, import_comparer) }
+
+      context 'when a service is no longer in the CSV' do
+        it 'alerts Icinga that a service is now missing and does not delete anything' do
+          FactoryGirl.create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
+          FactoryGirl.create(:service, lgsl_code: "13", label: "Abandoned shopping trolleys")
+          FactoryGirl.create(:service, lgsl_code: "427", label: "Overheated porridge")
+
+          csv_rows = [
+            {
+              lgsl_code: "1614",
+              label: "16 to 19 bursary fund",
+            }
+          ]
+          stub_csv_rows(csv_rows)
+
+          expect(import_comparer).to receive(:alert_missing_records)
+
+          importer.import_records
+
+          expect(Service.count).to eq(3)
+        end
+      end
+
+      context 'when no services are missing from the CSV' do
+        it 'tells Icinga that everything is fine' do
+          FactoryGirl.create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
+
+          csv_rows = [
+            {
+              lgsl_code: "1614",
+              label: "16 to 19 bursary fund",
+            }
+          ]
+          stub_csv_rows(csv_rows)
+
+          expect(import_comparer).to receive(:confirm_records_are_present)
+
+          importer.import_records
+        end
       end
     end
   end


### PR DESCRIPTION
We import data from a number of sources:
- local authorities
- services 
- interactions
- the allowed mapping of services/interactions
- links

Links are dealt with slightly differently because we will stop importing them at some point and become the sole source of the truth ourselves.

The other data sources are beyond our control to varying extents.  Things that we rely on may well disappear:
- Local authority boundaries change, new ones are created and some disappear altogether
- It's plausible that new service or interaction types will be introduced, some will be retired and the mappings between the two could change.

Because we can't see the future, we can't readily predict what our intentions would be for any of these events.  It's likely that the work that we'd have to do would not be limited to this application. Instead of cleaning up automatically, we'll just ensure that we find out about these occurrences as soon as possible.

This PR introduces Icinga alerts for import discrepancies for Local Authorities, Services and Interactions.

[Trello card](https://trello.com/c/KuN7jtEr/394-imports-should-delete-things-sensibly-5)
