### PR TITLE
Add Icinga status for start of link checker

### DIFF
--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -8,6 +8,7 @@ task "check-links": :environment do
   LocalLinksManager::DistributedLock.new('check-links').lock(
     lock_obtained: ->() {
       begin
+        Services.icinga_check(service_desc, true, "Lock obtained, starting link checker")
         LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
         LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
         # Flag nagios that this servers instance succeeded to stop lingering failures


### PR DESCRIPTION
We want to be a bit more clear about which server is running the link checker task. We were a bit confused this morning because the "freshold" (thanks @surminus) had been exceeded and we weren't sure what was happening.

cc @brenetic @davidbasalla 
