### PR TITLE
Use correct variables in Summariser#import_summary

### DIFF
--- a/lib/local-links-manager/import/summariser.rb
+++ b/lib/local-links-manager/import/summariser.rb
@@ -49,7 +49,7 @@ module LocalLinksManager
 
       def summary
         "#{@name} complete\n"\
-        "#{@data_items_name}: #{@data_items_count}\n"\
+        "#{@import_source_name}: #{@import_source_count}\n"\
         "Updated records: #{@updated_record_count}\n"\
         "Ignored source items: #{@ignored_items_count}\n"\
         "Import errors with missing Identifier: #{@missing_id_count}\n"\


### PR DESCRIPTION
While building we flipped from `data_source_xxx` to `import_source_xxx`
as the names for the internal variables to record the name and count
values for the imported data.  We changed the initializer and increment
methods, but forgot to change the reference in the `#import_summary`
methods.  Happily, ruby will treat all instance variable references as
`nil`, so nothing breaks but we do get odd log output.
