### PR TITLE
[DO NOT MERGE] Remodelling Tier relationships

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,11 +4,10 @@ class LocalAuthority < ApplicationRecord
   validates :gss, :snac, :slug, uniqueness: true
   validates :gss, :name, :snac, :tier, :slug, presence: true
   validates :homepage_url, non_blank_url: true, allow_blank: true
-  validates :tier, inclusion: { in: %w(county district unitary),
-    message: "%{value} is not an allowed tier" }
 
   has_many :links
   belongs_to :parent_local_authority, foreign_key: :parent_local_authority_id, class_name: "LocalAuthority"
+  belongs_to :tier
 
   def provided_services
     Service.for_tier(self.tier).enabled

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,6 +4,7 @@ class LocalAuthority < ApplicationRecord
   validates :gss, :snac, :slug, uniqueness: true
   validates :gss, :name, :snac, :tier, :slug, presence: true
   validates :homepage_url, non_blank_url: true, allow_blank: true
+  validates :tier_id, presence: true
 
   has_many :links
   belongs_to :parent_local_authority, foreign_key: :parent_local_authority_id, class_name: "LocalAuthority"

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,5 @@
 class Service < ApplicationRecord
   validates :lgsl_code, :label, :slug, presence: true, uniqueness: true
-  validates :tier, inclusion: { in: %w{all county/unitary district/unitary}, allow_nil: true }
 
   has_many :service_interactions
   has_many :interactions, through: :service_interactions
@@ -8,26 +7,10 @@ class Service < ApplicationRecord
   has_many :tiers, through: :service_tiers
 
   scope :for_tier, ->(tier) {
-    case tier
-    when 'county', 'district'
-      where("services.tier = 'all' OR services.tier = '#{tier}/unitary'")
-    when 'unitary', 'all'
-      where.not(services: { tier: nil })
-    else
-      raise ArgumentError, "invalid tier '#{tier}'"
-    end
+    Service
+      .joins(:service_tiers)
+      .where(service_tiers: { tier: tier })
   }
 
   scope :enabled, -> { where(enabled: true) }
-
-  def provided_by?(authority)
-    case tier
-    when nil
-      false
-    when 'all'
-      true
-    else
-      tiers.include? authority.tier
-    end
-  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,6 +4,8 @@ class Service < ApplicationRecord
 
   has_many :service_interactions
   has_many :interactions, through: :service_interactions
+  has_many :service_tiers
+  has_many :tiers, through: :service_tiers
 
   scope :for_tier, ->(tier) {
     case tier
@@ -27,11 +29,5 @@ class Service < ApplicationRecord
     else
       tiers.include? authority.tier
     end
-  end
-
-private
-
-  def tiers
-    tier.split('/')
   end
 end

--- a/app/models/service_tier.rb
+++ b/app/models/service_tier.rb
@@ -1,0 +1,4 @@
+class ServiceTier < ApplicationRecord
+  belongs_to :service
+  belongs_to :tier
+end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,0 +1,2 @@
+class Tier < ApplicationRecord
+end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,2 +1,13 @@
 class Tier < ApplicationRecord
+  def self.unitary
+    find_or_create_by(name: 'unitary')
+  end
+
+  def self.district
+    find_or_create_by(name: 'district')
+  end
+
+  def self.county
+    find_or_create_by(name: 'county')
+  end
 end

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -19,7 +19,7 @@ private
       "local_authority" => {
         "name" => @authority.name,
         "snac" => @authority.snac,
-        "tier" => @authority.tier,
+        "tier" => @authority.tier.name,
         "homepage_url" => @authority.homepage_url
       }
     }

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -22,7 +22,7 @@ private
     {
       "name" => local_authority.name,
       "homepage_url" => local_authority.homepage_url,
-      "tier" => local_authority.tier
+      "tier" => local_authority.tier.name
     }
   end
 

--- a/db/migrate/20161114122001_create_tier_and_service_tier.rb
+++ b/db/migrate/20161114122001_create_tier_and_service_tier.rb
@@ -1,0 +1,76 @@
+class CreateTierAndServiceTier < ActiveRecord::Migration[5.0]
+  def up
+    # create tables
+    create_table :tiers do |t|
+      t.string :name, null: false, unique: true
+      t.timestamps
+    end
+
+    create_table :service_tiers do |t|
+      t.integer :service_id
+      t.integer :tier_id
+      t.timestamps
+    end
+
+    add_column :local_authorities, :tier_id, :integer, index: true
+
+    # migrate data
+    unitary_tier = Tier.create(name: 'unitary')
+    district_tier = Tier.create(name: 'district')
+    county_tier = Tier.create(name: 'county')
+
+    LocalAuthority.all.each do |la|
+      la.tier_id = Tier.find_by(name: la.tier).id
+      la.save
+    end
+
+    Service.where.not(tier: nil).each do |service|
+      case service.tier
+      when 'district/unitary'
+        ServiceTier.create(service: service, tier: district_tier)
+        ServiceTier.create(service: service, tier: unitary_tier)
+      when 'county/unitary'
+        ServiceTier.create(service: service, tier: county_tier)
+        ServiceTier.create(service: service, tier: unitary_tier)
+      when 'all'
+        ServiceTier.create(service: service, tier: county_tier)
+        ServiceTier.create(service: service, tier: unitary_tier)
+        ServiceTier.create(service: service, tier: district_tier)
+      end
+    end
+
+    # delete old data
+    remove_column :local_authorities, :tier
+    remove_column :services, :tier
+  end
+
+  def down
+    # add columns
+    add_column :local_authorities, :tier, :string
+    add_column :services, :tier, :string
+
+    # migrate data
+    LocalAuthority.all.each do |la|
+      la.tier = Tier.find(la.tier_id).name
+      la.save
+    end
+
+    Service.enabled.each do |service|
+      if service.tiers.count == 3
+        service.tier = 'all'
+      elsif service.tiers.count == 2
+        if service.tiers.map(&:name).include?('district')
+          service.tier = 'district/unitary'
+        else
+          service.tier = 'county/unitary'
+        end
+      end
+      service.save
+    end
+
+    # delete old data
+    drop_table :tiers
+    drop_table :service_tiers
+    remove_column :local_authorities, :tier_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104150651) do
+ActiveRecord::Schema.define(version: 20161114122001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,13 +44,13 @@ ActiveRecord::Schema.define(version: 20161104150651) do
     t.string   "name",                                  null: false
     t.string   "slug",                                  null: false
     t.string   "snac",                                  null: false
-    t.string   "tier",                                  null: false
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.string   "status"
     t.datetime "link_last_checked"
     t.integer  "parent_local_authority_id"
     t.integer  "broken_link_count",         default: 0
+    t.integer  "tier_id"
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true, using: :btree
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true, using: :btree
     t.index ["snac"], name: "index_local_authorities_on_snac", unique: true, using: :btree
@@ -64,16 +64,29 @@ ActiveRecord::Schema.define(version: 20161104150651) do
     t.index ["service_id", "interaction_id"], name: "index_service_interactions_on_service_id_and_interaction_id", unique: true, using: :btree
   end
 
+  create_table "service_tiers", force: :cascade do |t|
+    t.integer  "service_id"
+    t.integer  "tier_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "services", force: :cascade do |t|
-    t.integer  "lgsl_code",                  null: false
-    t.string   "label",                      null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "tier"
-    t.string   "slug",                       null: false
-    t.boolean  "enabled",    default: false, null: false
+    t.integer  "lgsl_code",                         null: false
+    t.string   "label",                             null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.string   "slug",                              null: false
+    t.boolean  "enabled",           default: false, null: false
+    t.integer  "broken_link_count", default: 0
     t.index ["label"], name: "index_services_on_label", unique: true, using: :btree
     t.index ["lgsl_code"], name: "index_services_on_lgsl_code", unique: true, using: :btree
+  end
+
+  create_table "tiers", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,1 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+%w[ unitary district county ].each { |tier| Tier.find_or_create_by(name: tier) }

--- a/lib/local-links-manager/import/services_tier_importer.rb
+++ b/lib/local-links-manager/import/services_tier_importer.rb
@@ -44,10 +44,28 @@ module LocalLinksManager
         if item[:tier].blank?
           response.errors << "LGSL #{item[:lgsl_code]} is missing a tier"
           summariser.increment_ignored_items_count
+        elsif not update_tier(service, item[:tier])
+          response.errors << "LGSL #{item[:lgsl_code]} has incorrect tier name"
+          summariser.increment_ignored_items_count
         else
-          service.tier = item[:tier]
-          service.save!
           summariser.increment_updated_record_count
+        end
+      end
+
+      def update_tier(service, tier_name)
+        case tier_name
+        when 'district/unitary'
+          ServiceTier.create(service: service, tier: Tier.district)
+          ServiceTier.create(service: service, tier: Tier.unitary)
+        when 'county/unitary'
+          ServiceTier.create(service: service, tier: Tier.county)
+          ServiceTier.create(service: service, tier: Tier.unitary)
+        when 'all'
+          ServiceTier.create(service: service, tier: Tier.county)
+          ServiceTier.create(service: service, tier: Tier.unitary)
+          ServiceTier.create(service: service, tier: Tier.district)
+        else
+          false
         end
       end
     end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:name) { |n| "Local Authority Name #{n}" }
     sequence(:gss) { |n| "S%08i" % n }
     sequence(:snac) { |n| "%02iQC" % n }
-    tier "unitary"
+    tier { Tier.find_by(name: 'unitary') }
     slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"
     status nil

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -8,5 +8,13 @@ FactoryGirl.define do
     homepage_url "http://www.angus.gov.uk"
     status nil
     link_last_checked nil
+
+    trait :district_tier do
+      tier { Tier.district }
+    end
+
+    trait :county_tier do
+      tier { Tier.county }
+    end
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -4,6 +4,18 @@ FactoryGirl.define do
     sequence(:label) { |n| "Service Label #{n}" }
     slug { label.parameterize }
     enabled true
+
+    trait :all_tiers do
+      tiers { [Tier.unitary, Tier.district, Tier.county] }
+    end
+
+    trait :district do
+      tiers { [Tier.unitary, Tier.district] }
+    end
+
+    trait :county do
+      tiers { [Tier.unitary, Tier.county] }
+    end
   end
 
   factory :disabled_service, parent: :service do

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 feature "The interactions index page for a service provided by a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'county')
-    @service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1, tier: 'county/unitary')
+    @local_authority = FactoryGirl.create(:local_authority, :county_tier, name: 'Angus')
+    @service_1 = FactoryGirl.create(:service, :county, label: 'Service 1')
     visit local_authority_service_interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 

--- a/spec/features/services/services_index_spec.rb
+++ b/spec/features/services/services_index_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature "The services index page for a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'district')
+    @local_authority = FactoryGirl.create(:local_authority, :district_tier, name: "Angus")
     visit local_authority_services_path(local_authority_slug: @local_authority.slug)
   end
 
@@ -24,7 +24,7 @@ feature "The services index page for a local authority" do
     end
 
     it "renders the local authority services page successfully" do
-      ni_local_authority = FactoryGirl.create(:local_authority, name: 'Antrim and Newtownabbey Borough Council', gss: 'N09000001', snac: 'N09000001', tier: 'unitary', slug: 'antrim-newtownabbey', homepage_url: nil)
+      ni_local_authority = FactoryGirl.create(:local_authority, name: 'Antrim and Newtownabbey Borough Council', gss: 'N09000001', snac: 'N09000001', slug: 'antrim-newtownabbey', homepage_url: nil)
       visit local_authority_services_path(local_authority_slug: ni_local_authority.slug)
       expect(page.status_code).to eq(200)
 
@@ -60,11 +60,11 @@ feature "The services index page for a local authority" do
 
   describe "with services present" do
     before do
-      @service_1 = FactoryGirl.create(:service, label: 'All councils', lgsl_code: 1, tier: 'all', enabled: true)
-      @service_2 = FactoryGirl.create(:service, label: 'County and unitary only', lgsl_code: 2, tier: 'county/unitary', enabled: true)
-      @service_3 = FactoryGirl.create(:service, label: 'District and unitary only', lgsl_code: 3, tier: 'district/unitary', enabled: true)
-      @service_4 = FactoryGirl.create(:service, label: 'Unknown', lgsl_code: 4, tier: nil, enabled: true)
-      @service_5 = FactoryGirl.create(:service, label: 'District and unitary disabled', lgsl_code: 5, tier: 'district/unitary', enabled: false)
+      @service_1 = FactoryGirl.create(:service, :all_tiers, label: 'All councils', lgsl_code: 1, enabled: true)
+      @service_2 = FactoryGirl.create(:service, :county, label: 'County and unitary only', lgsl_code: 2, enabled: true)
+      @service_3 = FactoryGirl.create(:service, :district, label: 'District and unitary only', lgsl_code: 3, enabled: true)
+      @service_4 = FactoryGirl.create(:service, label: 'Unknown', lgsl_code: 4, enabled: true)
+      @service_5 = FactoryGirl.create(:service, :district, label: 'District and unitary disabled', lgsl_code: 5, enabled: false)
       visit local_authority_services_path(@local_authority.slug)
     end
 

--- a/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
@@ -31,7 +31,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq("Aberdeen City Council")
           expect(la.snac).to eq("00QA")
-          expect(la.tier).to eq("unitary")
+          expect(la.tier.name).to eq("unitary")
           expect(la.slug).to eq("aberdeen-city-council")
         end
 
@@ -68,7 +68,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.name).to eq("A Different Council")
           expect(la.snac).to eq("XXXX")
           expect(la.slug).to eq("another-slug")
-          expect(la.tier).to eq("district")
+          expect(la.tier.name).to eq("district")
         end
 
         it 'skips updating if GSS or SNAC code is blank' do
@@ -247,7 +247,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq('Aylesbury District Council')
           expect(la.snac).to eq('11UB')
-          expect(la.tier).to eq('district')
+          expect(la.tier.name).to eq('district')
           expect(la.slug).to eq('aylesbury-district-council')
           expect(la.parent_local_authority_id).to eq(parent_local_authority.id)
         end

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -8,18 +8,15 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
     it 'imports the tiers from the csv file and updates existing services' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: nil
+        label: "Abandoned shopping trolleys"
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        label: "Arson reduction",
-        tier: nil
+        label: "Arson reduction"
       )
       yellow_lines = FactoryGirl.create(:service,
         lgsl_code: 538,
-        label: "Yellow lines",
-        tier: nil
+        label: "Yellow lines"
       )
 
       csv_rows = [
@@ -43,9 +40,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
 
       expect(subject.import_tiers).to be_successful
 
-      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
-      expect(arson_reduction.reload.tier).to eq('district/unitary')
-      expect(yellow_lines.reload.tier).to eq('all')
+      expect(abandoned_shopping_trolleys.reload.tiers.pluck(:name)).to match_array(%w[ county unitary ])
+      expect(arson_reduction.reload.tiers.pluck(:name)).to match_array(%w[ district unitary ])
+      expect(yellow_lines.reload.tiers.pluck(:name)).to match_array(%w[ district unitary county ])
     end
 
     it 'does not create new services for rows in the csv without a matching Service instance' do
@@ -67,9 +64,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
 
     it 'does not update tiers to be blank' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
+        :all_tiers,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: 'all'
+        label: "Abandoned shopping trolleys"
       )
 
       csv_rows = [
@@ -85,24 +82,21 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
       expect(response).not_to be_successful
       expect(response.errors).to include('LGSL 1152 is missing a tier')
 
-      expect(abandoned_shopping_trolleys.reload.tier).not_to be_blank
+      expect(abandoned_shopping_trolleys.reload.tiers).not_to be_blank
     end
 
     it 'does not halt in the face of an error on a single row' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: nil
+        label: "Abandoned shopping trolleys"
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        label: "Arson reduction",
-        tier: nil
+        label: "Arson reduction"
       )
       soil_excavation = FactoryGirl.create(:service,
         lgsl_code: 1419,
-        label: "Soil excavation",
-        tier: nil
+        label: "Soil excavation"
       )
 
       csv_rows = [
@@ -137,9 +131,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
       expect(response).not_to be_successful
       expect(response.errors.count).to eq(3)
 
-      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
-      expect(arson_reduction.reload.tier).to be_blank
-      expect(soil_excavation.reload.tier).to eq('district/unitary')
+      expect(abandoned_shopping_trolleys.reload.tiers.pluck(:name)).to match_array(%w[ county unitary ])
+      expect(arson_reduction.reload.tiers).to be_blank
+      expect(soil_excavation.reload.tiers.pluck(:name)).to match_array(%w[ district unitary ])
     end
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -23,15 +23,6 @@ RSpec.describe LocalAuthority, type: :model do
       it { should_not allow_value('foo.com').for(:homepage_url) }
       it { is_expected.to allow_value(nil).for(:homepage_url) }
     end
-
-    describe 'tier' do
-      %w(county district unitary).each do |tier|
-        it { should allow_value(tier).for(:tier) }
-      end
-
-      it { should_not allow_value(nil).for(:tier) }
-      it { should_not allow_value('country').for(:tier) }
-    end
   end
 
   describe 'associations' do
@@ -39,29 +30,29 @@ RSpec.describe LocalAuthority, type: :model do
   end
 
   describe '#provided_services' do
-    let!(:all_service) { FactoryGirl.create(:service, tier: 'all', lgsl_code: 1, label: 'All Service', enabled: true) }
-    let!(:county_service) { FactoryGirl.create(:service, tier: 'county/unitary', lgsl_code: 2, label: 'County Service', enabled: true) }
-    let!(:district_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 3, label: 'District Service', enabled: true) }
-    let!(:nil_service) { FactoryGirl.create(:service, tier: nil, lgsl_code: 4, label: 'Nil Service', enabled: true) }
-    let!(:disabled_service) { FactoryGirl.create(:service, tier: 'district/unitary', lgsl_code: 5, label: 'Disabled District Service', enabled: false) }
+    let!(:all_service) { FactoryGirl.create(:service, :all_tiers) }
+    let!(:county_service) { FactoryGirl.create(:service, :county) }
+    let!(:district_service) { FactoryGirl.create(:service, :district) }
+    let!(:nil_service) { FactoryGirl.create(:service) }
+    let!(:disabled_service) { FactoryGirl.create(:disabled_service, :district) }
     subject { FactoryGirl.build(:local_authority) }
 
     context 'for a "district" LA' do
-      before { subject.tier = 'district' }
+      before { subject.tier = Tier.district }
       it 'returns all and district/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, district_service])
       end
     end
 
     context 'for a "county" LA' do
-      before { subject.tier = 'county' }
+      before { subject.tier = Tier.county }
       it 'returns all and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service])
       end
     end
 
     context 'for a "unitary" LA' do
-      before { subject.tier = 'unitary' }
+      before { subject.tier = Tier.unitary }
       it 'returns all, district/unitary, and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service, district_service])
       end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -11,95 +11,25 @@ RSpec.describe Service, type: :model do
   it { is_expected.to validate_uniqueness_of(:lgsl_code) }
   it { is_expected.to validate_uniqueness_of(:label) }
   it { is_expected.to validate_uniqueness_of(:slug) }
-  it { is_expected.to validate_inclusion_of(:tier).in_array(%w{all county/unitary district/unitary}) }
-  it { is_expected.to allow_value(nil).for(:tier) }
 
   it { is_expected.to have_many(:service_interactions) }
 
   describe '.for_tier' do
-    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, label: 'all service', tier: 'all') }
-    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, label: 'district service', tier: 'district/unitary') }
-    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, label: 'county service', tier: 'county/unitary') }
-    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, label: 'nil service', tier: nil) }
-
-    it 'returns all services with a tier when asked for "all"' do
-      expect(described_class.for_tier('all')).to match_array([all_service, district_service, county_service])
-    end
+    let!(:all_service) { FactoryGirl.create(:service, :all_tiers) }
+    let!(:district_service) { FactoryGirl.create(:service, :district) }
+    let!(:county_service) { FactoryGirl.create(:service, :county) }
+    let!(:nil_service) { FactoryGirl.create(:service) }
 
     it 'returns all services with a tier when asked for "unitary"' do
-      expect(described_class.for_tier('unitary')).to match_array([all_service, district_service, county_service])
+      expect(described_class.for_tier(Tier.unitary)).to match_array([all_service, district_service, county_service])
     end
 
-    it 'returns services with an "all" or "district/unitary" tier when asked for "distrct"' do
-      expect(described_class.for_tier('district')).to match_array([all_service, district_service])
+    it 'returns services with an "all" or "district/unitary" tier when asked for "district"' do
+      expect(described_class.for_tier(Tier.district)).to match_array([all_service, district_service])
     end
 
     it 'returns services with an "all" or "county/unitary" tier when asked for "county"' do
-      expect(described_class.for_tier('county')).to match_array([all_service, county_service])
-    end
-
-    it 'raises an ArgumentError for any other requested tier' do
-      expect {
-        described_class.for_tier('hats')
-      }.to raise_error(ArgumentError, "invalid tier 'hats'")
-    end
-  end
-
-  describe '#provided_by?' do
-    let(:district) { FactoryGirl.build(:local_authority, tier: 'district') }
-    let(:county) { FactoryGirl.build(:local_authority, tier: 'county') }
-    let(:unitary) { FactoryGirl.build(:local_authority, tier: 'unitary') }
-
-    context 'when the tier is blank' do
-      subject { FactoryGirl.build(:service, tier: nil) }
-      it 'is false for a district council' do
-        expect(subject).not_to be_provided_by(district)
-      end
-      it 'is false for a county council' do
-        expect(subject).not_to be_provided_by(county)
-      end
-      it 'is false for a unitary council' do
-        expect(subject).not_to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is all' do
-      subject { FactoryGirl.build(:service, tier: 'all') }
-      it 'is true for a district council' do
-        expect(subject).to be_provided_by(district)
-      end
-      it 'is true for a county council' do
-        expect(subject).to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is district/unitary' do
-      subject { FactoryGirl.build(:service, tier: 'district/unitary') }
-      it 'is true for a district council' do
-        expect(subject).to be_provided_by(district)
-      end
-      it 'is false for a county council' do
-        expect(subject).not_to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is county/unitary' do
-      subject { FactoryGirl.build(:service, tier: 'county/unitary') }
-      it 'is false for a district council' do
-        expect(subject).not_to be_provided_by(district)
-      end
-      it 'is true for a county council' do
-        expect(subject).to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
+      expect(described_class.for_tier(Tier.county)).to match_array([all_service, county_service])
     end
   end
 end

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -12,7 +12,7 @@ describe LinkApiResponsePresenter do
           "local_authority" => {
             "name" => authority.name,
             "snac" => authority.snac,
-            "tier" => authority.tier,
+            "tier" => authority.tier.name,
             "homepage_url" => authority.homepage_url
           },
           "local_interaction" => {
@@ -35,7 +35,7 @@ describe LinkApiResponsePresenter do
           "local_authority" => {
             "name" => authority.name,
             "snac" => authority.snac,
-            "tier" => authority.tier,
+            "tier" => authority.tier.name,
             "homepage_url" => authority.homepage_url
           }
         }

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -12,12 +12,12 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
-              "tier" => authority.tier
+              "tier" => authority.tier.name
             },
             {
               "name" => parent_local_authority.name,
               "homepage_url" => parent_local_authority.homepage_url,
-              "tier" => parent_local_authority.tier
+              "tier" => parent_local_authority.tier.name
             }
           ]
         }
@@ -36,7 +36,7 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
-              "tier" => authority.tier
+              "tier" => authority.tier.name
             }
           ]
         }

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe "link path", type: :request do
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
-                         snac: "00AG",
-                         tier: "unitary")
+                         snac: "00AG")
     }
     let(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
     let(:interaction) { FactoryGirl.create(:interaction, label: 'report', lgil_code: 4) }
@@ -88,8 +87,7 @@ RSpec.describe "link path", type: :request do
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.gov.uk",
-                         snac: "00AG",
-                         tier: "unitary")
+                         snac: "00AG")
     }
     let!(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
 

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe "find local authority", type: :request do
   context "for councils that have a parent authority" do
     let(:parent_local_authority) {
       FactoryGirl.create(:local_authority,
+                         :county_tier,
                          name: 'Rochester',
                          slug: 'rochester',
-                         homepage_url: "http://rochester.example.com",
-                         tier: "county",
+                         homepage_url: "http://rochester.example.com"
                         )
     }
     let!(:local_authority) {
       FactoryGirl.create(:local_authority,
+                         :district_tier,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
-                         tier: "district",
                          parent_local_authority: parent_local_authority
                         )
     }
@@ -51,7 +51,6 @@ RSpec.describe "find local authority", type: :request do
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
-                         tier: "unitary"
                         )
     }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,4 +87,8 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   # Kernel.srand config.seed
+
+  config.before(:suite) do
+    require "#{Rails.root}/db/seeds"
+  end
 end


### PR DESCRIPTION
The concept of `Tiers` was modelling as text strings with an opaque relationship. 
e.g. a Local Authority might be a 'unitary' type, and a Service might be of type 'district/unitary'
These implicit joins were slow and hard to reason about.

This replaces that with DB relations so we can enjoy all the fun stuff that brings.