### PR TITLE
Remove authentication for csv export

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,5 +1,6 @@
 class LinksController < ApplicationController
   before_action :load_dependencies
+  skip_before_action :require_signin_permission!, only: :exported_links
 
   def homepage_links_status_csv
     data = LinkCheckCSVPresenter.homepage_links_status_csv


### PR DESCRIPTION
We need the `/links-export` endpoint to open to the public therefore we
are skipping signon authentication for it.

[Trello card](https://trello.com/c/dFFQRlsp/448-generate-local-links-csv-3)
