### PR TITLE
Add link api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,7 @@ gem 'redis-namespace', '1.5.2'
 gem 'whenever', require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'pry-byebug'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,6 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.2.2)
-    byebug (8.2.2)
     capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
@@ -184,9 +183,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
-      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -346,7 +344,7 @@ DEPENDENCIES
   mlanett-redis-lock (= 0.2.7)
   pg
   plek (~> 1.10)
-  pry-byebug
+  pry-rails
   rails (= 4.2.5.2)
   redis-namespace (= 1.5.2)
   rspec-rails (~> 3.3)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,34 @@ Import all the links for each local authority:
 
 `bundle exec rake import:links:import_all`
 
-### Example API output (optional)
+### Example API output
+
+**Endpoint for local transactions links**
+
+`GET /api/link?authority_slug=<authority_slug>&lgsl=<lgsl>&lgil=<lgil>`
+
+This takes parameters for Authority Slug, LGSL and optionally LGIL.
+
+Returns JSON details for local authorty and interation or just local authority depending whether the LGIL parameter is passed in. If the LGIL is passed in we return the link for the LGIL if it exists. If not then only the local authority details are returned. If the LGIL is not passed in it returns the appropriate fallback link. If no appropriate link is found then once again we only return the local authority details.
+
+```
+{
+  "local_authority" => {
+    "name" => "Blackburn",
+      "snac" => "00AG",
+      "tier" => "unitary",
+      "homepage_url" => "http://blackburn.example.com",
+  },
+    "local_interaction" => {
+      "lgsl_code" => 2,
+      "lgil_code" => 4,
+      "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+    }
+}
+```
+
+We do not require authentication for this request.
+
 
 ## Licence
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,91 @@
+class ApiController < ApplicationController
+  skip_before_action :require_signin_permission!
+  before_action :load_authority, :load_service
+
+  PROVIDING_INFORMATION_LGIL = 8
+
+  def link
+    render json: {}, status: 400 and return unless params[:authority_slug] && params[:lgsl]
+    render json: {}, status: 404 and return unless @authority && @service
+
+    if params[:lgil]
+      load_service_interaction
+      render json: {}, status: 404 and return unless @service_interaction
+      return_link_for_lgil
+    else
+      return_fallback_link
+    end
+  end
+
+private
+
+  def load_authority
+    @authority = LocalAuthority.find_by(slug: params[:authority_slug])
+  end
+
+  def load_service
+    @service = Service.find_by(lgsl_code: params[:lgsl])
+  end
+
+  def load_service_interaction
+    @service_interaction = ServiceInteraction.find_by(service: @service, interaction: interaction)
+  end
+
+  def interaction
+    Interaction.find_by(lgil_code: params[:lgil])
+  end
+
+  def return_link_for_lgil
+    @link = @authority.links.find_by_lgsl_and_lgil(params[:lgsl], params[:lgil])
+    render json: local_interaction_response
+  end
+
+  def return_fallback_link
+    if service_links_ordered_by_lgil.count == 1
+      @link = service_links_ordered_by_lgil.first
+    else
+      @link = link_with_lowest_lgil_but_not_providing_information_lgil
+    end
+
+    render json: local_interaction_response
+  end
+
+  def service_links_ordered_by_lgil
+    @_links ||= @authority.links.for_service(@service).order("interactions.lgil_code").to_a
+  end
+
+  def link_with_lowest_lgil_but_not_providing_information_lgil
+    service_links_ordered_by_lgil.detect do |link|
+      link.interaction.lgil_code != PROVIDING_INFORMATION_LGIL
+    end
+  end
+
+  def local_interaction_response
+    if @link
+      local_authority_details.merge(link_details)
+    else
+      local_authority_details
+    end
+  end
+
+  def local_authority_details
+    {
+      "local_authority" => {
+        "name" => @authority.name,
+        "snac" => @authority.snac,
+        "tier" => @authority.tier,
+        "homepage_url" => @authority.homepage_url
+      }
+    }
+  end
+
+  def link_details
+    {
+      "local_interaction" => {
+        "lgsl_code" => @link.service.lgsl_code,
+        "lgil_code" => @link.interaction.lgil_code,
+        "url" => @link.url
+      }
+    }
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,91 +1,44 @@
+require 'local-links-manager/link_resolver'
+
 class ApiController < ApplicationController
   skip_before_action :require_signin_permission!
-  before_action :load_authority, :load_service
-
-  PROVIDING_INFORMATION_LGIL = 8
 
   def link
-    render json: {}, status: 400 and return unless params[:authority_slug] && params[:lgsl]
-    render json: {}, status: 404 and return unless @authority && @service
+    return render json: {}, status: 400 if missing_required_params?
+    return render json: {}, status: 404 if missing_objects?
 
-    if params[:lgil]
-      load_service_interaction
-      render json: {}, status: 404 and return unless @service_interaction
-      return_link_for_lgil
-    else
-      return_fallback_link
-    end
+    @link = LocalLinksManager::LinkResolver.new(authority, service, interaction).resolve
+
+    render json: LinkApiResponsePresenter.new(authority, @link).present
   end
 
 private
 
-  def load_authority
-    @authority = LocalAuthority.find_by(slug: params[:authority_slug])
+  def missing_required_params?
+    params[:authority_slug].blank? || params[:lgsl].blank?
   end
 
-  def load_service
-    @service = Service.find_by(lgsl_code: params[:lgsl])
+  def missing_objects?
+    authority.nil? || service.nil? || service_interaction_required_but_not_found?
   end
 
-  def load_service_interaction
-    @service_interaction = ServiceInteraction.find_by(service: @service, interaction: interaction)
+  def authority
+    @authority ||= LocalAuthority.find_by(slug: params[:authority_slug])
+  end
+
+  def service
+    @service ||= Service.find_by(lgsl_code: params[:lgsl])
+  end
+
+  def service_interaction_required_but_not_found?
+    params[:lgil] && service_interaction.nil?
+  end
+
+  def service_interaction
+    @service_interaction ||= ServiceInteraction.find_by(service: @service, interaction: interaction)
   end
 
   def interaction
-    Interaction.find_by(lgil_code: params[:lgil])
-  end
-
-  def return_link_for_lgil
-    @link = @authority.links.find_by_lgsl_and_lgil(params[:lgsl], params[:lgil])
-    render json: local_interaction_response
-  end
-
-  def return_fallback_link
-    if service_links_ordered_by_lgil.count == 1
-      @link = service_links_ordered_by_lgil.first
-    else
-      @link = link_with_lowest_lgil_but_not_providing_information_lgil
-    end
-
-    render json: local_interaction_response
-  end
-
-  def service_links_ordered_by_lgil
-    @_links ||= @authority.links.for_service(@service).order("interactions.lgil_code").to_a
-  end
-
-  def link_with_lowest_lgil_but_not_providing_information_lgil
-    service_links_ordered_by_lgil.detect do |link|
-      link.interaction.lgil_code != PROVIDING_INFORMATION_LGIL
-    end
-  end
-
-  def local_interaction_response
-    if @link
-      local_authority_details.merge(link_details)
-    else
-      local_authority_details
-    end
-  end
-
-  def local_authority_details
-    {
-      "local_authority" => {
-        "name" => @authority.name,
-        "snac" => @authority.snac,
-        "tier" => @authority.tier,
-        "homepage_url" => @authority.homepage_url
-      }
-    }
-  end
-
-  def link_details
-    {
-      "local_interaction" => {
-        "lgsl_code" => @link.service.lgsl_code,
-        "lgil_code" => @link.interaction.lgil_code,
-        "url" => @link.url
-      }
-    }
+    @interaction ||= Interaction.find_by(lgil_code: params[:lgil])
   end
 end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,4 +1,6 @@
 class Interaction < ActiveRecord::Base
+  PROVIDING_INFORMATION_LGIL = 8
+
   validates :lgil_code, :label, :slug, presence: true, uniqueness: true
 
   has_many :service_interactions

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -29,10 +29,10 @@ class Link < ActiveRecord::Base
     ) || build(params)
   end
 
-  def self.find_by_lgsl_and_lgil(lgsl_code, lgil_code)
+  def self.find_by_service_and_interaction(service, interaction)
     self.joins(:service, :interaction).find_by(
-      services: { lgsl_code: lgsl_code },
-      interactions: { lgil_code: lgil_code }
+      services: { id: service.id },
+      interactions: { id: interaction.id }
     )
   end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -29,6 +29,13 @@ class Link < ActiveRecord::Base
     ) || build(params)
   end
 
+  def self.find_by_lgsl_and_lgil(lgsl_code, lgil_code)
+    self.joins(:service, :interaction).find_by(
+      services: { lgsl_code: lgsl_code },
+      interactions: { lgil_code: lgil_code }
+    )
+  end
+
   def self.build(params)
     Link.new(
       local_authority: LocalAuthority.find_by(slug: params[:local_authority_slug]),

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -1,0 +1,37 @@
+class LinkApiResponsePresenter
+  def initialize(authority, link)
+    @authority = authority
+    @link = link
+  end
+
+  def present
+    if @link
+      local_authority_details.merge(link_details)
+    else
+      local_authority_details
+    end
+  end
+
+private
+
+  def local_authority_details
+    {
+      "local_authority" => {
+        "name" => @authority.name,
+        "snac" => @authority.snac,
+        "tier" => @authority.tier,
+        "homepage_url" => @authority.homepage_url
+      }
+    }
+  end
+
+  def link_details
+    {
+      "local_interaction" => {
+        "lgsl_code" => @link.service.lgsl_code,
+        "lgil_code" => @link.interaction.lgil_code,
+        "url" => @link.url
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get '/check_homepage_links_status.csv', to: 'links#homepage_links_status_csv'
   get '/check_links_status.csv', to: 'links#links_status_csv'
 
+  get '/api/link', to: 'api#link'
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/lib/local-links-manager/link_resolver.rb
+++ b/lib/local-links-manager/link_resolver.rb
@@ -1,0 +1,41 @@
+module LocalLinksManager
+  class LinkResolver
+    def initialize(authority, service, interaction = nil)
+      @authority = authority
+      @service = service
+      @interaction = interaction
+    end
+
+    def resolve
+      if @interaction
+        link_for_interaction
+      else
+        fallback_link
+      end
+    end
+
+  private
+
+    def link_for_interaction
+      @authority.links.find_by_service_and_interaction(@service, @interaction)
+    end
+
+    def fallback_link
+      if service_links_ordered_by_lgil.count == 1
+        service_links_ordered_by_lgil.first
+      else
+        link_with_lowest_lgil_but_not_providing_information_lgil
+      end
+    end
+
+    def service_links_ordered_by_lgil
+      @_links ||= @authority.links.for_service(@service).order("interactions.lgil_code").to_a
+    end
+
+    def link_with_lowest_lgil_but_not_providing_information_lgil
+      service_links_ordered_by_lgil.detect do |link|
+        link.interaction.lgil_code != Interaction::PROVIDING_INFORMATION_LGIL
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/link_resolver_spec.rb
+++ b/spec/lib/local-links-manager/link_resolver_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+require 'local-links-manager/link_resolver'
+
+describe LocalLinksManager::LinkResolver do
+  describe "#resolve" do
+    context "with interaction" do
+      let(:local_authority) { FactoryGirl.create(:local_authority) }
+      let(:service_interaction) { FactoryGirl.create(:service_interaction) }
+      let(:link_resolver) { described_class.new(local_authority, service_interaction.service, service_interaction.interaction) }
+
+      it "returns a link for matching service and interaction" do
+        link = FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction)
+
+        expect(link_resolver.resolve).to eq(link)
+      end
+
+      it "returns nil if no link exists" do
+        expect(link_resolver.resolve).to be_nil
+      end
+
+      it "returns nil if no service interaction exists" do
+        service_interaction.destroy
+
+        expect(link_resolver.resolve).to be_nil
+      end
+    end
+
+    context "without interaction" do
+      let(:local_authority) { FactoryGirl.create(:local_authority) }
+      let(:service) { FactoryGirl.create(:service) }
+      let(:link_resolver) { described_class.new(local_authority, service) }
+
+      context "there are 2 links" do
+        let(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 1) }
+        let(:interaction_2) { FactoryGirl.create(:interaction, lgil_code: 2) }
+        let(:service_interaction_1) { FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1) }
+        let(:service_interaction_2) { FactoryGirl.create(:service_interaction, service: service, interaction: interaction_2) }
+        let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_1) }
+        let!(:link_2) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_2) }
+
+        it "returns the link with the lower LGIL" do
+          expect(link_resolver.resolve).to eq(link_1)
+        end
+
+        context "and one of them is for LGIL 8" do
+          before do
+            interaction_1.update_attributes(lgil_code: 8)
+          end
+
+          it "returns the link that is not for LGIL 8" do
+            expect(link_resolver.resolve).to eq(link_2)
+          end
+
+          it "returns the link that is not for LGIL 8 if its LGIL is higher than 8" do
+            interaction_2.update_attributes(lgil_code: 9)
+
+            expect(link_resolver.resolve).to eq(link_2)
+          end
+        end
+      end
+
+      context "there is only one link" do
+        let(:service_interaction) { FactoryGirl.create(:service_interaction, service: service) }
+        let!(:link) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction) }
+
+        it "returns the link" do
+          expect(link_resolver.resolve).to eq(link)
+        end
+
+        it "returns the link if it is for LGIL 8" do
+          link.interaction.update_attributes(lgil_code: 8)
+
+          expect(link_resolver.resolve).to eq(link)
+        end
+      end
+
+      context "there are no links" do
+        it "returns nil" do
+          expect(link_resolver.resolve).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe LinkApiResponsePresenter do
+  describe '#present' do
+    let(:authority) { FactoryGirl.build(:local_authority) }
+    let(:presenter) { described_class.new(authority, link) }
+
+    context 'link is present' do
+      let(:link) { FactoryGirl.build(:link) }
+      let(:expected_response) do
+        {
+          "local_authority" => {
+            "name" => authority.name,
+            "snac" => authority.snac,
+            "tier" => authority.tier,
+            "homepage_url" => authority.homepage_url
+          },
+          "local_interaction" => {
+            "lgsl_code" => link.service.lgsl_code,
+            "lgil_code" => link.interaction.lgil_code,
+            "url" => link.url
+          }
+        }
+      end
+
+      it 'returns combined details for the local authority and local interaction' do
+        expect(presenter.present).to eq(expected_response)
+      end
+    end
+
+    context 'no link is present' do
+      let(:link) { nil }
+      let(:expected_response) do
+        {
+          "local_authority" => {
+            "name" => authority.name,
+            "snac" => authority.snac,
+            "tier" => authority.tier,
+            "homepage_url" => authority.homepage_url
+          }
+        }
+      end
+
+      it 'returns details for just the local authority' do
+        expect(presenter.present).to eq(expected_response)
+      end
+    end
+  end
+end

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -1,0 +1,228 @@
+require 'rails_helper'
+
+RSpec.describe "link path", type: :request do
+  context "for a request with authority slug, lgsl and lgil params" do
+    let(:local_authority) {
+      FactoryGirl.create(:local_authority,
+                         name: 'Blackburn',
+                         slug: 'blackburn',
+                         homepage_url: "http://blackburn.example.com",
+                         snac: "00AG",
+                         tier: "unitary")
+    }
+    let(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
+    let(:interaction) { FactoryGirl.create(:interaction, label: 'report', lgil_code: 4) }
+    let(:service_interaction) { FactoryGirl.create(:service_interaction, service: service, interaction: interaction) }
+    let!(:link) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction) }
+
+    let(:expected_response) {
+      {
+        "local_authority" => {
+          "name" => "Blackburn",
+          "snac" => "00AG",
+          "tier" => "unitary",
+          "homepage_url" => "http://blackburn.example.com",
+        },
+        "local_interaction" => {
+          "lgsl_code" => 2,
+          "lgil_code" => 4,
+          "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+        }
+      }
+    }
+    let(:expected_response_with_no_link) {
+      {
+        "local_authority" => {
+          "name" => "Blackburn",
+          "snac" => "00AG",
+          "tier" => "unitary",
+          "homepage_url" => "http://blackburn.example.com",
+        },
+      }
+    }
+
+    it "responds with LocalAuthority and Link details" do
+      get "/api/link?authority_slug=blackburn&lgsl=2&lgil=4"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+
+    it "responds without link details if Link not present for LGIL" do
+      interaction = FactoryGirl.create(:interaction, lgil_code: 5)
+      FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+      get "/api/link?authority_slug=blackburn&lgsl=2&lgil=5"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response_with_no_link)
+    end
+
+    it "responds with 404 and {} for unsupported local_authority" do
+      get "/api/link?authority_slug=hogwarts&lgsl=2&lgil=4"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "responds with 404 and {} for unsupported lgsl" do
+      get "/api/link?authority_slug=blackburn&lgsl=99&lgil=4"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "responds with 404 and {} for unsupported lgsl and lgil combination" do
+      link.destroy
+      service_interaction.destroy
+
+      get "/api/link?authority_slug=blackburn&lgsl=2&lgil=4"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+
+  context "for a request with authority slug and lgsl params" do
+    let!(:local_authority) {
+      FactoryGirl.create(:local_authority,
+                         name: 'Blackburn',
+                         slug: 'blackburn',
+                         homepage_url: "http://blackburn.gov.uk",
+                         snac: "00AG",
+                         tier: "unitary")
+    }
+    let!(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
+
+    context "when LGILs exist" do
+      it "responds with Link details for the lowest LGIL" do
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.gov.uk",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 1,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          }
+        }
+
+        interaction_1 = FactoryGirl.create(:interaction, label: 'report', lgil_code: 1)
+        interaction_2 = FactoryGirl.create(:interaction, label: 'appeal', lgil_code: 2)
+        service_interaction_1 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1)
+        service_interaction_2 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_2)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_1)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_2)
+
+        get "/api/link?authority_slug=blackburn&lgsl=2"
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+
+      it "does not respond with LGIL 8 even if it is the lowest" do
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.gov.uk",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 9,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/regulation",
+          }
+        }
+
+        interaction_1 = FactoryGirl.create(:interaction, label: 'providing_information', lgil_code: 8)
+        interaction_2 = FactoryGirl.create(:interaction, label: 'regulation', lgil_code: 9)
+        service_interaction_1 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1)
+        service_interaction_2 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_2)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_1)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_2)
+
+        get "/api/link?authority_slug=blackburn&lgsl=2"
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+    end
+
+    context "the only LGIL that exists is LGIL 8" do
+      it "responds with Link details for the LGIL 8" do
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.gov.uk",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 8,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/providing_information",
+          }
+        }
+
+        interaction = FactoryGirl.create(:interaction, label: 'providing_information', lgil_code: 8)
+        service_interaction = FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction)
+
+        get "/api/link?authority_slug=blackburn&lgsl=2"
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+    end
+
+    context "no LGIL links exist" do
+      it "responds with no link details" do
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.gov.uk",
+          },
+        }
+        get "/api/link?authority_slug=blackburn&lgsl=2"
+
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(expected_response)
+      end
+    end
+
+    it "responds with 404 and {} for unsupported local_authority" do
+      get "/api/link?authority_slug=hogwarts&lgsl=2"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "responds with 404 and {} for unsupported lgsl" do
+      get "/api/link?authority_slug=blackburn&lgsl=99"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+
+  context "for a request with missing mandatory query parameters" do
+    it "responds with 400 and {} for missing authority_slug param" do
+      get "/api/link?lgsl=2"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "responds with 400 and {} for missing lgsl param" do
+      get "/api/link?authority_slug=blackburn"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/U31MOcCC/396-2-of-4-add-the-api-endpoint-to-local-links-manager-3

We add an api endpoint for link details, expecting a local authority slug, lgsl and optionally lgil as query parameters to the route `/api/link`. We extract the logic for determining the correct link (including fallback logic) to a separate class which is easier to unit test and could be reused in future.

We also switch back to using `pry-rails` for debugging as we were getting Segmentation faults when using `binding.pry` in our rspec tests.

Mobbed with @emmabeynon, @brenetic and @h-lame 
