### PR TITLE
Increase unicorn workers to 4

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,8 @@
+# Load the system-wide standard Unicorn file
+def load_file_if_exists(config, file)
+  config.instance_eval(File.read(file)) if File.exist?(file)
+end
+load_file_if_exists(self, "/etc/govuk/unicorn.rb")
+working_directory File.dirname(File.dirname(__FILE__))
+worker_processes 4
+


### PR DESCRIPTION
Local links manager is now serving production traffic via its API.  We expect the traffic to further increase when we bring the `find-your-local-council` service online.  To ensure that we can manage this extra traffic, we're increasing the number of unicorn worker processes to 4.

This is inline with Imminence which fulfils a similar role for `place` formats as Local Links Manager does for `local_transactions`.

For context, the default configuration is provided by [govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/etc/govuk/unicorn.rb)
We're following the example of [Imminence](https://github.com/alphagov/imminence/blob/master/config/unicorn.rb)
