### PR TITLE
[DISCUSS] Add new api route and controller

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,28 @@
+class ApiController < ApplicationController
+  def service_interaction_for_local_authority
+    @authority = LocalAuthority.find_by_slug!(params[:authority_slug])
+    @service = Service.find_by(lgsl_code: params[:lgsl])
+    interactions = @service.interactions
+    @link = links.detect { |l| interactions.first.service_interactions.first.id == l.service_interaction.id }
+
+    render json: local_interaction_response
+  end
+
+private
+
+  def local_interaction_response
+    {
+      "local_authority"=>{
+        "name"=>@authority.name,
+      },
+      "local_interaction"=>{
+        "url"=>@link.url
+      }
+    }
+  end
+
+  def links
+    @_links ||= @authority.links.for_service(@service)
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
+  get '/api/local_interaction_details', to: 'api#service_interaction_for_local_authority'
+  get '/api/local_authorities', to: 'api#local_authority'
+
+
   resources "local_authorities", only: [:index, :edit, :update], param: :slug do
     resources "services", only: [:index], param: :slug do
       resources "interactions", only: [:index], param: :slug do

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe ApiController, type: :controller do
+  before do
+    @local_authority = FactoryGirl.create(:local_authority, name: 'Blackburn', slug: 'blackburn')
+    @service = FactoryGirl.create(:service, label: 'Service 2', lgsl_code: 2)
+    @interaction = FactoryGirl.create(:interaction, label: 'Interaction 4', lgil_code: 4)
+    @service_interaction = FactoryGirl.create(:service_interaction, service_id: @service.id, interaction_id: @interaction.id)
+    @link = FactoryGirl.create(:link, local_authority_id: @local_authority.id, service_interaction_id: @service_interaction.id)
+    @expected_body = {
+      "local_authority"=>{
+        "name"=>"Blackburn",
+      },
+      "local_interaction"=>{
+        "url"=>"http://local-authority-name-1.example.com/service-label-1/interaction-label-1"
+      }
+    }
+  end
+
+  describe "GET #local_interaction_details" do
+    it "returns http success" do
+      login_as_stub_user
+      get :service_interaction_for_local_authority, authority_slug: 'blackburn', lgsl: 2, lgil: 4
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)).to eq(@expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## For discussion about LocalLinksManager API, do not merge

This is an alternative approach to https://github.com/alphagov/local-links-manager/pull/42

We add a separate controller to handle JSON requests for the API. We add a method to return local interaction details and find the related data through query params that are passed along with the request. 

A lot more logic would have to be added to handle the fallback logic for local interactions, but again just a broad outline.

A future 'local_authority' method could be added here for handling requests for 'Find my local council'.
