### PR TITLE
Correct enabled service checker

### DIFF
--- a/lib/local-links-manager/import/enabled_service_checker.rb
+++ b/lib/local-links-manager/import/enabled_service_checker.rb
@@ -32,8 +32,7 @@ module LocalLinksManager
     private
 
       def set_enabled_state(service)
-        enabled = @supported_lgsl_codes.include? service.lgsl_code
-
+        enabled = @supported_lgsl_codes.include? service.lgsl_code.to_s
         service.enabled = enabled
         Rails.logger.info("'#{service.lgsl_code}' enabled = #{enabled}")
         service.save!

--- a/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
+++ b/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
@@ -4,7 +4,7 @@ require 'local-links-manager/import/enabled_service_checker'
 describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
   describe '#enabled_services' do
     let(:csv_downloader) { instance_double CsvDownloader }
-    let(:csv_rows) { [{ "LGSL" => 1614 }, { "LGSL" => 13 }, { "LGSL" => 100010001 }] }
+    let(:csv_rows) { [{ "LGSL" => "1614" }, { "LGSL" => "13" }, { "LGSL" => "100010001" }] }
     let!(:service_0) { FactoryGirl.create(:disabled_service, lgsl_code: 1614, label: "Bursary Fund Service") }
     let!(:service_1) { FactoryGirl.create(:disabled_service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
     let!(:service_2) { FactoryGirl.create(:disabled_service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
@@ -34,7 +34,7 @@ describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
       it 'should warn when an lgsl code is in the csv that does not correspond to a service' do
         checker = LocalLinksManager::Import::EnabledServiceChecker.new(csv_downloader)
 
-        expect(checker).to receive(:warn_missing).with(100010001)
+        expect(checker).to receive(:warn_missing).with("100010001")
         checker.enable_services
       end
     end


### PR DESCRIPTION
We were incorrectly expecting the enabled service CSV file to provide us with
numeric values (when they are strings).  This threw out the comparator which
enables/disables the services we're interested in resulting in us disabling all
of the services.

We've fixed the tests to be more reflective of reality and now compare strings
instead.
