### PR TITLE
Add require distributed_lock to relevant tasks

### DIFF
--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -1,3 +1,4 @@
+require 'local-links-manager/distributed_lock'
 require 'local-links-manager/check_links/homepage_status_updater'
 require 'local-links-manager/check_links/link_status_updater'
 

--- a/lib/tasks/import/links.rake
+++ b/lib/tasks/import/links.rake
@@ -1,3 +1,4 @@
+require 'local-links-manager/distributed_lock'
 require 'local-links-manager/import/links_importer'
 
 namespace :import do

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -1,3 +1,4 @@
+require 'local-links-manager/distributed_lock'
 require 'local-links-manager/import/services_importer'
 require 'local-links-manager/import/interactions_importer'
 require 'local-links-manager/import/service_interactions_importer'


### PR DESCRIPTION
Some of the rake tasks were failing due to:
`NameError: uninitialized constant LocalLinksManager::DistributedLock`
