### PR TITLE
Strip white space around interaction URLs

### DIFF
--- a/db/migrate/20161014123008_strip_urls.rb
+++ b/db/migrate/20161014123008_strip_urls.rb
@@ -1,0 +1,8 @@
+class StripUrls < ActiveRecord::Migration
+  def change
+    Link.all.each do |link|
+      link.url.strip!
+      link.save! if link.url_changed?
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160729113356) do
+ActiveRecord::Schema.define(version: 20161014123008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We have ~240 URLs that fail link checking because of `Invalid URI`.  A short
investigation revealed that ~220 of these have trailing white space on the URL
which will cause URI.parse to throw `URI::InvalidURIError` before they get a 
chance to be link checked.  (They may have other problems as well)

We already have code to strip white space in [links_controller](https://github.com/alphagov/local-links-manager/blob/16c4f0ae9f48f72a981a5142b1e5619fdc416fd4/app/controllers/links_controller.rb#L19) and
[local_authorities_controller](https://github.com/alphagov/local-links-manager/blob/16c4f0ae9f48f72a981a5142b1e5619fdc416fd4/app/controllers/local_authorities_controller.rb#L12), but this is only called when a URL is edited.

`homepage_urls` are not affected by this problem.
