### PR TITLE
All councils page.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
     ast (2.3.0)
-    autoprefixer-rails (6.5.1.1)
+    autoprefixer-rails (6.5.2)
       execjs
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -116,7 +116,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_admin_template (4.4.1)
+    govuk_admin_template (4.4.2)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.1.1)
       rails (>= 3.2.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
  *= require_self
  */
 @import 'govuk_admin_template';
+@import 'components/tables';
 
 .no-gutter {
   padding-right:0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,29 @@
   padding-right:0;
   padding-left:0;
 }
+
+.nav.nav-tabs {
+  *[role='presentation'] {
+    a {
+      background-color: $component-active-bg;
+      color: $component-active-color;
+      border-bottom-color: $nav-tabs-border-color;
+      &:hover {
+        background-color: darken($component-active-bg, 15%);
+        border-color: darken($component-active-bg, 15%);
+      };
+      margin-right: 10px;
+    }
+    &.active {
+      a {
+        background-color: $body-bg;
+        border-bottom-color: $body-bg;
+        color: $text-color;
+        &:hover {
+          border-color: $nav-tabs-border-color;
+          border-bottom-color: $body-bg;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -13,7 +13,7 @@ table.table-with-counts {
       }
     }
 
-    .local-authority-name {
+    .name {
       font-weight: bold;
       font-size: 1.25em;
     }
@@ -21,4 +21,30 @@ table.table-with-counts {
 
   th .count span { padding-right: 4px; }
   td .count span { display: block; }
+}
+
+table.table-with-controls {
+  th, td {
+    float: left;
+    width: 100%;
+
+    .sort-order-dropdown {
+      float: left;
+      width: 22%;
+    }
+
+    .filter-control {
+      float: left;
+      width: 78%;
+
+      @media (max-width: 1199px){
+        clear: left;
+        margin-top: 20px;
+      }
+
+       @media (max-width: 991px){
+        width: 100%;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -1,0 +1,24 @@
+table.table-with-counts {
+  font-size: 1.2em;
+
+  th, td {
+    .count {
+      float:right;
+      font-size: 75%;
+
+      span {
+        font-size: 3.8em;
+        font-weight: bold;
+        margin-left: -11px;
+      }
+    }
+
+    .local-authority-name {
+      font-weight: bold;
+      font-size: 1.25em;
+    }
+  }
+
+  th .count span { padding-right: 4px; }
+  td .count span { display: block; }
+}

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -1,0 +1,23 @@
+module Sortable
+  extend ActiveSupport::Concern
+
+  included do
+    def current_sort_order
+      {
+        description: I18n.t(sort_order.keys.first),
+        param: sort_order.keys.first
+      }
+    end
+    helper_method :current_sort_order
+
+    def all_sort_order_options
+      sort_order_options.map do |key, _|
+        {
+          description: I18n.t(key),
+          param: key
+        }
+      end
+    end
+    helper_method :all_sort_order_options
+  end
+end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -19,6 +19,7 @@ class LinksController < ApplicationController
     @link.url = params[:link][:url].strip
 
     if @link.save
+      @link.local_authority.update_broken_link_count
       redirect
     else
       flash.now[:danger] = "Please enter a valid link."

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -1,6 +1,8 @@
 class LocalAuthoritiesController < ApplicationController
+  include Sortable
+
   def index
-    @authorities = LocalAuthority.all.order(name: :asc)
+    @authorities = LocalAuthority.all.order(sort_order)
   end
 
   def edit
@@ -23,5 +25,21 @@ private
       flash.now[:danger] = "Please enter a valid link."
       render :edit
     end
+  end
+
+  def sort_order
+    order = params[:sort_order] || default_sort_order
+    sort_order_options.select { |k, _v| k == order.to_sym }
+  end
+
+  def default_sort_order
+    :broken_link_count
+  end
+
+  def sort_order_options
+    {
+      broken_link_count: :desc,
+      name: :asc
+    }
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -19,6 +19,11 @@ class Link < ApplicationRecord
       .where(service_interactions: { service_id: service })
   }
 
+  HTTP_OK_STATUS_CODE = 200
+
+  scope :currently_broken, -> { where.not(status: HTTP_OK_STATUS_CODE) }
+  scope :have_been_checked, -> { where.not(status: nil) }
+
   def self.enabled_links
     self.joins(:service).where(services: { enabled: true })
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,6 @@
 class Link < ApplicationRecord
   before_update :set_time_and_status_on_updated_link, if: :url_changed?
+  after_save :trigger_recount_of_broken_links, if: :status_changed?
   before_create :set_time_and_status_on_new_link
 
   belongs_to :local_authority
@@ -76,5 +77,9 @@ private
   def set_status_and_last_checked_for(link)
     self.status = link.status
     self.link_last_checked = link.link_last_checked
+  end
+
+  def trigger_recount_of_broken_links
+    local_authority.calculate_count_of_broken_links
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,6 +1,5 @@
 class Link < ApplicationRecord
   before_update :set_time_and_status_on_updated_link, if: :url_changed?
-  after_save :trigger_recount_of_broken_links, if: :status_changed?
   before_create :set_time_and_status_on_new_link
 
   belongs_to :local_authority
@@ -82,9 +81,5 @@ private
   def set_status_and_last_checked_for(link)
     self.status = link.status
     self.link_last_checked = link.link_last_checked
-  end
-
-  def trigger_recount_of_broken_links
-    local_authority.calculate_count_of_broken_links
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -14,11 +14,11 @@ class LocalAuthority < ApplicationRecord
     Service.for_tier(self.tier).enabled
   end
 
-  def calculate_count_of_broken_links
-    # to ensure that we can replay our migrations, wrap the update in a guard clause.
-    if respond_to?(:broken_link_count)
-      update_attribute(:broken_link_count, self.links.where.not(status: 200).count)
-    end
+  def update_broken_link_count
+    update_attribute(
+      :broken_link_count,
+      links.have_been_checked.currently_broken.count
+    )
   end
 
 private

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -14,6 +14,13 @@ class LocalAuthority < ApplicationRecord
     Service.for_tier(self.tier).enabled
   end
 
+  def calculate_count_of_broken_links
+    # to ensure that we can replay our migrations, wrap the update in a guard clause.
+    if respond_to?(:broken_link_count)
+      update_attribute(:broken_link_count, self.links.where.not(status: 200).count)
+    end
+  end
+
 private
 
   def reset_time_and_status

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -9,12 +9,15 @@
 <%= render partial: 'shared/home_nav' %>
 
 <% if @authorities.any? %>
-  <table class="table table-bordered table-with-counts" data-module="filterable-table">
+  <table class="table table-bordered table-with-counts table-with-controls" data-module="filterable-table">
     <thead>
       <tr class="table-header">
         <th>
           <div class='sort-order-dropdown'>
             <%= render partial: "shared/sort_order_dropdown" %>
+          </div>
+          <div class='filter-control'>
+            <%= render partial: "govuk_admin_template/table_filter_form" %>
           </div>
           <div class='count'>
             <span><%= @authorities.count %></span>
@@ -27,7 +30,7 @@
       <% @authorities.each do |authority| %>
         <tr>
           <td>
-            <%= link_to authority.name, local_authority_services_path(authority.slug), class: 'js-open-on-submit local-authority-name' %>
+            <%= link_to authority.name, local_authority_services_path(authority.slug), class: 'js-open-on-submit name' %>
             <div class="count">
               <span><%= authority.broken_link_count %></span>
               <%= 'Broken link'.pluralize(authority.broken_link_count) %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -10,7 +10,12 @@
   <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
     <thead>
       <tr class="table-header">
-        <th>Local Authorities (<%= @authorities.count %>)</th>
+        <th>
+          <div class='count'>
+            <span><%= @authorities.count %></span>
+            <%= 'local authorities'.pluralize(@authorities.count) %>
+          </div>
+        </th>
       </tr>
       <%= render partial: "govuk_admin_template/table_filter",
       locals: {placeholder: "Filter list of local authorities"} %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -9,7 +9,7 @@
 <%= render partial: 'shared/home_nav' %>
 
 <% if @authorities.any? %>
-  <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
+  <table class="table table-bordered table-with-counts" data-module="filterable-table">
     <thead>
       <tr class="table-header">
         <th>
@@ -22,14 +22,16 @@
           </div>
         </th>
       </tr>
-      <%= render partial: "govuk_admin_template/table_filter",
-      locals: {placeholder: "Filter list of local authorities"} %>
     </thead>
     <tbody>
       <% @authorities.each do |authority| %>
         <tr>
-          <td class="name">
-            <%= link_to authority.name, local_authority_services_path(authority.slug), class: 'js-open-on-submit' %>
+          <td>
+            <%= link_to authority.name, local_authority_services_path(authority.slug), class: 'js-open-on-submit local-authority-name' %>
+            <div class="count">
+              <span><%= authority.broken_link_count %></span>
+              <%= 'Broken link'.pluralize(authority.broken_link_count) %>
+            </div>
           </td>
         </tr>
       <% end %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -13,6 +13,9 @@
     <thead>
       <tr class="table-header">
         <th>
+          <div class='sort-order-dropdown'>
+            <%= render partial: "shared/sort_order_dropdown" %>
+          </div>
           <div class='count'>
             <span><%= @authorities.count %></span>
             <%= 'local authorities'.pluralize(@authorities.count) %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -6,6 +6,8 @@
   <h1>Local Authorities</h1>
 </div>
 
+<%= render partial: 'shared/home_nav' %>
+
 <% if @authorities.any? %>
   <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
     <thead>

--- a/app/views/shared/_home_nav.html.erb
+++ b/app/views/shared/_home_nav.html.erb
@@ -1,0 +1,5 @@
+<nav class="home-nav">
+  <ul class="nav nav-tabs">
+    <li role="presentation"<% if controller_name == 'local_authorities' %> class="active"<% end %>><%= link_to 'View all councils', local_authorities_path %></li>
+  </ul>
+</nav>

--- a/app/views/shared/_sort_order_dropdown.html.erb
+++ b/app/views/shared/_sort_order_dropdown.html.erb
@@ -1,0 +1,12 @@
+<div class="dropdown">
+  <button class="btn btn-default dropdown-toggle" type="button" id="sort-services-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+    Sort by: <%= current_sort_order[:description] %>
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="sort-services-dropdown">
+    <% all_sort_order_options.each do |sort_order_option| %>
+      <li><%= link_to sort_order_option[:description],
+                      url_for(params.permit!.merge(sort_order: sort_order_option[:param])) %></li>
+    <% end %>
+  </ul>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,5 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  broken_link_count: Number of broken links
+  name: A-Z

--- a/db/migrate/20161104150651_add_broken_link_count_to_local_authority.rb
+++ b/db/migrate/20161104150651_add_broken_link_count_to_local_authority.rb
@@ -1,0 +1,11 @@
+class AddBrokenLinkCountToLocalAuthority < ActiveRecord::Migration[5.0]
+  def up
+    add_column :local_authorities, :broken_link_count, :integer, default: 0
+
+    LocalAuthority.all.map(&:calculate_count_of_broken_links)
+  end
+
+  def down
+    remove_column :local_authorities, :broken_link_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161014123008) do
+ActiveRecord::Schema.define(version: 20161104150651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,17 +39,18 @@ ActiveRecord::Schema.define(version: 20161014123008) do
   end
 
   create_table "local_authorities", force: :cascade do |t|
-    t.string   "gss",                       null: false
+    t.string   "gss",                                   null: false
     t.string   "homepage_url"
-    t.string   "name",                      null: false
-    t.string   "slug",                      null: false
-    t.string   "snac",                      null: false
-    t.string   "tier",                      null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string   "name",                                  null: false
+    t.string   "slug",                                  null: false
+    t.string   "snac",                                  null: false
+    t.string   "tier",                                  null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "status"
     t.datetime "link_last_checked"
     t.integer  "parent_local_authority_id"
+    t.integer  "broken_link_count",         default: 0
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true, using: :btree
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true, using: :btree
     t.index ["snac"], name: "index_local_authorities_on_snac", unique: true, using: :btree

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -3,29 +3,29 @@ require 'local-links-manager/check_links/link_checker'
 module LocalLinksManager
   module CheckLinks
     class LinkStatusUpdater
-      attr_reader :url_checker
-
-      def initialize(url_checker = LinkChecker.new)
-        @url_checker = url_checker
+      def initialize(link_checker = LinkChecker.new)
+        @link_checker = link_checker
       end
 
       def update
-        links.each do |url|
-          response = url_checker.check_link(url)
-          update_link(url, response)
+        urls_for_enabled_services.each do |url|
+          link_checker_response = link_checker.check_link(url)
+          update_link(url, link_checker_response)
         end
       end
 
     private
 
-      def links
+      attr_reader :link_checker
+
+      def urls_for_enabled_services
         Link.enabled_links.distinct.pluck(:url)
       end
 
-      def update_link(url, link_response)
+      def update_link(url, link_checker_response)
         Link.where(url: url).update_all(
-          status: link_response[:status],
-          link_last_checked: link_response[:checked_at],
+          status: link_checker_response[:status],
+          link_last_checked: link_checker_response[:checked_at],
         )
       end
     end

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -8,27 +8,20 @@ module LocalLinksManager
       end
 
       def update
-        check_all_links
-        update_local_authorities_with_broken_link_count
+        urls_for_enabled_services.each do |url|
+          link_checker_response = link_checker.check_link(url)
+          update_link(url, link_checker_response)
+          update_local_authority_broken_link_count(url)
+        end
       end
 
     private
 
       attr_reader :link_checker
 
-      def check_all_links
-        urls_for_enabled_services.each do |url|
-          link_checker_response = link_checker.check_link(url)
-          update_link(url, link_checker_response)
-        end
-      end
-
-      def update_local_authorities_with_broken_link_count
-        LocalAuthority.all.each do |local_authority|
-          local_authority.update_attribute(
-            :broken_link_count,
-            local_authority.links.have_been_checked.currently_broken.count
-          )
+      def update_local_authority_broken_link_count(url)
+        Link.where(url: url).each do |link|
+          link.local_authority.update_broken_link_count
         end
       end
 

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -8,15 +8,29 @@ module LocalLinksManager
       end
 
       def update
+        check_all_links
+        update_local_authorities_with_broken_link_count
+      end
+
+    private
+
+      attr_reader :link_checker
+
+      def check_all_links
         urls_for_enabled_services.each do |url|
           link_checker_response = link_checker.check_link(url)
           update_link(url, link_checker_response)
         end
       end
 
-    private
-
-      attr_reader :link_checker
+      def update_local_authorities_with_broken_link_count
+        LocalAuthority.all.each do |local_authority|
+          local_authority.update_attribute(
+            :broken_link_count,
+            local_authority.links.have_been_checked.currently_broken.count
+          )
+        end
+      end
 
       def urls_for_enabled_services
         Link.enabled_links.distinct.pluck(:url)

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -3,29 +3,27 @@ require 'local-links-manager/check_links/link_checker'
 module LocalLinksManager
   module CheckLinks
     class LinkStatusUpdater
-      attr_reader :column, :table, :url_checker
+      attr_reader :url_checker
 
       def initialize(url_checker = LinkChecker.new)
-        @table = Link
-        @column = :url
         @url_checker = url_checker
       end
 
       def update
-        links.each do |link|
-          link_response = url_checker.check_link(link)
-          update_link(link, link_response)
+        links.each do |url|
+          response = url_checker.check_link(url)
+          update_link(url, response)
         end
       end
 
     private
 
       def links
-        table.joins(:service).where(services: { enabled: true }).distinct.pluck(column)
+        Link.enabled_links.distinct.pluck(:url)
       end
 
-      def update_link(link, link_response)
-        table.where(column => link).update_all(
+      def update_link(url, link_response)
+        Link.where(url: url).update_all(
           status: link_response[:status],
           link_last_checked: link_response[:checked_at],
         )

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -19,8 +19,7 @@ feature "The local authorities index page" do
   describe "with local authorities present" do
     before do
       @angus = FactoryGirl.create(:local_authority, name: 'Angus')
-      @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', gss: 'XXXXXXXXX', snac: 'ZZZZ')
-      FactoryGirl.create(:link, :with_service_interaction, local_authority: @zorro, status: 500)
+      @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', broken_link_count: 1)
 
       visit root_path
     end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -20,6 +20,8 @@ feature "The local authorities index page" do
     before do
       @angus = FactoryGirl.create(:local_authority, name: 'Angus')
       @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', gss: 'XXXXXXXXX', snac: 'ZZZZ')
+      FactoryGirl.create(:link, :with_service_interaction, local_authority: @zorro, status: 500)
+
       visit root_path
     end
 
@@ -34,6 +36,30 @@ feature "The local authorities index page" do
         click_link('Angus')
         expect(current_path).to eq(local_authority_services_path(@angus.slug))
       end
+    end
+
+    context "the sort order" do
+      it "defaults to Number of Broken Links, but we can change it to A-Z" do
+        expect('Zorro Council').to appear_before "Angus"
+        change_sort_order_to_alphabetical
+        expect('Angus').to appear_before 'Zorro Council'
+        change_sort_order_to_number_of_broken_links
+        expect('Zorro Council').to appear_before "Angus"
+      end
+    end
+  end
+
+  def change_sort_order_to_alphabetical
+    click_button "Sort by: Number of broken links"
+    within 'ul.dropdown-menu' do
+      click_link 'A-Z'
+    end
+  end
+
+  def change_sort_order_to_number_of_broken_links
+    click_button "Sort by: A-Z"
+    within 'ul.dropdown-menu' do
+      click_link 'Number of broken links'
     end
   end
 end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -24,7 +24,7 @@ feature "The local authorities index page" do
     end
 
     it "shows the available local authorities with links to their respective pages" do
-      expect(page).to have_content 'Local Authorities (2)'
+      expect(page).to have_content '2 local authorities'
       expect(page).to have_link('Angus', href: local_authority_services_path(@angus.slug))
       expect(page).to have_link('Zorro Council', href: local_authority_services_path(@zorro.slug))
     end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -31,6 +31,11 @@ feature "The local authorities index page" do
       expect(page).to have_link('Zorro Council', href: local_authority_services_path(@zorro.slug))
     end
 
+    it "shows the count of broken links for each local authority" do
+      expect(page).to have_content "Angus 0 Broken links"
+      expect(page).to have_content "Zorro Council 1 Broken link"
+    end
+
     describe "clicking on the LA name on the index page" do
       it "takes you to the show page for that LA" do
         click_link('Angus')

--- a/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_status_updater_spec.rb
@@ -11,8 +11,9 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
 
   describe '#update' do
     context "with links for enabled Services" do
-      let!(:link_1) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/schools/attendance/Pages/Educating-your-child-at-home.aspx') }
-      let!(:link_2) { FactoryGirl.create(:link, url: 'http://www.lewisham.gov.uk/myservices/education/student-pupil-support/Pages/default.aspx') }
+      let(:local_authority) { FactoryGirl.create(:local_authority, broken_link_count: 2) }
+      let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority, url: 'http://www.lewisham.gov.uk/myservices/education/schools/attendance/Pages/Educating-your-child-at-home.aspx') }
+      let!(:link_2) { FactoryGirl.create(:link, local_authority: local_authority, url: 'http://www.lewisham.gov.uk/myservices/education/student-pupil-support/Pages/default.aspx') }
 
       it 'updates the link\'s status code and link last checked time in the database' do
         allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
@@ -21,6 +22,13 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater do
 
         expect(link_1.reload.status).to eq('200')
         expect(link_2.reload.link_last_checked).to eq(@time)
+      end
+
+      it 'updates the Local Authorities broken_link_count' do
+        allow(link_checker).to receive(:check_link).and_return(status: '200', checked_at: @time)
+        expect { status_updater.update }
+          .to change { local_authority.reload.broken_link_count }
+          .from(2).to(0)
       end
 
       context "with duplicate links" do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -155,13 +155,4 @@ RSpec.describe Link, type: :model do
     expect(@link.status).to be nil
     expect(@link.link_last_checked).to be nil
   end
-
-  describe "after_update" do
-    it "triggers a recount of the local authority's broken links" do
-      local_authority = FactoryGirl.create(:local_authority)
-      link = FactoryGirl.create(:link, local_authority: local_authority)
-      expect(local_authority).to receive(:calculate_count_of_broken_links)
-      link.update_attribute(:status, 500)
-    end
-  end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -155,4 +155,13 @@ RSpec.describe Link, type: :model do
     expect(@link.status).to be nil
     expect(@link.link_last_checked).to be nil
   end
+
+  describe "after_update" do
+    it "triggers a recount of the local authority's broken links" do
+      local_authority = FactoryGirl.create(:local_authority)
+      link = FactoryGirl.create(:link, local_authority: local_authority)
+      expect(local_authority).to receive(:calculate_count_of_broken_links)
+      link.update_attribute(:status, 500)
+    end
+  end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -76,13 +76,23 @@ RSpec.describe LocalAuthority, type: :model do
         expect(@local_authority.link_last_checked).to be_nil
       end
     end
+  end
 
-    describe "calculate_count_of_broken_links" do
-      it "calculates the correct number of broken for the local authority" do
-        local_authority = FactoryGirl.create(:local_authority)
-        FactoryGirl.create(:link, :with_service_interaction, local_authority: local_authority, status: 500)
-        expect { local_authority.calculate_count_of_broken_links }.to change { local_authority.broken_link_count }.from(0).to(1)
-      end
+  describe "#update_broken_link_count" do
+    it "updates the broken_link_count" do
+      link = FactoryGirl.create(:link, status: 500)
+      local_authority = link.local_authority
+      expect { local_authority.update_broken_link_count }
+        .to change { local_authority.broken_link_count }
+        .from(0).to(1)
+    end
+
+    it "ignores unchecked links" do
+      local_authority = FactoryGirl.create(:local_authority, broken_link_count: 1)
+      FactoryGirl.create(:link, local_authority: local_authority, status: nil)
+      expect { local_authority.update_broken_link_count }
+        .to change { local_authority.broken_link_count }
+        .from(1).to(0)
     end
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -76,5 +76,13 @@ RSpec.describe LocalAuthority, type: :model do
         expect(@local_authority.link_last_checked).to be_nil
       end
     end
+
+    describe "calculate_count_of_broken_links" do
+      it "calculates the correct number of broken for the local authority" do
+        local_authority = FactoryGirl.create(:local_authority)
+        FactoryGirl.create(:link, :with_service_interaction, local_authority: local_authority, status: 500)
+        expect { local_authority.calculate_count_of_broken_links }.to change { local_authority.broken_link_count }.from(0).to(1)
+      end
+    end
   end
 end

--- a/spec/support/appear_before_matcher.rb
+++ b/spec/support/appear_before_matcher.rb
@@ -1,0 +1,32 @@
+module SortOrderMatchers
+  class AppearBeforeMatcher < Capybara::RSpecMatchers::Matcher
+    def initialize(*later_content)
+      @later_content = later_content[0]
+    end
+
+    def matches?(earlier_content)
+      @earlier_content = earlier_content
+      page.body.index(earlier_content) < page.body.index(@later_content)
+    end
+
+    def description
+      "appear in the rendered page before #{@later_content}"
+    end
+
+    def failure_message
+      "Expected to find #{@earlier_content} in the page before #{@later_content} but it isn't"
+    end
+
+    def page
+      Capybara.current_session
+    end
+  end
+
+  def appear_before(later_content)
+    AppearBeforeMatcher.new(later_content)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SortOrderMatchers, type: :feature
+end


### PR DESCRIPTION
A sortable, filterable index page to browse all local authorities. 

https://trello.com/c/6xQryalX/537-update-view-all-councils-page-5

<img width="1174" alt="llm-all-councils-implementation" src="https://cloud.githubusercontent.com/assets/608867/20133602/19ed47ea-a660-11e6-9f85-914963c7ffbf.png">

Missing from the design is the fancy-pants search/filtering widget. There was some feedback from the user tests that I think we wanted to discuss before investing too much time in a build.  This solution uses the Table Filter from `govuk_admin_template` which does the basics for us.  A more sophisticated thing could be built on top of this, once we're sure what to go for.
 
