### PR TITLE
Change locks for imports

### DIFF
--- a/lib/tasks/import/all.rake
+++ b/lib/tasks/import/all.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  desc "Runs all the imports required to set up a functioning database - in the right order"
+  task all: :environment do
+    Rake::Task["import:local_authorities:import_all"].invoke
+    Rake::Task["import:service_interactions:import_all"].invoke
+    Rake::Task["import:links:import_all"].invoke
+  end
+end

--- a/lib/tasks/import/links.rake
+++ b/lib/tasks/import/links.rake
@@ -5,7 +5,7 @@ namespace :import do
     desc "Import local authority links for service (lgsl) and interaction (lgil) combinations from local DirectGov"
     task import_all: :environment do
       service_desc = 'Import links to service interactions for local authorities into local-links-manager'
-      LocalLinksManager::DistributedLock.new('check-links').lock(
+      LocalLinksManager::DistributedLock.new('links-import').lock(
         lock_obtained: ->() {
           begin
             LocalLinksManager::Import::LinksImporter.import

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -9,7 +9,7 @@ namespace :import do
     desc "Import ServiceInteractions and dependencies"
     task import_all: :environment do
       service_desc = 'Import services and interactions into local-links-manager'
-      LocalLinksManager::DistributedLock.new('check-links').lock(
+      LocalLinksManager::DistributedLock.new('service-imports').lock(
         lock_obtained: ->() {
           begin
             Rake::Task["import:service_interactions:import_services"].invoke


### PR DESCRIPTION
Currently the link checker, services/interactions imports and the links import
all share the same key for obtaining a distributed lock.  The lock was
intended to ensure that we wouldn't run the same import on multiple machines,
not to manage contention between the tasks themselves.

At present, if the link checker is running, we won't be able to run either of
the above imports (they'd fail with 'unable to obtain lock' messages).  The
link checker takes over 9 hours at current pace, so this is quite curtailing.
The service/interactions importer only runs on the 1st of the month and it's
quite feasible that this would fail and we would be none the wiser until the
freshness threshold was triggered in Icinga 32 days later.

By giving them separate lock names, we enable them all to run whenever
they want, which we think is fine.  As previously stated, we just want to
ensure that the same job doesn't run on multiple machines.
