### PR TITLE
[1 of 4] Migrate to a new tier model

### DIFF
--- a/app/models/service_tier.rb
+++ b/app/models/service_tier.rb
@@ -1,0 +1,3 @@
+class ServiceTier < ApplicationRecord
+  belongs_to :service
+end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,0 +1,17 @@
+class Tier
+  COUNTY = 1
+  DISTRICT = 2
+  UNITARY = 3
+
+  def self.county
+    COUNTY
+  end
+
+  def self.district
+    DISTRICT
+  end
+
+  def self.unitary
+    UNITARY
+  end
+end

--- a/db/migrate/20161114122001_create_tier_and_service_tier.rb
+++ b/db/migrate/20161114122001_create_tier_and_service_tier.rb
@@ -1,0 +1,11 @@
+class CreateTierAndServiceTier < ActiveRecord::Migration[5.0]
+  def change
+    create_table :service_tiers do |t|
+      t.integer :tier_id, null: false, index: true
+    end
+
+    add_reference :service_tiers, :service, null: false, index: true, foreign_key: true
+
+    add_column :local_authorities, :tier_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161110122049) do
+ActiveRecord::Schema.define(version: 20161114122001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20161110122049) do
     t.datetime "link_last_checked"
     t.integer  "parent_local_authority_id"
     t.integer  "broken_link_count",         default: 0
+    t.integer  "tier_id"
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true, using: :btree
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true, using: :btree
     t.index ["snac"], name: "index_local_authorities_on_snac", unique: true, using: :btree
@@ -62,6 +63,13 @@ ActiveRecord::Schema.define(version: 20161110122049) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.index ["service_id", "interaction_id"], name: "index_service_interactions_on_service_id_and_interaction_id", unique: true, using: :btree
+  end
+
+  create_table "service_tiers", force: :cascade do |t|
+    t.integer "tier_id",    null: false
+    t.integer "service_id", null: false
+    t.index ["service_id"], name: "index_service_tiers_on_service_id", using: :btree
+    t.index ["tier_id"], name: "index_service_tiers_on_tier_id", using: :btree
   end
 
   create_table "services", force: :cascade do |t|
@@ -94,4 +102,5 @@ ActiveRecord::Schema.define(version: 20161110122049) do
   add_foreign_key "links", "service_interactions"
   add_foreign_key "service_interactions", "interactions"
   add_foreign_key "service_interactions", "services"
+  add_foreign_key "service_tiers", "services"
 end

--- a/lib/tasks/migrate_tiers_to_new_schema.rake
+++ b/lib/tasks/migrate_tiers_to_new_schema.rake
@@ -1,0 +1,29 @@
+desc 'Migrate Tier data to new schema'
+task migrate_tier: :environment do
+  puts 'Migrating Local Authority Tiers'
+  LocalAuthority.all.each do |local_authority|
+    local_authority.tier_id = Tier.public_send(local_authority.tier)
+    local_authority.save
+    print '.'
+  end
+
+  puts
+  puts 'Migrating Service tiers'
+  Service.where.not(tier: nil).each do |service|
+    case service.tier
+    when 'district/unitary'
+      ServiceTier.create(service: service, tier_id: Tier.district)
+      ServiceTier.create(service: service, tier_id: Tier.unitary)
+    when 'county/unitary'
+      ServiceTier.create(service: service, tier_id: Tier.county)
+      ServiceTier.create(service: service, tier_id: Tier.unitary)
+    when 'all'
+      ServiceTier.create(service: service, tier_id: Tier.county)
+      ServiceTier.create(service: service, tier_id: Tier.unitary)
+      ServiceTier.create(service: service, tier_id: Tier.district)
+    end
+    print '.'
+  end
+  puts
+  puts 'Done'
+end


### PR DESCRIPTION
This contains the schema and data migration component of the new Tier
model. It should be deployed before any other Tier related PRs.

Once deployed, you will need to run the rake task: `migrate_tiers` to ensure the data is up to date with the new schema.