### PR TITLE
Alert us of empty homepage URLs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,3 +16,8 @@ end
 every :month, on: '1st' do
   rake 'import:service_interactions:import_all'
 end
+
+# Run the rake task to import homepage URLs for local authorities into Local Links Manager every day
+every :day, at: '12:30am' do
+  rake 'import:local_authorities:add_urls'
+end

--- a/lib/local-links-manager/import/local_authorities_url_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_url_importer.rb
@@ -23,7 +23,25 @@ module LocalLinksManager
         end
       end
 
+      def self.alert_empty_urls(service_desc)
+        las_with_empty_urls = LocalAuthority.where(homepage_url: [nil, ''])
+
+        if las_with_empty_urls.any?
+          alert_missing_urls(service_desc, las_with_empty_urls)
+        else
+          confirm_no_missing_urls(service_desc)
+        end
+      end
+
     private
+
+      def self.alert_missing_urls(service_desc, local_authorities)
+        Services.icinga_check(service_desc, false, local_authorities.map(&:gss).join("\n"))
+      end
+
+      def self.confirm_no_missing_urls(service_desc)
+        Services.icinga_check(service_desc, true, "Success")
+      end
 
       def process_row(row)
         return if row['SNAC Code'].blank?

--- a/lib/tasks/import/local_authorities.rake
+++ b/lib/tasks/import/local_authorities.rake
@@ -1,3 +1,4 @@
+require 'local-links-manager/distributed_lock'
 require 'local-links-manager/import/local_authorities_importer'
 require 'local-links-manager/import/local_authorities_url_importer'
 
@@ -17,7 +18,30 @@ namespace :import do
     desc "Add homepage URLs from local.direct.gov.uk to the list of authorities
      imported by running `import_authorities`"
     task add_urls: :environment do
-      LocalLinksManager::Import::LocalAuthoritiesURLImporter.import_urls
+      service_desc = "Check for blank homepage urls in local-links-manager"
+      LocalLinksManager::DistributedLock.new('import-homepages').lock(
+        lock_obtained: ->() {
+          begin
+            Rails.logger.info("Lock obtained, starting homepage url import.")
+            Services.icinga_check(service_desc, true, "Lock obtained, starting job.")
+
+            LocalLinksManager::Import::LocalAuthoritiesURLImporter.import_urls
+            # Flags nagios that this servers instance succeeded to stop lingering failures
+            LocalLinksManager::Import::LocalAuthoritiesURLImporter.alert_empty_urls(service_desc)
+
+            Rails.logger.info("Homepage url import completed.")
+            Services.icinga_check(service_desc, true, "Success")
+          rescue StandardError => e
+            Rails.logger.error("Error while running homepage url import\n#{e}")
+            Services.icinga_check(service_desc, false, e.to_s)
+            raise e
+          end
+        },
+        lock_not_obtained: ->() {
+          Rails.logger.info("Unable to lock")
+          Services.icinga_check(service_desc, true, "Unable to lock")
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
We rely on homepage URLs being present as they are the ultimate fall back for local_transaction URLs if no more specific link exists.  It is important that we have something present. This PR also adds a schedule for running the homepage_url import as it is only currently run manually.  The link checker should run after the import to tell us if the URLs are incorrect.

I've configured a freshness threshold in this PR: https://github.com/alphagov/govuk-puppet/pull/4643
