### PR TITLE
Migrate Airbrake from v4 to v5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,5 @@ end
 
 gem 'plek', '~> 1.10'
 gem 'airbrake', '~> 5.6.1'
+gem 'airbrake-ruby', '1.6'
 gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (~> 5.6.1)
+  airbrake-ruby (= 1.6)
   capistrano-rails
   capybara (~> 2.7)
   factory_girl_rails (~> 4.7)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.api_key = ENV['ERRBIT_API_KEY']
-    config.host = errbit_uri.host
-    config.secure = errbit_uri.scheme == 'https'
-    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.project_key = ENV['ERRBIT_API_KEY']
+    config.project_id = 1 #dummy, not used in Errbit
+    config.host = errbit_uri.to_s
+    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
   end
 end


### PR DESCRIPTION
When we upgraded to Rails 5 we also upgraded the `airbrake` Gem from v4 to v5.
This was a significant change which needs us to add the `airbrake-ruby` gem to
 keep core functionality, and also change some of the initializer code to set
 it up properly.  We're currently not able to deploy Local Links Manager
 because [we're setting variables which no longer exist][1].

I've added the `airbrake-ruby` Gem and changed the initializer code to follow
[the migration guide][2] so this should now work.

[1]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/7932/console
[2]: https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md