### PR TITLE
Manually unlock locked rake tasks

### DIFF
--- a/lib/local-links-manager/distributed_lock.rb
+++ b/lib/local-links-manager/distributed_lock.rb
@@ -2,20 +2,34 @@ require 'redis-lock'
 
 module LocalLinksManager
   class DistributedLock
+    attr_accessor :lock_name, :redis_lock
+
+    APP = "local-links-manager"
     LIFETIME = (60 * 60) # seconds
 
     def initialize(lock_name)
       @lock_name = lock_name
+      @redis_lock = Redis::Lock.new(Services.redis, "#{APP}:#{lock_name}", owner: APP, life: LIFETIME)
     end
 
     def lock(lock_obtained:, lock_not_obtained:)
-      Services.redis.lock("local-links-manager:#{Rails.env}:#{@lock_name}", life: LIFETIME) do
-        Rails.logger.debug('Successfully got a lock. Running...')
-        lock_obtained.call
-      end
+      redis_lock.lock
+      Rails.logger.debug('Successfully got a lock. Running...')
+      lock_obtained.call
     rescue Redis::Lock::LockNotAcquired => e
-      Rails.logger.debug("Failed to get lock for #{@lock_name} (#{e.message}). Another process probably got there first.")
+      Rails.logger.debug("Failed to get lock for #{lock_name} (#{e.message}). Another process probably got there first.")
       lock_not_obtained.call
+    end
+
+    def unlock
+      redis_lock.unlock
+      Rails.logger.debug("Successfully unlocked #{lock_name}")
+    rescue StandardError => e
+      Rails.logger.error("Failed to unlock #{lock_name}\n#{e.message}")
+    end
+
+    def locked?
+      redis_lock.locked?
     end
   end
 end

--- a/lib/tasks/remove_lock.rake
+++ b/lib/tasks/remove_lock.rake
@@ -1,0 +1,16 @@
+require 'redis-lock'
+
+desc "Unlock lock"
+task :unlock, [] => :environment do |_task, args|
+  if args.extras.empty?
+    puts "Pass in a lock key. Eg. unlock['check-links']"
+  else
+    lock = LocalLinksManager::DistributedLock.new("#{args.extras.first}")
+    if lock.locked?
+      lock.unlock
+      puts "#{args.extras.first} successfully unlocked."
+    else
+      puts "No lock exists for #{args.extras.first}"
+    end
+  end
+end


### PR DESCRIPTION
There have been instances where rake tasks have not completed for
for some reason leaving the Distributed Lock for that task in
place. It is then necessary to wait for the lifetime of the lock
to end before being able to run task again.

This rake task adds the ability for the lock to be removed for the
given task passed in.

`Rails.env` was removed from the key as it was felt to be
superfluous since all rake tasks run in the same environment.

[Trello card](https://trello.com/c/OtTKMe3H/465-enable-unlocking-of-scheduled-tasks-2-pair-with-katie-pls)
