### PR TITLE
Update lozenge styling and fix Link Status display

### DIFF
--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -37,7 +37,7 @@
             <p><%= link_to_if interaction.link_url, nil, interaction.link_url %></p>
           </td>
           <td class="status">
-            <span class="<%= interaction.label_status_class %>" text-muted">
+            <span class="<%= interaction.label_status_class %> text-muted">
               <b><%= interaction.link_status %></b>
             </span>
             <p class="text-muted">

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -3,9 +3,7 @@
   <p>
     Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %>
     <%= link_to authority.homepage_button_text, edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %><br>
-    <span class="<%= authority.label_status_class %>">
-      <b><%= authority.status_description %></b>
-    </span>
+    <span class="<%= authority.label_status_class %>"><b><%= authority.status_description %></b></span>
     <span class="text-muted"><%= authority.last_checked %></span>
   </p>
 </div>


### PR DESCRIPTION
This commit adds extra space to the right of the lozenges and displays
the Link Status as grey when there is no link.

We had to move both opening and closing <span> elements onto one
line to get the correct spacing. The following link displays the effect in
detail: http://stackoverflow.com/a/25879479
# Before

<img width="411" alt="screen shot 2016-07-21 at 10 56 10" src="https://cloud.githubusercontent.com/assets/5112255/17018896/d3d248bc-4f31-11e6-8975-1994f7e3684e.png">
# After

<img width="422" alt="screen shot 2016-07-21 at 10 56 17" src="https://cloud.githubusercontent.com/assets/5112255/17018897/d3da246a-4f31-11e6-9956-db6da903277e.png">
