### PR TITLE
Add API endpoint for Find Local Authority

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,22 +4,37 @@ class ApiController < ApplicationController
   skip_before_action :require_signin_permission!
 
   def link
-    return render json: {}, status: 400 if missing_required_params?
-    return render json: {}, status: 404 if missing_objects?
+    return render json: {}, status: 400 if missing_required_params_for_link?
+    return render json: {}, status: 404 if missing_objects_for_link?
 
     @link = LocalLinksManager::LinkResolver.new(authority, service, interaction).resolve
 
     render json: LinkApiResponsePresenter.new(authority, @link).present
   end
 
+  def local_authority
+    return render json: {}, status: 400 if missing_required_params_for_local_authority?
+    return render json: {}, status: 404 if missing_objects_for_local_authority?
+
+    render json: LocalAuthorityApiResponsePresenter.new(authority).present
+  end
+
 private
 
-  def missing_required_params?
+  def missing_required_params_for_link?
     params[:authority_slug].blank? || params[:lgsl].blank?
   end
 
-  def missing_objects?
+  def missing_required_params_for_local_authority?
+    params[:authority_slug].blank?
+  end
+
+  def missing_objects_for_link?
     authority.nil? || service.nil?
+  end
+
+  def missing_objects_for_local_authority?
+    authority.nil?
   end
 
   def authority

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -1,0 +1,32 @@
+class LocalAuthorityApiResponsePresenter
+  def initialize(authority)
+    @authority = authority
+  end
+
+  def present
+    local_authority_json = {
+      "local_authorities" => [
+        present_local_authority(@authority)
+      ]
+    }
+    if parent
+      local_authority_json["local_authorities"] << present_local_authority(parent)
+    end
+
+    local_authority_json
+  end
+
+private
+
+  def present_local_authority(local_authority)
+    {
+      "name" => local_authority.name,
+      "homepage_url" => local_authority.homepage_url,
+      "tier" => local_authority.tier
+    }
+  end
+
+  def parent
+    @parent ||= @authority.parent_local_authority
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
 
   get '/api/link', to: 'api#link'
 
+  get '/api/local-authority', to: 'api#local_authority'
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe LocalAuthorityApiResponsePresenter do
+  describe '#present' do
+    context 'when the local authority has a parent' do
+      let(:parent_local_authority) { FactoryGirl.build(:local_authority) }
+      let(:authority) { FactoryGirl.build(:local_authority, parent_local_authority: parent_local_authority) }
+      let(:presenter) { described_class.new(authority) }
+      let(:expected_response) do
+        {
+          "local_authorities" => [
+            {
+              "name" => authority.name,
+              "homepage_url" => authority.homepage_url,
+              "tier" => authority.tier
+            },
+            {
+              "name" => parent_local_authority.name,
+              "homepage_url" => parent_local_authority.homepage_url,
+              "tier" => parent_local_authority.tier
+            }
+          ]
+        }
+      end
+      it "returns a json with the authority's details and its parent authority details" do
+        expect(presenter.present).to eq(expected_response)
+      end
+    end
+
+    context 'when local authority does not have a parent' do
+      let(:authority) { FactoryGirl.build(:local_authority) }
+      let(:presenter) { described_class.new(authority) }
+      let(:expected_response) do
+        {
+          "local_authorities" => [
+            {
+              "name" => authority.name,
+              "homepage_url" => authority.homepage_url,
+              "tier" => authority.tier
+            }
+          ]
+        }
+      end
+
+      it "returns a json response with unitary local authority details" do
+        expect(presenter.present).to eq(expected_response)
+      end
+    end
+  end
+end

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe "find local authority", type: :request do
+  context "for councils that have a parent authority" do
+    let(:parent_local_authority) {
+      FactoryGirl.create(:local_authority,
+                         name: 'Rochester',
+                         slug: 'rochester',
+                         homepage_url: "http://rochester.example.com",
+                         tier: "county",
+                        )
+    }
+    let!(:local_authority) {
+      FactoryGirl.create(:local_authority,
+                         name: 'Blackburn',
+                         slug: 'blackburn',
+                         homepage_url: "http://blackburn.example.com",
+                         tier: "district",
+                         parent_local_authority: parent_local_authority
+                        )
+    }
+
+    let(:expected_response) do
+      {
+        "local_authorities" => [
+          {
+            "name" => 'Blackburn',
+            "homepage_url" => "http://blackburn.example.com",
+            "tier" => "district"
+          },
+          {
+            "name" => 'Rochester',
+            "homepage_url" => "http://rochester.example.com",
+            "tier" => "county"
+          }
+        ]
+      }
+    end
+
+    it 'returns details of the child and parent in the api response' do
+      get '/api/local-authority?authority_slug=blackburn'
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+  end
+
+  context "for councils that do not have a parent authority" do
+    let!(:local_authority) {
+      FactoryGirl.create(:local_authority,
+                         name: 'Blackburn',
+                         slug: 'blackburn',
+                         homepage_url: "http://blackburn.example.com",
+                         tier: "unitary"
+                        )
+    }
+
+    let(:expected_response) do
+      {
+        "local_authorities" => [
+          {
+            "name" => 'Blackburn',
+            "homepage_url" => "http://blackburn.example.com",
+            "tier" => "unitary"
+          }
+        ]
+      }
+    end
+
+    it 'returns details of the council in the api response' do
+      get '/api/local-authority?authority_slug=blackburn'
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+  end
+
+  context "for requests with missing parameters" do
+    it "returns a 400 status" do
+      get '/api/local-authority'
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+
+  context "for requests with parameters that do not refer to data" do
+    it "returns a 404 status" do
+      get '/api/local-authority?authority_slug=foobar'
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/R2rJjDbs/435-2-of-3-ensure-the-api-supports-find-my-local-council-3)

This adds the `api/local-authority` endpoint for Find Local Authority
