### PR TITLE
Return LocalAuthority details for missing ServiceInteraction

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -19,7 +19,7 @@ private
   end
 
   def missing_objects?
-    authority.nil? || service.nil? || service_interaction_required_but_not_found?
+    authority.nil? || service.nil?
   end
 
   def authority
@@ -28,14 +28,6 @@ private
 
   def service
     @service ||= Service.find_by(lgsl_code: params[:lgsl])
-  end
-
-  def service_interaction_required_but_not_found?
-    params[:lgil] && service_interaction.nil?
-  end
-
-  def service_interaction
-    @service_interaction ||= ServiceInteraction.find_by(service: @service, interaction: interaction)
   end
 
   def interaction

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe "link path", type: :request do
       expect(JSON.parse(response.body)).to eq({})
     end
 
-    it "responds with 404 and {} for unsupported lgsl and lgil combination" do
+    it "responds without link details for unsupported lgsl and lgil combination" do
       link.destroy
       service_interaction.destroy
 
       get "/api/link?authority_slug=blackburn&lgsl=2&lgil=4"
 
-      expect(response.status).to eq(404)
-      expect(JSON.parse(response.body)).to eq({})
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response_with_no_link)
     end
   end
 


### PR DESCRIPTION
When we request a LGSL and LGIL combination from the local links API which does not exist, we should still return the LocalAuthority details. Previously only a 404 and and an empty hash was returned, which meant Frontend was serving its "Sorry, we are experiencing technical difficulties" page. Instead Frontend should show the homepage for the given Service and LocalAuthority.

This fix was prompted by visiting '/report-stray-dog' which is LGSL 432 and LGIL 0. This is a ServiceInteraction that we do not support in LocalLinksManager. We have a story in the Custom Team backlog about coming up with a fix for this missing ServiceInteraction -> https://trello.com/c/y79vHOmC/330-investigate-local-transactions-for-lgsl-432-dog-wardens
