### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'local-links-manager'
+
+node {
+   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+   try {
+      stage("Checkout") {
+         checkout scm
+      }
+
+      stage("Build") {
+         sh "${WORKSPACE}/jenkins.sh"
+      }
+
+      stage("Push release tag") {
+         echo 'Pushing tag'
+         govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
+      // Deploy on Integration (only master)
+      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+   
+   } catch (e) {
+      currentBuild.result = "FAILED"
+      step([$class: 'Mailer',
+            notifyEveryUnstableBuild: true,
+            recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+            sendToIndividuals: true])
+      throw e
+   }
+
+}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# We can remove the gh-status code when we move to Jenkins 2
 GH_STATUS_REPO_NAME=${INITIATING_REPO_NAME:-"alphagov/local-links-manager"}
 CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
 GH_STATUS_GIT_COMMIT=${INITIATING_GIT_COMMIT:-${GIT_COMMIT}}


### PR DESCRIPTION
We are currently looking at updating the way in which we do CI. In Jenkins 2 we can define our Build steps with a Jenkinsfile. This is one of the applications we would like to test with, because it's simple.

This Jenkinsfile is for Jenkins 2. The new version of Jenkins takes
care of notifying GitHub so we can remove `gh-status`.

There are probably other things in the `jenkins.sh` which can be deduplicated
as Jenkinsfile functions.