### PR TITLE
Generate CSVs for homepage link status and interaction link status

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,6 +1,18 @@
 class LinksController < ApplicationController
   before_action :load_dependencies
 
+  def homepage_links_status_csv
+    data = LinkCheckCSVPresenter.homepage_links_status_csv
+    filename = "homepage_link_status.csv"
+    send_data data, filename: filename
+  end
+
+  def links_status_csv
+    data = LinkCheckCSVPresenter.links_status_csv
+    filename = "link_status.csv"
+    send_data data, filename: filename
+  end
+
   def edit; end
 
   def update

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -17,6 +17,10 @@ class Link < ActiveRecord::Base
       .where(service_interactions: { service_id: service })
   }
 
+  def self.enabled_links
+    self.joins(:service).where(services: { enabled: true })
+  end
+
   def self.retrieve(params)
     self.joins(:local_authority, :service, :interaction).find_by(
       local_authorities: { slug: params[:local_authority_slug] },

--- a/app/presenters/link_check_csv_presenter.rb
+++ b/app/presenters/link_check_csv_presenter.rb
@@ -1,0 +1,21 @@
+require 'csv'
+
+class LinkCheckCSVPresenter
+  def self.homepage_links_status_csv
+    CSV.generate do |csv|
+      csv << %w(status count)
+      LocalAuthority.group(:status).count.each do |key, value|
+        csv << [key || "nil", value]
+      end
+    end
+  end
+
+  def self.links_status_csv
+    CSV.generate do |csv|
+      csv << %w(status count)
+      Link.enabled_links.group(:status).count.each do |key, value|
+        csv << [key || "nil", value]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/check_homepage_links_status.csv', to: 'links#homepage_links_status_csv'
+  get '/check_links_status.csv', to: 'links#links_status_csv'
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe LinksController, type: :controller do
   before do
+    login_as_stub_user
     @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
     @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
     @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
@@ -9,8 +10,6 @@ RSpec.describe LinksController, type: :controller do
 
   describe 'GET edit' do
     it 'retrieves HTTP success' do
-      login_as_stub_user
-
       get :edit, local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug
       expect(response).to have_http_status(:success)
     end
@@ -18,10 +17,25 @@ RSpec.describe LinksController, type: :controller do
 
   describe 'delete links' do
     it 'handles deletion of links that have already been deleted' do
-      login_as_stub_user
       delete :destroy, local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug
       expect(response).to have_http_status(302)
       expect(flash[:danger]).not_to be_present
+    end
+  end
+
+  describe 'GET homepage_links_status_csv' do
+    it "retrieves HTTP success" do
+      get :homepage_links_status_csv
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Content-Type']).to eq('text/csv')
+    end
+  end
+
+  describe 'GET homepage_links_status_csv' do
+    it "retrieves HTTP success" do
+      get :links_status_csv
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -180,4 +180,24 @@ feature 'The links for a local authority' do
       end
     end
   end
+
+  describe "homepage link check status CSV" do
+    it "should show a CSV" do
+      visit '/check_homepage_links_status.csv'
+      expect(page.body).to include("status,count\n")
+      expect(page.body.count("\n")).to be > 1
+    end
+  end
+
+  describe "interaction link CSV" do
+    before do
+      FactoryGirl.create(:link, status: '200', link_last_checked: @time - (60 * 60))
+    end
+
+    it "should show a CSV" do
+      visit '/check_links_status.csv'
+      expect(page.body).to include("status,count\n")
+      expect(page.body.count("\n")).to be > 1
+    end
+  end
 end

--- a/spec/presenters/link_check_csv_presenter_spec.rb
+++ b/spec/presenters/link_check_csv_presenter_spec.rb
@@ -1,0 +1,17 @@
+describe LinkCheckCSVPresenter do
+  describe ".homepage_links_status_csv" do
+    it "returns aggregate results of homepage links checks" do
+      allow(LocalAuthority).to receive_message_chain("group.count").and_return("Invalid URI" => 11, "Timeout Error" => 10, "Connection failed" => 24, "200" => 371, "404" => 2)
+
+      expect(LinkCheckCSVPresenter.homepage_links_status_csv).to eq("status,count\nInvalid URI,11\nTimeout Error,10\nConnection failed,24\n200,371\n404,2\n")
+    end
+  end
+
+  describe ".links_status_csv" do
+    it "returns aggregate results of links checks" do
+      allow(Link).to receive_message_chain("enabled_links.group.count").and_return(nil => 7155, "Invalid URI" => 61, "Connection failed" => 628, "500" => 167, "400" => 1, "200" => 72246, "Too many redirects" => 6, "503" => 1, "Timeout Error" => 159, "410" => 78, "401" => 6, "404" => 1814, "403" => 30, "SSL Error" => 110)
+
+      expect(LinkCheckCSVPresenter.links_status_csv).to eq("status,count\nnil,7155\nInvalid URI,61\nConnection failed,628\n500,167\n400,1\n200,72246\nToo many redirects,6\n503,1\nTimeout Error,159\n410,78\n401,6\n404,1814\n403,30\nSSL Error,110\n")
+    end
+  end
+end


### PR DESCRIPTION
- This generates CSVs of link check statistics when people access `/check_homepage_links_status.csv` and `/check_links_status.csv`, so we can do reporting into the numbers of broken links etc.
- Trello: https://trello.com/c/BCMg9RTo/426-get-the-data-for-broken-links-2

(Paired with @klssmith.)
