### PR TITLE
Add logging to link-checker rake task

### DIFF
--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -1,6 +1,5 @@
 require 'local-links-manager/check_links/homepage_status_updater'
 require 'local-links-manager/check_links/link_status_updater'
-require 'local-links-manager/distributed_lock'
 
 desc "Check links"
 task "check-links": :environment do
@@ -8,17 +7,23 @@ task "check-links": :environment do
   LocalLinksManager::DistributedLock.new('check-links').lock(
     lock_obtained: ->() {
       begin
+        Rails.logger.info("Lock obtained, starting link checker")
         Services.icinga_check(service_desc, true, "Lock obtained, starting link checker")
+
         LocalLinksManager::CheckLinks::HomepageStatusUpdater.new.update
         LocalLinksManager::CheckLinks::LinkStatusUpdater.new.update
-        # Flag nagios that this servers instance succeeded to stop lingering failures
+
+        Rails.logger.info("Link checker completed")
+        # Flag nagios that this server's instance succeeded to stop lingering failures
         Services.icinga_check(service_desc, true, "Success")
       rescue StandardError => e
+        Rails.logger.error("Error while running link checker\n#{e}")
         Services.icinga_check(service_desc, false, e.to_s)
         raise e
       end
     },
     lock_not_obtained: ->() {
+      Rails.logger.info("Unable to lock")
       Services.icinga_check(service_desc, true, "Unable to lock")
     }
   )


### PR DESCRIPTION
We've experienced a few unexpected freshness threshold alerts in Icinga.  We want to increase our knowledge of exactly what is happening, so we're adding logs on start and finish of the rake task.
