### PR TITLE
Fix homepage link status when blank

### DIFF
--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -8,4 +8,8 @@ class LocalAuthorityPresenter < SimpleDelegator
   def homepage_status
     homepage_url.blank? ? 'No link' : status_description
   end
+
+  def homepage_link_last_checked
+    homepage_url.blank? ? '' : last_checked
+  end
 end

--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -4,4 +4,8 @@ class LocalAuthorityPresenter < SimpleDelegator
   def homepage_button_text
     homepage_url.blank? ? 'Add link' : 'Edit link'
   end
+
+  def homepage_status
+    homepage_url.blank? ? 'No link' : status_description
+  end
 end

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -1,9 +1,11 @@
 <div class="page-title">
   <h1><%= authority.name %></h1>
   <p>
-    Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %>
-    <%= link_to authority.homepage_button_text, edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %><br>
+    Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %><br>
     <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
-    <span class="text-muted"><%= authority.last_checked %></span>
+    <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
+  </p>
+  <p>
+    <%= link_to authority.homepage_button_text, edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs' %>
   </p>
 </div>

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -3,7 +3,7 @@
   <p>
     Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %>
     <%= link_to authority.homepage_button_text, edit_local_authority_path(slug: authority.slug), class: 'btn btn-default btn-xs add-left-margin' %><br>
-    <span class="<%= authority.label_status_class %>"><b><%= authority.status_description %></b></span>
+    <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
     <span class="text-muted"><%= authority.last_checked %></span>
   </p>
 </div>

--- a/lib/local-links-manager/check_links/homepage_status_updater.rb
+++ b/lib/local-links-manager/check_links/homepage_status_updater.rb
@@ -21,7 +21,7 @@ module LocalLinksManager
     private
 
       def links
-        table.distinct.pluck(column)
+        table.distinct.where.not(column => '').pluck(column)
       end
 
       def update_link(link, link_response)

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -32,6 +32,15 @@ feature "The services index page for a local authority" do
         expect(page).not_to have_link("/local_authorities/#{ni_local_authority.slug}/services")
       end
     end
+
+    it "displays 'No link'" do
+      @local_authority.homepage_url = nil
+      @local_authority.save
+      visit local_authority_services_path(local_authority_slug: @local_authority.slug)
+      within(:css, ".page-title") do
+        expect(page).to have_content('No link')
+      end
+    end
   end
 
   describe "with no services present" do

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -41,6 +41,15 @@ feature "The services index page for a local authority" do
         expect(page).to have_content('No link')
       end
     end
+
+    it "does not display 'Link not checked'" do
+      @local_authority.homepage_url = nil
+      @local_authority.save
+      visit local_authority_services_path(local_authority_slug: @local_authority.slug)
+      within(:css, ".page-title") do
+        expect(page).not_to have_content('Link not checked')
+      end
+    end
   end
 
   describe "with no services present" do

--- a/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
@@ -9,7 +9,7 @@ describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
       name: 'Lewisham Council',
       homepage_url: 'http://www.lewisham.gov.uk')
   }
-  let!(:local_authority_3) { FactoryGirl.create(:local_authority, homepage_url: nil )}
+  let!(:local_authority_3) { FactoryGirl.create(:local_authority, homepage_url: nil) }
   subject(:status_updater) { described_class.new(link_checker) }
 
   before do
@@ -28,7 +28,7 @@ describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
     it 'does not update the status and link last checked time of a Local Authority that has a blank homepage url' do
       allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
       status_updater.update
-      
+
       expect(local_authority_3.reload.status).to be_nil
       expect(local_authority_3.reload.link_last_checked).to be_nil
     end

--- a/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/homepage_status_updater_spec.rb
@@ -9,6 +9,7 @@ describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
       name: 'Lewisham Council',
       homepage_url: 'http://www.lewisham.gov.uk')
   }
+  let!(:local_authority_3) { FactoryGirl.create(:local_authority, homepage_url: nil )}
   subject(:status_updater) { described_class.new(link_checker) }
 
   before do
@@ -16,12 +17,20 @@ describe LocalLinksManager::CheckLinks::HomepageStatusUpdater do
   end
 
   describe '#update' do
-    it 'updates the link\'s status code and link last checked time in the database' do
+    it 'updates the link\'s status and link last checked time in the database' do
       allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
       status_updater.update
 
       expect(local_authority_1.reload.status).to eq('200')
       expect(local_authority_2.reload.link_last_checked).to eq(@time)
+    end
+
+    it 'does not update the status and link last checked time of a Local Authority that has a blank homepage url' do
+      allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
+      status_updater.update
+      
+      expect(local_authority_3.reload.status).to be_nil
+      expect(local_authority_3.reload.link_last_checked).to be_nil
     end
   end
 end

--- a/spec/presenters/local_authority_presenter_spec.rb
+++ b/spec/presenters/local_authority_presenter_spec.rb
@@ -38,4 +38,27 @@ describe LocalAuthorityPresenter do
       expect(presenter.homepage_status).to eq('No link')
     end
   end
+
+  describe '#homepage_link_last_checked' do
+    let(:local_authority) { double(:local_authority) }
+    let(:presenter) { described_class.new(local_authority) }
+
+    it 'returns the time the URL was last checked if a URL is present' do
+      time = Timecop.freeze(Time.now)
+      allow(local_authority).to receive(:homepage_url).and_return('http://example.com')
+      allow(local_authority).to receive(:link_last_checked).and_return(time - (60 * 60))
+
+      expect(presenter.homepage_link_last_checked).to eq('Checked about 1 hour ago')
+    end
+
+    it 'returns an empty string if the homepage URL is set to nil' do
+      allow(local_authority).to receive(:homepage_url).and_return(nil)
+      expect(presenter.homepage_link_last_checked).to be_empty
+    end
+
+    it 'returns an empty string if the homepage URL is set to an empty string' do
+      allow(local_authority).to receive(:homepage_url).and_return('')
+      expect(presenter.homepage_link_last_checked).to be_empty
+    end
+  end
 end

--- a/spec/presenters/local_authority_presenter_spec.rb
+++ b/spec/presenters/local_authority_presenter_spec.rb
@@ -17,4 +17,25 @@ describe LocalAuthorityPresenter do
       expect(presenter.homepage_button_text).to eq('Add link')
     end
   end
+
+  describe '#homepage_status' do
+    let(:local_authority) { double(:local_authority) }
+    let(:presenter) { described_class.new(local_authority) }
+
+    it 'returns the homepage URL\'s status description if a URL is present' do
+      allow(local_authority).to receive(:homepage_url).and_return('http://example.com')
+      allow(local_authority).to receive(:status).and_return('200')
+      expect(presenter.homepage_status).to eq('Good')
+    end
+
+    it 'returns "No link" if the homepage URL is set to nil' do
+      allow(local_authority).to receive(:homepage_url).and_return(nil)
+      expect(presenter.homepage_status).to eq('No link')
+    end
+
+    it 'returns "No link" if the homepage URL is set to an empty string' do
+      allow(local_authority).to receive(:homepage_url).and_return('')
+      expect(presenter.homepage_status).to eq('No link')
+    end
+  end
 end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/tibzgu4G/437-fix-homepage-link-status-when-we-don-t-have-a-homepage)

This allows the correct information to be displayed when a Local Authority homepage url is set to nil or an empty string.  Previously, the page displayed 'Link not checked' when a URL was not present.  We now display 'No link' and no last checked time.  Additionally, we found a bug where the link checker was checking blank homepage URLs and returning an 'Invalid URI' error.  This has now been fixed, and blank homepage URLs are no longer checked.

Paired with @klssmith 
