### PR TITLE
Export local authority links and associated data to a CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@
 /tmp
 /coverage
 
-.DS_Store
+# Ignore /data, 'cause that's where we're storing the data exports.
+public/data/*
+!public/data/.keep
 
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Import all the links for each local authority:
 
 `bundle exec rake import:links:import_all`
 
+### Exporting Local Authority links to services
+
+Exports are run daily and produce a `links.csv` file in the `public/data` directory. This is publicly available data found at `https://local-links-manager.publishing.service.gov.uk/data/links.csv`
+
+`bundle exec rake export:links:all`
+
 ### Example API output
 
 **Endoint for local authorities**

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -13,6 +13,10 @@ class LinksController < ApplicationController
     send_data data, filename: filename
   end
 
+  def exported_links
+    send_file 'public/data/links_to_services_provided_by_local_authorities.csv', type: 'text/csv'
+  end
+
   def edit; end
 
   def update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
   get '/api/local-authority', to: 'api#local_authority'
 
+  get '/links-export', to: 'links#exported_links'
+
   if Rails.env.development?
     mount GovukAdminTemplate::Engine, at: "/style-guide"
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,3 +21,8 @@ end
 every :day, at: '12:30am' do
   rake 'import:local_authorities:add_urls'
 end
+
+# Run the rake task to export data to CSV for data.gov.uk.
+every :day, at: '3am' do
+  rake 'export:links:all'
+end

--- a/lib/local-links-manager/export/links_exporter.rb
+++ b/lib/local-links-manager/export/links_exporter.rb
@@ -1,0 +1,65 @@
+require 'csv'
+
+module LocalLinksManager
+  module Export
+    class LinksExporter
+      HEADINGS = ["Authority Name", "SNAC", "GSS", "Description", "LGSL", "LGIL", "URL", "Supported by GOV.UK"]
+
+      def self.export_links
+        path = Rails.root.join("public", "data", 'links_to_services_provided_by_local_authorities.csv')
+
+        File.open(path, 'w') do |file|
+          new.export(file)
+        end
+      end
+
+      def export(io)
+        output = CSV.generate do |csv|
+          csv << HEADINGS
+          records.each do |record|
+            csv << format(record)
+          end
+        end
+        io.write(output)
+      end
+
+      def records
+        Link.joins(:local_authority, :service, :interaction)
+          .select(
+            "local_authorities.name",
+            :snac,
+            :gss,
+            "services.label as service_label",
+            "interactions.label as interaction_label",
+            :lgsl_code,
+            :lgil_code,
+            :url,
+            :enabled
+          ).order("local_authorities.name", "services.lgsl_code", "interactions.lgil_code").all
+      end
+
+    private
+
+      def format(record)
+        [
+          record.name,
+          snac(record),
+          record.gss,
+          description(record),
+          record.lgsl_code,
+          record.lgil_code,
+          record.url,
+          record.enabled
+        ]
+      end
+
+      def description(record)
+        "#{record.service_label}: #{record.interaction_label}"
+      end
+
+      def snac(record)
+        record.snac unless record.snac == record.gss
+      end
+    end
+  end
+end

--- a/lib/tasks/export/link_exporter.rake
+++ b/lib/tasks/export/link_exporter.rake
@@ -1,0 +1,23 @@
+require 'local-links-manager/distributed_lock'
+require 'local-links-manager/export/links_exporter'
+
+namespace :export do
+  namespace :links do
+    desc "Export links to CSV"
+    task "all": :environment do
+      service_desc = "Export links to CSV from local-links-manager"
+      begin
+        Rails.logger.info("Starting link exporter")
+        Services.icinga_check(service_desc, true, "Starting link exporter")
+
+        LocalLinksManager::Export::LinksExporter.export_links
+        Rails.logger.info("Link export to CSV completed")
+        Services.icinga_check(service_desc, true, "Success")
+      rescue StandardError => e
+        Rails.logger.error("Error while running link exporter\n#{e}")
+        Services.icinga_check(service_desc, false, e.to_s)
+        raise e
+      end
+    end
+  end
+end

--- a/spec/lib/local-links-manager/export/fixtures/exported_links.csv
+++ b/spec/lib/local-links-manager/export/fixtures/exported_links.csv
@@ -1,0 +1,6 @@
+Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK
+Exeter,00AD,456,Service 123: Interaction 0,123,0,http://exeter.example.com/service-123/interaction-0,true
+Exeter,00AD,456,Service 123: Interaction 1,123,1,http://exeter.example.com/service-123/interaction-1,true
+Exeter,00AD,456,Service 666: Interaction 0,666,0,http://exeter.example.com/service-666/interaction-0,false
+London,00AB,123,Service 123: Interaction 0,123,0,http://london.example.com/service-123/interaction-0,true
+London,00AB,123,Service 123: Interaction 1,123,1,http://london.example.com/service-123/interaction-1,true

--- a/spec/lib/local-links-manager/export/fixtures/ni_link.csv
+++ b/spec/lib/local-links-manager/export/fixtures/ni_link.csv
@@ -1,0 +1,2 @@
+Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK
+Belfast,,456,Service 123: Interaction 1,123,1,http://belfast.example.com/service-123/interaction-1,true

--- a/spec/lib/local-links-manager/export/links_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/links_exporter_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require 'local-links-manager/export/links_exporter'
+
+describe LocalLinksManager::Export::LinksExporter do
+  def fixture_file(file)
+    File.expand_path("fixtures/" + file, File.dirname(__FILE__))
+  end
+
+  let(:exporter) { LocalLinksManager::Export::LinksExporter.new }
+
+  describe '#export_links' do
+    it "exports the links to CSV format with headings" do
+      service = FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+      disabled_service = FactoryGirl.create(:disabled_service, lgsl_code: 666, label: 'Service 666')
+      interaction_0 = FactoryGirl.create(:interaction, lgil_code: 0, label: 'Interaction 0')
+      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      service_interaction_0 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_0)
+      service_interaction_1 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1)
+      disabled_service_interaction = FactoryGirl.create(:service_interaction, service: disabled_service, interaction: interaction_0)
+
+      local_authority_1 = FactoryGirl.create(:local_authority, name: 'London', snac: '00AB', gss: '123')
+      local_authority_2 = FactoryGirl.create(:local_authority, name: 'Exeter', snac: '00AD', gss: '456')
+
+      FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_0)
+      FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1)
+      FactoryGirl.create(:link, local_authority: local_authority_2, service_interaction: service_interaction_0)
+      FactoryGirl.create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1)
+      FactoryGirl.create(:link, local_authority: local_authority_2, service_interaction: disabled_service_interaction)
+
+      csv_file = File.read(fixture_file("exported_links.csv"))
+
+      StringIO.open do |io|
+        exporter.export(io)
+        expect(io.string).to eq(csv_file)
+      end
+    end
+
+    it "should use empty string if we don't have a real SNAC code" do
+      service = FactoryGirl.create(:service, lgsl_code: 123, label: 'Service 123')
+      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      service_interaction_1 = FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1)
+
+      pretend_ni_authority = FactoryGirl.create(:local_authority, name: 'Belfast', snac: '456', gss: '456')
+
+      FactoryGirl.create(:link, local_authority: pretend_ni_authority, service_interaction: service_interaction_1)
+
+      csv_file = File.read(fixture_file("ni_link.csv"))
+
+      StringIO.open do |io|
+        exporter.export(io)
+        expect(io.string).to eq(csv_file)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add class, tests and route to export all links to csv.
- Add rake task.
- The plan is to put these on data.gov.uk and for them to be as
  close to the old LDG CSVs as possible so people can still use
  them.
- Add a scheduled job to run the export rake task daily at 3am
- There is a symlink from `shared/data` to `public/data` inside the current release on each backend box. This done in `govuk-app-deployment` to persist the data between releases.

We don't want to use a distributed lock on this task as we need the file to
exist on each host.

[Trello card](https://trello.com/c/dFFQRlsp/448-generate-local-links-csv-3)

Mobbed with @brenetic @issyl0 
