### PR TITLE
Disable services that are not in the CSV

### DIFF
--- a/lib/local-links-manager/import/enabled_service_checker.rb
+++ b/lib/local-links-manager/import/enabled_service_checker.rb
@@ -14,9 +14,15 @@ module LocalLinksManager
       end
 
       def enable_services
-        @csv_downloader.each_row do |row|
-          set_enabled_service(row)
-        end
+        @supported_lgsl_codes = Set.new
+
+        @csv_downloader.each_row { |row| @supported_lgsl_codes.add(row["LGSL"]) }
+
+        Service.all.each { |service| set_enabled_state(service) }
+
+        check_for_missing_services
+
+        log_result
       rescue CsvDownloader::Error => e
         Rails.logger.error e.message
       rescue => e
@@ -25,14 +31,37 @@ module LocalLinksManager
 
     private
 
-      def set_enabled_service(row)
-        service = Service.find_by(lgsl_code: row["LGSL"])
-        if service.nil?
-          Rails.logger.warn("'#{row['LGSL']}' is not an imported Service")
-        else
-          service.enabled = true
-          Rails.logger.info("'#{row['LGSL']}' enabled")
-          service.save!
+      def set_enabled_state(service)
+        enabled = @supported_lgsl_codes.include? service.lgsl_code
+
+        service.enabled = enabled
+        Rails.logger.info("'#{service.lgsl_code}' enabled = #{enabled}")
+        service.save!
+      end
+
+      def check_for_missing_services
+        @supported_lgsl_codes.each do |lgsl|
+          if Service.find_by(lgsl_code: lgsl).nil?
+            warn_missing(lgsl)
+          end
+        end
+      end
+
+      def warn_missing(lgsl)
+        Rails.logger.warn("'#{lgsl}' is not an imported Service")
+      end
+
+      def log_result
+        total_services_count = Service.all.count
+        enabled_services_count = Service.where(enabled: true).count
+        supported_lgsl_codes_count = @supported_lgsl_codes.count
+
+        Rails.logger.info("Enabled #{enabled_services_count} of #{total_services_count} services")
+
+        unless supported_lgsl_codes_count == enabled_services_count
+          Rails.logger.warn "Could not enable all services in the CSV "\
+            "(#{enabled_services_count} enabled, but there are "\
+            "#{supported_lgsl_codes_count} services in the list)"
         end
       end
     end

--- a/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
+++ b/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
@@ -4,10 +4,11 @@ require 'local-links-manager/import/enabled_service_checker'
 describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
   describe '#enabled_services' do
     let(:csv_downloader) { instance_double CsvDownloader }
-    let(:csv_rows) { [{ "LGSL" => 1614 }, { "LGSL" => 13 }] }
+    let(:csv_rows) { [{ "LGSL" => 1614 }, { "LGSL" => 13 }, { "LGSL" => 100010001 }] }
     let!(:service_0) { FactoryGirl.create(:disabled_service, lgsl_code: 1614, label: "Bursary Fund Service") }
     let!(:service_1) { FactoryGirl.create(:disabled_service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
     let!(:service_2) { FactoryGirl.create(:disabled_service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
+    let!(:service_3) { FactoryGirl.create(:service, lgsl_code: 47) }
 
     context 'when the csv is downloaded successfully' do
       before do
@@ -23,6 +24,18 @@ describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
       it 'should not enable an unrequired service' do
         LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader).enable_services
         expect(service_2.reload.enabled).to eq(false)
+      end
+
+      it 'should disable a previously required service that is no longer required' do
+        LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader).enable_services
+        expect(service_3.reload.enabled).to eq(false)
+      end
+
+      it 'should warn when an lgsl code is in the csv that does not correspond to a service' do
+        checker = LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader)
+
+        expect(checker).to receive(:warn_missing).with(100010001)
+        checker.enable_services
       end
     end
   end


### PR DESCRIPTION
In addition to enabling services that are in the CSV, we want to ensure that we disable the others in our database.  This allows us to remove unsupported services by using the CSV without having to write migrations to support it.

At some point in the near future we will stop having to import this CSV as local links manager will control which services we support, not a CSV in Publisher.
