### PR TITLE
[3 of 4] Tiers - remove deprecated 'tier' columns

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -2,16 +2,21 @@ class LocalAuthority < ApplicationRecord
   after_update :reset_time_and_status, if: :homepage_url_changed?
 
   validates :gss, :snac, :slug, uniqueness: true
-  validates :gss, :name, :snac, :tier, :slug, presence: true
+  validates :gss, :name, :snac, :slug, presence: true
   validates :homepage_url, non_blank_url: true, allow_blank: true
-  validates :tier, inclusion: { in: %w(county district unitary),
-    message: "%{value} is not an allowed tier" }
+  validates :tier_id, allow_blank: true, inclusion:
+    {
+      in: [Tier.unitary, Tier.district, Tier.county],
+      message: "%{value} is not a valid tier"
+    }
 
   has_many :links
   belongs_to :parent_local_authority, foreign_key: :parent_local_authority_id, class_name: "LocalAuthority"
 
+  # has_many :services, through: :service_tiers
+
   def provided_services
-    Service.for_tier(self.tier).enabled
+    Service.for_tier(self.tier_id).enabled
   end
 
   def update_broken_link_count

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,6 +12,10 @@ class Service < ApplicationRecord
       .where(service_tiers: { tier_id: tier })
   }
 
+  def tiers
+    service_tiers.pluck(:tier_id)
+  end
+
   scope :enabled, -> { where(enabled: true) }
 
   def update_broken_link_count

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,22 +1,21 @@
 class Service < ApplicationRecord
   validates :lgsl_code, :label, :slug, presence: true, uniqueness: true
-  validates :tier, inclusion: { in: %w{all county/unitary district/unitary}, allow_nil: true }
 
   has_many :service_interactions
   has_many :interactions, through: :service_interactions
   has_many :service_tiers
 
-  scope :for_tier, ->(tier) {
+  scope :for_tier, ->(tier_id) {
     Service
       .joins(:service_tiers)
-      .where(service_tiers: { tier_id: tier })
+      .where(service_tiers: { tier_id: tier_id })
   }
+
+  scope :enabled, -> { where(enabled: true) }
 
   def tiers
     service_tiers.pluck(:tier_id)
   end
-
-  scope :enabled, -> { where(enabled: true) }
 
   def update_broken_link_count
     update_attribute(

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -14,4 +14,15 @@ class Tier
   def self.unitary
     UNITARY
   end
+
+  def self.as_string(tier)
+    case tier
+    when COUNTY
+      'county'
+    when DISTRICT
+      'district'
+    when UNITARY
+      'unitary'
+    end
+  end
 end

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -19,7 +19,7 @@ private
       "local_authority" => {
         "name" => @authority.name,
         "snac" => @authority.snac,
-        "tier" => @authority.tier,
+        "tier" => Tier.as_string(@authority.tier_id),
         "homepage_url" => @authority.homepage_url
       }
     }

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -22,7 +22,7 @@ private
     {
       "name" => local_authority.name,
       "homepage_url" => local_authority.homepage_url,
-      "tier" => local_authority.tier
+      "tier" => Tier.as_string(local_authority.tier_id)
     }
   end
 

--- a/db/migrate/20161116153011_delete_old_tier_columns.rb
+++ b/db/migrate/20161116153011_delete_old_tier_columns.rb
@@ -1,0 +1,6 @@
+class DeleteOldTierColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :local_authorities, :tier
+    remove_column :services, :tier
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114122001) do
+ActiveRecord::Schema.define(version: 20161116153011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 20161114122001) do
     t.string   "name",                                  null: false
     t.string   "slug",                                  null: false
     t.string   "snac",                                  null: false
-    t.string   "tier",                                  null: false
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
     t.string   "status"
@@ -77,7 +76,6 @@ ActiveRecord::Schema.define(version: 20161114122001) do
     t.string   "label",                             null: false
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
-    t.string   "tier"
     t.string   "slug",                              null: false
     t.boolean  "enabled",           default: false, null: false
     t.integer  "broken_link_count", default: 0

--- a/lib/local-links-manager/import/local_authorities_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_importer.rb
@@ -6,9 +6,9 @@ require_relative 'errors'
 module LocalLinksManager
   module Import
     class LocalAuthoritiesImporter
-      DISTRICT = 'district'.freeze
-      COUNTY = 'county'.freeze
-      UNITARY = 'unitary'.freeze
+      DISTRICT = Tier.district
+      COUNTY = Tier.county
+      UNITARY = Tier.unitary
 
       LOCAL_AUTHORITY_MAPPING = {
         "COI" => UNITARY,
@@ -73,7 +73,8 @@ module LocalLinksManager
         la.name = mapit_la[:name]
         la.snac = mapit_la[:snac]
         la.slug = mapit_la[:slug]
-        la.tier = mapit_la[:tier]
+        la.tier = 'deprecated'
+        la.tier_id = mapit_la[:tier_id]
         la.save!
         if existing_record
           summariser.increment_updated_record_count
@@ -101,13 +102,13 @@ module LocalLinksManager
         authority[:snac] = parsed_authority["codes"]["ons"]
         authority[:gss] = parsed_authority["codes"]["gss"]
         authority[:slug] = parsed_authority["codes"]["govuk_slug"]
-        authority[:tier] = identify_tier(parsed_authority["type"])
+        authority[:tier_id] = identify_tier_id(parsed_authority["type"])
         authority[:mapit_id] = parsed_authority["id"]
         authority[:parent_mapit_id] = parsed_authority["parent_area"]
         authority
       end
 
-      def identify_tier(area_type)
+      def identify_tier_id(area_type)
         LOCAL_AUTHORITY_MAPPING[area_type]
       end
 

--- a/lib/local-links-manager/import/local_authorities_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_importer.rb
@@ -74,7 +74,6 @@ module LocalLinksManager
         la.name = mapit_la[:name]
         la.snac = mapit_la[:snac]
         la.slug = mapit_la[:slug]
-        la.tier = 'deprecated'
         la.tier_id = mapit_la[:tier_id]
         la.save!
         if existing_record

--- a/lib/local-links-manager/import/local_authorities_importer.rb
+++ b/lib/local-links-manager/import/local_authorities_importer.rb
@@ -2,6 +2,7 @@ require_relative 'import_comparer'
 require_relative 'processor'
 require_relative 'error_message_formatter'
 require_relative 'errors'
+require "#{Rails.root}/app/models/tier"
 
 module LocalLinksManager
   module Import

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe LinksController, type: :controller do
   before do
     login_as_stub_user
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
-    @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
-    @interaction = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
+    @local_authority = FactoryGirl.create(:local_authority)
+    @service = FactoryGirl.create(:service)
+    @interaction = FactoryGirl.create(:interaction)
   end
 
   describe 'GET edit' do

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -4,9 +4,25 @@ FactoryGirl.define do
     sequence(:gss) { |n| "S%08i" % n }
     sequence(:snac) { |n| "%02iQC" % n }
     tier "unitary"
+    tier_id { Tier.unitary }
     slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"
     status nil
     link_last_checked nil
+  end
+
+  factory :district_council, parent: :local_authority do
+    tier 'district'
+    tier_id { Tier.district }
+  end
+
+  factory :unitary_council, parent: :local_authority do
+    tier 'unitary'
+    tier_id { Tier.unitary }
+  end
+
+  factory :county_council, parent: :local_authority do
+    tier 'county'
+    tier_id { Tier.county }
   end
 end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     sequence(:name) { |n| "Local Authority Name #{n}" }
     sequence(:gss) { |n| "S%08i" % n }
     sequence(:snac) { |n| "%02iQC" % n }
-    tier "unitary"
     tier_id { Tier.unitary }
     slug { name.parameterize }
     homepage_url "http://www.angus.gov.uk"
@@ -12,17 +11,14 @@ FactoryGirl.define do
   end
 
   factory :district_council, parent: :local_authority do
-    tier 'district'
     tier_id { Tier.district }
   end
 
   factory :unitary_council, parent: :local_authority do
-    tier 'unitary'
     tier_id { Tier.unitary }
   end
 
   factory :county_council, parent: :local_authority do
-    tier 'county'
     tier_id { Tier.county }
   end
 end

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -1,6 +1,6 @@
 def create_factory_service_tiers(service, tiers)
-  tiers.each do |tier|
-    service.service_tiers << ServiceTier.create(service: service, tier_id: tier)
+  tiers.each do |tier_id|
+    service.service_tiers << ServiceTier.create(service: service, tier_id: tier_id)
   end
 end
 

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -1,9 +1,36 @@
+def create_factory_service_tiers(service, tiers)
+  tiers.each do |tier|
+    service.service_tiers << ServiceTier.create(service: service, tier_id: tier)
+  end
+end
+
 FactoryGirl.define do
   factory :service do
     sequence(:lgsl_code) { |n| n }
     sequence(:label) { |n| "Service Label #{n}" }
     slug { label.parameterize }
     enabled true
+
+    trait :all_tiers do
+      sequence(:label) { |n| "All Tiers #{n}" }
+      after(:create) do |service|
+        create_factory_service_tiers(service, [Tier.unitary, Tier.district, Tier.county])
+      end
+    end
+
+    trait :district_unitary do
+      sequence(:label) { |n| "District/Unitary #{n}" }
+      after(:create) do |service|
+        create_factory_service_tiers(service, [Tier.unitary, Tier.district])
+      end
+    end
+
+    trait :county_unitary do
+      sequence(:label) { |n| "County/Unitary #{n}" }
+      after(:create) do |service|
+        create_factory_service_tiers(service, [Tier.unitary, Tier.county])
+      end
+    end
   end
 
   factory :disabled_service, parent: :service do

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 feature "The interactions index page for a service provided by a local authority" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
-    @local_authority = FactoryGirl.create(:local_authority, name: 'Angus', tier: 'county')
-    @service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1, tier: 'county/unitary')
+    @local_authority = FactoryGirl.create(:county_council)
+    @service_1 = FactoryGirl.create(:service, :county_unitary)
     visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 
@@ -15,8 +15,8 @@ feature "The interactions index page for a service provided by a local authority
   it 'has a list of breadcrumbs pointing back to the authority and service that lead us here' do
     within '.breadcrumb' do
       expect(page).to have_link 'Local links', href: root_path
-      expect(page).to have_link 'Angus', href: local_authority_path(@local_authority.slug)
-      expect(page).to have_text 'Service 1'
+      expect(page).to have_link @local_authority.name, href: local_authority_path(@local_authority.slug)
+      expect(page).to have_text @service_1.label
     end
   end
 

--- a/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
@@ -31,7 +31,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq("Aberdeen City Council")
           expect(la.snac).to eq("00QA")
-          expect(la.tier).to eq("unitary")
+          expect(la.tier_id).to eq(Tier.unitary)
           expect(la.slug).to eq("aberdeen-city-council")
         end
 
@@ -68,7 +68,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.name).to eq("A Different Council")
           expect(la.snac).to eq("XXXX")
           expect(la.slug).to eq("another-slug")
-          expect(la.tier).to eq("district")
+          expect(la.tier_id).to eq(Tier.district)
         end
 
         it 'skips updating if GSS or SNAC code is blank' do
@@ -247,7 +247,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq('Aylesbury District Council')
           expect(la.snac).to eq('11UB')
-          expect(la.tier).to eq('district')
+          expect(la.tier_id).to eq(Tier.district)
           expect(la.slug).to eq('aylesbury-district-council')
           expect(la.parent_local_authority_id).to eq(parent_local_authority.id)
         end

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -8,18 +8,15 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
     it 'imports the tiers from the csv file and updates existing services' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: nil
+        label: "Abandoned shopping trolleys"
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        label: "Arson reduction",
-        tier: nil
+        label: "Arson reduction"
       )
       yellow_lines = FactoryGirl.create(:service,
         lgsl_code: 538,
-        label: "Yellow lines",
-        tier: nil
+        label: "Yellow lines"
       )
 
       csv_rows = [
@@ -43,9 +40,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
 
       expect(subject.import_tiers).to be_successful
 
-      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
-      expect(arson_reduction.reload.tier).to eq('district/unitary')
-      expect(yellow_lines.reload.tier).to eq('all')
+      expect(abandoned_shopping_trolleys.reload.tiers).to match_array([Tier.county, Tier.unitary])
+      expect(arson_reduction.reload.tiers).to match_array([Tier.district, Tier.unitary])
+      expect(yellow_lines.reload.tiers).to match_array([Tier.district, Tier.unitary, Tier.county])
     end
 
     it 'does not create new services for rows in the csv without a matching Service instance' do
@@ -67,9 +64,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
 
     it 'does not update tiers to be blank' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
+        :all_tiers,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: 'all'
+        label: "Abandoned shopping trolleys"
       )
 
       csv_rows = [
@@ -85,24 +82,21 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
       expect(response).not_to be_successful
       expect(response.errors).to include('LGSL 1152 is missing a tier')
 
-      expect(abandoned_shopping_trolleys.reload.tier).not_to be_blank
+      expect(abandoned_shopping_trolleys.reload.tiers).not_to be_empty
     end
 
     it 'does not halt in the face of an error on a single row' do
       abandoned_shopping_trolleys = FactoryGirl.create(:service,
         lgsl_code: 1152,
-        label: "Abandoned shopping trolleys",
-        tier: nil
+        label: "Abandoned shopping trolleys"
       )
       arson_reduction = FactoryGirl.create(:service,
         lgsl_code: 800,
-        label: "Arson reduction",
-        tier: nil
+        label: "Arson reduction"
       )
       soil_excavation = FactoryGirl.create(:service,
         lgsl_code: 1419,
-        label: "Soil excavation",
-        tier: nil
+        label: "Soil excavation"
       )
 
       csv_rows = [
@@ -137,9 +131,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
       expect(response).not_to be_successful
       expect(response.errors.count).to eq(3)
 
-      expect(abandoned_shopping_trolleys.reload.tier).to eq('county/unitary')
-      expect(arson_reduction.reload.tier).to be_blank
-      expect(soil_excavation.reload.tier).to eq('district/unitary')
+      expect(abandoned_shopping_trolleys.reload.tiers).to match_array([Tier.county, Tier.unitary])
+      expect(arson_reduction.reload.tiers).to be_blank
+      expect(soil_excavation.reload.tiers).to match_array([Tier.district, Tier.unitary])
     end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -17,89 +17,21 @@ RSpec.describe Service, type: :model do
   it { is_expected.to have_many(:service_interactions) }
 
   describe '.for_tier' do
-    let!(:all_service) { FactoryGirl.create(:service, lgsl_code: 1, label: 'all service', tier: 'all') }
-    let!(:district_service) { FactoryGirl.create(:service, lgsl_code: 2, label: 'district service', tier: 'district/unitary') }
-    let!(:county_service) { FactoryGirl.create(:service, lgsl_code: 3, label: 'county service', tier: 'county/unitary') }
-    let!(:nil_service) { FactoryGirl.create(:service, lgsl_code: 4, label: 'nil service', tier: nil) }
-
-    it 'returns all services with a tier when asked for "all"' do
-      expect(described_class.for_tier('all')).to match_array([all_service, district_service, county_service])
-    end
+    let!(:all_service) { FactoryGirl.create(:service, :all_tiers) }
+    let!(:district_service) { FactoryGirl.create(:service, :district_unitary) }
+    let!(:county_service) { FactoryGirl.create(:service, :county_unitary) }
+    let!(:nil_service) { FactoryGirl.create(:service) }
 
     it 'returns all services with a tier when asked for "unitary"' do
-      expect(described_class.for_tier('unitary')).to match_array([all_service, district_service, county_service])
+      expect(described_class.for_tier(Tier.unitary)).to match_array([all_service, district_service, county_service])
     end
 
     it 'returns services with an "all" or "district/unitary" tier when asked for "distrct"' do
-      expect(described_class.for_tier('district')).to match_array([all_service, district_service])
+      expect(described_class.for_tier(Tier.district)).to match_array([all_service, district_service])
     end
 
     it 'returns services with an "all" or "county/unitary" tier when asked for "county"' do
-      expect(described_class.for_tier('county')).to match_array([all_service, county_service])
-    end
-
-    it 'raises an ArgumentError for any other requested tier' do
-      expect {
-        described_class.for_tier('hats')
-      }.to raise_error(ArgumentError, "invalid tier 'hats'")
-    end
-  end
-
-  describe '#provided_by?' do
-    let(:district) { FactoryGirl.build(:local_authority, tier: 'district') }
-    let(:county) { FactoryGirl.build(:local_authority, tier: 'county') }
-    let(:unitary) { FactoryGirl.build(:local_authority, tier: 'unitary') }
-
-    context 'when the tier is blank' do
-      subject { FactoryGirl.build(:service, tier: nil) }
-      it 'is false for a district council' do
-        expect(subject).not_to be_provided_by(district)
-      end
-      it 'is false for a county council' do
-        expect(subject).not_to be_provided_by(county)
-      end
-      it 'is false for a unitary council' do
-        expect(subject).not_to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is all' do
-      subject { FactoryGirl.build(:service, tier: 'all') }
-      it 'is true for a district council' do
-        expect(subject).to be_provided_by(district)
-      end
-      it 'is true for a county council' do
-        expect(subject).to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is district/unitary' do
-      subject { FactoryGirl.build(:service, tier: 'district/unitary') }
-      it 'is true for a district council' do
-        expect(subject).to be_provided_by(district)
-      end
-      it 'is false for a county council' do
-        expect(subject).not_to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
-    end
-
-    context 'when the tier is county/unitary' do
-      subject { FactoryGirl.build(:service, tier: 'county/unitary') }
-      it 'is false for a district council' do
-        expect(subject).not_to be_provided_by(district)
-      end
-      it 'is true for a county council' do
-        expect(subject).to be_provided_by(county)
-      end
-      it 'is true for a unitary council' do
-        expect(subject).to be_provided_by(unitary)
-      end
+      expect(described_class.for_tier(Tier.county)).to match_array([all_service, county_service])
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Service, type: :model do
   it { is_expected.to validate_uniqueness_of(:lgsl_code) }
   it { is_expected.to validate_uniqueness_of(:label) }
   it { is_expected.to validate_uniqueness_of(:slug) }
-  it { is_expected.to validate_inclusion_of(:tier).in_array(%w{all county/unitary district/unitary}) }
-  it { is_expected.to allow_value(nil).for(:tier) }
 
   it { is_expected.to have_many(:service_interactions) }
 

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe LinkApiResponsePresenter do
   describe '#present' do
-    let(:authority) { FactoryGirl.build(:local_authority) }
+    let(:authority) { FactoryGirl.build(:district_council) }
     let(:presenter) { described_class.new(authority, link) }
 
     context 'link is present' do
@@ -12,7 +12,7 @@ describe LinkApiResponsePresenter do
           "local_authority" => {
             "name" => authority.name,
             "snac" => authority.snac,
-            "tier" => authority.tier,
+            "tier" => 'district',
             "homepage_url" => authority.homepage_url
           },
           "local_interaction" => {
@@ -35,7 +35,7 @@ describe LinkApiResponsePresenter do
           "local_authority" => {
             "name" => authority.name,
             "snac" => authority.snac,
-            "tier" => authority.tier,
+            "tier" => 'district',
             "homepage_url" => authority.homepage_url
           }
         }

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe LocalAuthorityApiResponsePresenter do
   describe '#present' do
     context 'when the local authority has a parent' do
-      let(:parent_local_authority) { FactoryGirl.build(:local_authority) }
-      let(:authority) { FactoryGirl.build(:local_authority, parent_local_authority: parent_local_authority) }
+      let(:parent_local_authority) { FactoryGirl.build(:county_council) }
+      let(:authority) { FactoryGirl.build(:district_council, parent_local_authority: parent_local_authority) }
       let(:presenter) { described_class.new(authority) }
       let(:expected_response) do
         {
@@ -12,12 +12,12 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
-              "tier" => authority.tier
+              "tier" => 'district'
             },
             {
               "name" => parent_local_authority.name,
               "homepage_url" => parent_local_authority.homepage_url,
-              "tier" => parent_local_authority.tier
+              "tier" => 'county'
             }
           ]
         }
@@ -28,7 +28,7 @@ describe LocalAuthorityApiResponsePresenter do
     end
 
     context 'when local authority does not have a parent' do
-      let(:authority) { FactoryGirl.build(:local_authority) }
+      let(:authority) { FactoryGirl.build(:unitary_council) }
       let(:presenter) { described_class.new(authority) }
       let(:expected_response) do
         {
@@ -36,7 +36,7 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
-              "tier" => authority.tier
+              "tier" => 'unitary'
             }
           ]
         }

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 RSpec.describe "link path", type: :request do
   context "for a request with authority slug, lgsl and lgil params" do
     let(:local_authority) {
-      FactoryGirl.create(:local_authority,
+      FactoryGirl.create(:unitary_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
-                         snac: "00AG",
-                         tier: "unitary")
+                         snac: "00AG")
     }
     let(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
     let(:interaction) { FactoryGirl.create(:interaction, label: 'report', lgil_code: 4) }
@@ -84,12 +83,11 @@ RSpec.describe "link path", type: :request do
 
   context "for a request with authority slug and lgsl params" do
     let!(:local_authority) {
-      FactoryGirl.create(:local_authority,
+      FactoryGirl.create(:unitary_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.gov.uk",
-                         snac: "00AG",
-                         tier: "unitary")
+                         snac: "00AG")
     }
     let!(:service) { FactoryGirl.create(:service, label: 'abandoned-shopping-trolleys', lgsl_code: 2) }
 

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -3,19 +3,17 @@ require 'rails_helper'
 RSpec.describe "find local authority", type: :request do
   context "for councils that have a parent authority" do
     let(:parent_local_authority) {
-      FactoryGirl.create(:local_authority,
+      FactoryGirl.create(:county_council,
                          name: 'Rochester',
                          slug: 'rochester',
-                         homepage_url: "http://rochester.example.com",
-                         tier: "county",
+                         homepage_url: "http://rochester.example.com"
                         )
     }
     let!(:local_authority) {
-      FactoryGirl.create(:local_authority,
+      FactoryGirl.create(:district_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
-                         tier: "district",
                          parent_local_authority: parent_local_authority
                         )
     }
@@ -47,11 +45,10 @@ RSpec.describe "find local authority", type: :request do
 
   context "for councils that do not have a parent authority" do
     let!(:local_authority) {
-      FactoryGirl.create(:local_authority,
+      FactoryGirl.create(:unitary_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
-                         homepage_url: "http://blackburn.example.com",
-                         tier: "unitary"
+                         homepage_url: "http://blackburn.example.com"
                         )
     }
 


### PR DESCRIPTION
Tidies up the schema cruft left over from previous work.

*NOTE:* This must not be deployed to any server until [this PR](https://github.com/alphagov/local-links-manager/pull/78) and [this PR](https://github.com/alphagov/local-links-manager/pull/79) have been released OK.