### PR TITLE
[4 of 4] Adds the bi-directional relation to LocalAuthority and Service models

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,7 +4,7 @@ class LocalAuthority < ApplicationRecord
   validates :gss, :snac, :slug, uniqueness: true
   validates :gss, :name, :snac, :slug, presence: true
   validates :homepage_url, non_blank_url: true, allow_blank: true
-  validates :tier_id, allow_blank: true, inclusion:
+  validates :tier_id, presence: true, inclusion:
     {
       in: [Tier.unitary, Tier.district, Tier.county],
       message: "%{value} is not a valid tier"
@@ -12,13 +12,15 @@ class LocalAuthority < ApplicationRecord
 
   has_many :links
   belongs_to :parent_local_authority, foreign_key: :parent_local_authority_id, class_name: "LocalAuthority"
+  has_many :service_tiers, foreign_key: :tier_id, primary_key: :tier_id
+  has_many :services, through: :service_tiers
 
   def tier
     Tier.as_string(tier_id)
   end
 
   def provided_services
-    Service.for_tier(self.tier_id).enabled
+    services.enabled
   end
 
   def update_broken_link_count

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -13,6 +13,10 @@ class LocalAuthority < ApplicationRecord
   has_many :links
   belongs_to :parent_local_authority, foreign_key: :parent_local_authority_id, class_name: "LocalAuthority"
 
+  def tier
+    Tier.as_string(tier_id)
+  end
+
   def provided_services
     Service.for_tier(self.tier_id).enabled
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -14,7 +14,7 @@ class Service < ApplicationRecord
   scope :enabled, -> { where(enabled: true) }
 
   def tiers
-    service_tiers.pluck(:tier_id)
+    service_tiers.pluck(:tier_id).map { |t_id| Tier.as_string(t_id) }
   end
 
   def update_broken_link_count

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,12 +4,7 @@ class Service < ApplicationRecord
   has_many :service_interactions
   has_many :interactions, through: :service_interactions
   has_many :service_tiers
-
-  scope :for_tier, ->(tier_id) {
-    Service
-      .joins(:service_tiers)
-      .where(service_tiers: { tier_id: tier_id })
-  }
+  has_many :local_authorities, through: :service_tiers
 
   scope :enabled, -> { where(enabled: true) }
 

--- a/app/models/service_tier.rb
+++ b/app/models/service_tier.rb
@@ -1,3 +1,4 @@
 class ServiceTier < ApplicationRecord
   belongs_to :service
+  belongs_to :local_authority, foreign_key: :tier_id, primary_key: :tier_id
 end

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -19,7 +19,7 @@ private
       "local_authority" => {
         "name" => @authority.name,
         "snac" => @authority.snac,
-        "tier" => Tier.as_string(@authority.tier_id),
+        "tier" => @authority.tier,
         "homepage_url" => @authority.homepage_url
       }
     }

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -22,7 +22,7 @@ private
     {
       "name" => local_authority.name,
       "homepage_url" => local_authority.homepage_url,
-      "tier" => Tier.as_string(local_authority.tier_id)
+      "tier" => local_authority.tier
     }
   end
 

--- a/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
@@ -31,7 +31,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq("Aberdeen City Council")
           expect(la.snac).to eq("00QA")
-          expect(la.tier_id).to eq(Tier.unitary)
+          expect(la.tier).to eq('unitary')
           expect(la.slug).to eq("aberdeen-city-council")
         end
 
@@ -68,7 +68,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.name).to eq("A Different Council")
           expect(la.snac).to eq("XXXX")
           expect(la.slug).to eq("another-slug")
-          expect(la.tier_id).to eq(Tier.district)
+          expect(la.tier).to eq('district')
         end
 
         it 'skips updating if GSS or SNAC code is blank' do
@@ -247,7 +247,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
           expect(la.name).to eq('Aylesbury District Council')
           expect(la.snac).to eq('11UB')
-          expect(la.tier_id).to eq(Tier.district)
+          expect(la.tier).to eq('district')
           expect(la.slug).to eq('aylesbury-district-council')
           expect(la.parent_local_authority_id).to eq(parent_local_authority.id)
         end

--- a/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_tier_importer_spec.rb
@@ -40,9 +40,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
 
       expect(subject.import_tiers).to be_successful
 
-      expect(abandoned_shopping_trolleys.reload.tiers).to match_array([Tier.county, Tier.unitary])
-      expect(arson_reduction.reload.tiers).to match_array([Tier.district, Tier.unitary])
-      expect(yellow_lines.reload.tiers).to match_array([Tier.district, Tier.unitary, Tier.county])
+      expect(abandoned_shopping_trolleys.reload.tiers).to match_array(%w[ county unitary ])
+      expect(arson_reduction.reload.tiers).to match_array(%w[ district unitary ])
+      expect(yellow_lines.reload.tiers).to match_array(%w[ district unitary county ])
     end
 
     it 'does not create new services for rows in the csv without a matching Service instance' do
@@ -131,9 +131,9 @@ describe LocalLinksManager::Import::ServicesTierImporter, :csv_importer do
       expect(response).not_to be_successful
       expect(response.errors.count).to eq(3)
 
-      expect(abandoned_shopping_trolleys.reload.tiers).to match_array([Tier.county, Tier.unitary])
+      expect(abandoned_shopping_trolleys.reload.tiers).to match_array(%w[ county unitary ])
       expect(arson_reduction.reload.tiers).to be_blank
-      expect(soil_excavation.reload.tiers).to match_array([Tier.district, Tier.unitary])
+      expect(soil_excavation.reload.tiers).to match_array(%w[ district unitary ])
     end
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe LocalAuthority, type: :model do
     end
   end
 
+  describe "#tier" do
+    it "is a string representation of the Tier" do
+      local_authority = FactoryGirl.create(:district_council)
+      expect(local_authority.tier).to eql 'district'
+    end
+  end
+
   describe "#update_broken_link_count" do
     it "updates the broken_link_count" do
       link = FactoryGirl.create(:link, status: 500)

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe LocalAuthority, type: :model do
       [Tier.county, Tier.district, Tier.unitary].each do |tier|
         it { should allow_value(tier).for(:tier_id) }
       end
+
+      it { should_not allow_value(-1).for(:tier_id) }
+      it { should_not allow_value(nil).for(:tier_id) }
     end
   end
 
@@ -40,24 +43,26 @@ RSpec.describe LocalAuthority, type: :model do
     let!(:district_service) { FactoryGirl.create(:service, :district_unitary) }
     let!(:nil_service) { FactoryGirl.create(:service) }
     let!(:disabled_service) { FactoryGirl.create(:disabled_service, :district_unitary) }
-    subject { FactoryGirl.build(:local_authority) }
 
     context 'for a "district" LA' do
-      before { subject.tier_id = Tier.district }
+      subject { FactoryGirl.create(:district_council) }
+
       it 'returns all and district/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, district_service])
       end
     end
 
     context 'for a "county" LA' do
-      before { subject.tier_id = Tier.county }
+      subject { FactoryGirl.create(:county_council) }
+
       it 'returns all and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service])
       end
     end
 
     context 'for a "unitary" LA' do
-      before { subject.tier_id = Tier.unitary }
+      subject { FactoryGirl.create(:unitary_council) }
+
       it 'returns all, district/unitary, and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service, district_service])
       end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Service, type: :model do
     end
   end
 
+  describe '#tiers' do
+    subject { FactoryGirl.create(:service, :all_tiers) }
+    let(:result) { subject.tiers }
+
+    it 'returns an array of tier names' do
+      expect(result).to match_array(%w[ unitary district county ])
+    end
+  end
+
   describe "#update_broken_link_count" do
     it "updates the broken_link_count" do
       link = FactoryGirl.create(:link, status: 500)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -14,25 +14,6 @@ RSpec.describe Service, type: :model do
 
   it { is_expected.to have_many(:service_interactions) }
 
-  describe '.for_tier' do
-    let!(:all_service) { FactoryGirl.create(:service, :all_tiers) }
-    let!(:district_service) { FactoryGirl.create(:service, :district_unitary) }
-    let!(:county_service) { FactoryGirl.create(:service, :county_unitary) }
-    let!(:nil_service) { FactoryGirl.create(:service) }
-
-    it 'returns all services with a tier when asked for "unitary"' do
-      expect(described_class.for_tier(Tier.unitary)).to match_array([all_service, district_service, county_service])
-    end
-
-    it 'returns services with an "all" or "district/unitary" tier when asked for "distrct"' do
-      expect(described_class.for_tier(Tier.district)).to match_array([all_service, district_service])
-    end
-
-    it 'returns services with an "all" or "county/unitary" tier when asked for "county"' do
-      expect(described_class.for_tier(Tier.county)).to match_array([all_service, county_service])
-    end
-  end
-
   describe '#tiers' do
     subject { FactoryGirl.create(:service, :all_tiers) }
     let(:result) { subject.tiers }


### PR DESCRIPTION
Previous Pull Requests have created the relationship between `Local Authorities` and `Services` via `Tiers` and the `ServiceTiers` join table. [[3 of 4]](https://github.com/alphagov/local-links-manager/pull/81) deleted the `tier` columns from both of these tables, which frees up the namespace for this change.

In addition, it has been possible to create the sugar methods `LocalAuthority#tier => "district"` and `Service#tiers => ["district", "unitary"]`
 
**NOTE** This cannot be deployed until [[1]](https://github.com/alphagov/local-links-manager/pull/78), [[2]](https://github.com/alphagov/local-links-manager/pull/79), and [[3]](https://github.com/alphagov/local-links-manager/pull/81) have been released.


