### PR TITLE
Update method call in broken link count migration

### DIFF
--- a/db/migrate/20161104150651_add_broken_link_count_to_local_authority.rb
+++ b/db/migrate/20161104150651_add_broken_link_count_to_local_authority.rb
@@ -2,7 +2,7 @@ class AddBrokenLinkCountToLocalAuthority < ActiveRecord::Migration[5.0]
   def up
     add_column :local_authorities, :broken_link_count, :integer, default: 0
 
-    LocalAuthority.all.map(&:calculate_count_of_broken_links)
+    LocalAuthority.all.map(&:update_broken_link_count)
   end
 
   def down


### PR DESCRIPTION
This method was renamed so this migration would have failed.