### PR TITLE
List all interactions for specific council page

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -4,6 +4,7 @@ table.table-service {
   th h3 { margin: 10px; }
   h4 { margin-top: 0px; }
   tr.first-row {
+    border-top: 1px solid #ddd;
     td.lgsl p { display: block; }
     h4 { display: block; }
   }

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -9,7 +9,8 @@ class LocalAuthoritiesController < ApplicationController
 
   def show
     @authority = LocalAuthorityPresenter.new(LocalAuthority.find_by_slug!(params[:local_authority_slug]))
-    @services = @authority.provided_services.order(lgsl_code: :asc)
+    @services = @authority.provided_services.order('services.label ASC')
+    @links = @authority.links.includes([:service, :interaction]).all.group_by { |link| link.service.id }
   end
 
   def update

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -6,32 +6,30 @@
 
 <% breadcrumb :services, @authority %>
 
-<%= render partial: "shared/local_authority_details", locals: {authority: @authority} %>
+<%= render partial: "shared/local_authority_details", locals: { authority: @authority } %>
 
-<% if @services.any? %>
-  <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
+<% if @links.any? %>
+  <table class="table table-bordered table-service">
     <thead>
       <tr class="table-header">
-        <th>LGSL Code</th>
-        <th>Local Government Services (<%= @services.count %>)</th>
+        <th class='center'>Code</th>
+        <th width:'40%'>Services and links</th>
+        <th>Link status</th>
+        <th></th>
       </tr>
-      <%= render partial: "govuk_admin_template/table_filter",
-      locals: {placeholder: "Filter list of local services"} %>
     </thead>
     <tbody>
       <% @services.each do |service| %>
-        <tr>
-          <td class="lgsl_code">
-            <%= service.lgsl_code %>
-          </td>
-          <td class="name">
-            <%= link_to service.label, interactions_path(service_slug: service.slug, local_authority_slug: @authority.slug), class: 'js-open-on-submit' %>
-          </td>
-        </tr>
+        <% links_by_service = @links[service.id] %>
+        <% next if links_by_service.blank? %>
+        <% first_link, *remaining_links = links_by_service %>
+        <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(first_link, view_context: self, first: true) %>
+        <% remaining_links.each do |link| %>
+          <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(link, view_context: self, first: false) %>
+        <% end %>
       <% end %>
     </tbody>
   </table>
-
 <% else %>
   <h4>No local services found</h4>
 <% end %>


### PR DESCRIPTION
This changes the local authority show page to show Service Interaction
links grouped by service

<img width="1181" alt="screen shot 2016-11-21 at 10 46 51" src="https://cloud.githubusercontent.com/assets/3466862/20479914/09a8308a-afd8-11e6-81db-67d0b2f3bce8.png">

[Trello card](https://trello.com/c/SMFW5Ctd/540-update-specific-council-page-to-list-all-service-interactions-3)