### PR TITLE
Update specs to use mapit gds api adapter test helpers

### DIFF
--- a/lib/local-links-manager/import/local_authorities_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_importer.rb
@@ -51,6 +51,10 @@ module LocalLinksManager
         @response
       end
 
+      def self.local_authority_types
+        LOCAL_AUTHORITY_MAPPING.keys.join(',')
+      end
+
     private
 
       def create_or_update_la(mapit_la)
@@ -75,11 +79,7 @@ module LocalLinksManager
       end
 
       def mapit_service_response
-        Services.mapit.areas_for_type(local_authority_types)
-      end
-
-      def local_authority_types
-        LOCAL_AUTHORITY_MAPPING.keys.join(',')
+        Services.mapit.areas_for_type(self.class.local_authority_types)
       end
 
       def local_authority_hash(parsed_authority)


### PR DESCRIPTION
Since we're using the gds api adapter for MapIt, we should use the test helpers that are provided for MapIt as well. It will keep us in sync with any future work related to MapIt in the gds-api-adapters gem. 
