### PR TITLE
[DISCUSS] Enable show route for a JSON request for a specific Link

### DIFF
--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,4 +1,27 @@
 class InteractionsController < ApplicationController
+  def show
+    sanitize_service_slug_param
+    sanitize_interaction_slug_param
+
+    @authority = LocalAuthorityPresenter.new(LocalAuthority.find_by_slug!(params[:local_authority_slug]))
+    @service = Service.find_by_slug!(params[:service_slug])
+    @interactions = @service.interactions
+    @link = presented_links.detect { |l| @interactions.first.service_interactions.first.id == l.service_interaction.id }
+
+    # Should have a method like?
+    # links = @authority.links.for_service_interaction(@service, @interaction)
+
+    response = {
+      "local_authority"=>{
+        "name"=>@authority.name,
+      },
+      "local_interaction"=>{
+        "url"=>@link.url
+      }
+    }
+    render :json => response
+  end
+
   def index
     @authority = LocalAuthorityPresenter.new(LocalAuthority.find_by_slug!(params[:local_authority_slug]))
     @service = Service.find_by_slug!(params[:service_slug])
@@ -20,4 +43,16 @@ private
   def presented_links
     @_links ||= @authority.links.for_service(@service).map { |link| LinkPresenter.new(link) }
   end
+
+  def sanitize_service_slug_param
+    service = Service.find_by(lgsl_code: params[:service_slug])
+    params[:service_slug] = service.slug if service
+  end
+
+  def sanitize_interaction_slug_param
+    interaction = Interaction.find_by(lgil_code: params[:slug])
+    params[:interaction_slug] = interaction.slug if interaction
+  end
 end
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources "local_authorities", only: [:index, :edit, :update], param: :slug do
     resources "services", only: [:index], param: :slug do
-      resources "interactions", only: [:index], param: :slug do
+      resources "interactions", only: [:index, :show], param: :slug do
         resource "links", only: [:edit, :update, :destroy]
       end
     end

--- a/spec/controllers/interactions_controller_spec.rb
+++ b/spec/controllers/interactions_controller_spec.rb
@@ -1,17 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe InteractionsController, type: :controller do
-  before do
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
-    @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
-    @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
-  end
 
   describe "GET #index" do
+
+    before do
+      @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
+      @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
+      @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+    end
+
     it "returns http success" do
       login_as_stub_user
       get :index, local_authority_slug: @local_authority.slug, service_slug: @service.slug
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #show" do
+
+    before do
+      @local_authority = FactoryGirl.create(:local_authority, name: 'Blackburn')
+      @service = FactoryGirl.create(:service, label: 'Service 2', lgsl_code: 2)
+      @interaction = FactoryGirl.create(:interaction, label: 'Interaction 4', lgil_code: 4)
+      @service_interaction = FactoryGirl.create(:service_interaction, service_id: @service.id, interaction_id: @interaction.id)
+      @link = FactoryGirl.create(:link, local_authority_id: @local_authority.id, service_interaction_id: @service_interaction.id)
+      @expected_body = {
+        "local_authority"=>{
+          "name"=>"Blackburn",
+        },
+        "local_interaction"=>{
+          "url"=>"http://local-authority-name-1.example.com/service-label-1/interaction-label-1"
+        }
+      }
+    end
+
+    it "returns json success" do
+      login_as_stub_user
+      get :show, local_authority_slug: @local_authority.slug, service_slug: @service.slug, slug: @interaction.slug, format: :json
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)).to eq(@expected_body)
+    end
+
+    it "returns json success for numeric slugs" do
+      login_as_stub_user
+      get :show, local_authority_slug: @local_authority.slug, service_slug: 2, slug: 4, format: :json
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)).to eq(@expected_body)
     end
   end
 end


### PR DESCRIPTION
## For discussion about LocalLinksManager API, do not merge

We enable the show route for nested Interactions, so the link for the specific ServiceInteraction can be requested.
The request would look like:

`GET /local_authorities/bolton/services/412/interactions/8.json`

The most contentious part of this implementation is probably that we have to convert from LGSL and LGIL codes to slugs in the controller. Frontend will make the request and only knows about LGSL and LGIL codes. However the routes we have set up in LocalLinksManager currently all work with slugs. That's why we need to convert the params hash in the controller to convert the numbers into relevant slugs.
