### PR TITLE
Configure Memcached as cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'redis-namespace', '1.5.2'
 
 gem 'whenever', require: false
 
+gem 'dalli'
+
 group :development, :test do
   gem 'pry-rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,66 +1,43 @@
 ruby File.read('.ruby-version').strip
 source 'https://rubygems.org'
 
-
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
   gem 'gds-api-adapters', '36.0.0'
 end
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '5.0.0.1'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
-gem 'gds-sso', '~> 13.0'
-gem 'govuk_admin_template', '~> 4.2'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-gem 'capistrano-rails', group: :development
-
-gem 'pg'
-
-# Provides breadcrumbs, see config/breadcrumbs.rb
-gem 'gretel', '3.0.9'
-
 gem 'addressable'
-
+gem 'airbrake', '~> 5.6.1'
+gem 'airbrake-ruby', '1.6'
+gem 'dalli'
 gem 'faraday'
 gem 'faraday_middleware'
-
+gem 'govuk_admin_template', '~> 4.2'
+gem 'govuk-lint'
+gem 'gds-sso', '~> 13.0'
+gem 'gretel', '3.0.9'
+gem 'jbuilder', '~> 2.0'
+gem 'logstasher', '0.6.2'
 gem 'mlanett-redis-lock', '0.2.7'
+gem 'plek', '~> 1.10'
+gem 'pg'
+gem 'rails', '5.0.0.1'
 gem 'redis-namespace', '1.5.2'
-
+gem 'sass-rails', '~> 5.0'
+gem 'uglifier', '>= 1.3.0'
+gem 'unicorn', '~> 4.9.0'
 gem 'whenever', require: false
 
-gem 'dalli'
-
-group :development, :test do
-  gem 'pry-rails'
-end
-
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
+  gem 'capistrano-rails'
+  gem 'web-console', '~> 2.0' # Access an IRB console by using <%= console %> in views
 end
 
-
-gem 'unicorn', '~> 4.9.0'
-gem 'logstasher', '0.6.2'
 group :development, :test do
   gem 'capybara', '~> 2.7'
   gem 'factory_girl_rails', '~> 4.7'
+  gem 'pry-rails'
   gem 'rspec-rails', '~> 3.5'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov', '0.10.0', require: false
@@ -68,11 +45,10 @@ group :development, :test do
 end
 
 group :test do
-  gem 'webmock', '~> 1.2'
   gem 'timecop'
+  gem 'webmock', '~> 1.2'
 end
 
-gem 'plek', '~> 1.10'
-gem 'airbrake', '~> 5.6.1'
-gem 'airbrake-ruby', '1.6'
-gem 'govuk-lint'
+group :doc do
+  gem 'sdoc', '~> 0.4.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    dalli (2.7.2)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -338,6 +339,7 @@ DEPENDENCIES
   airbrake-ruby (= 1.6)
   capistrano-rails
   capybara (~> 2.7)
+  dalli
   factory_girl_rails (~> 4.7)
   faraday
   faraday_middleware

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,8 +52,8 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # use memcached in Production
+  config.cache_store = :dalli_store, nil, { namespace: :local_links_manager }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
In order to use the Rails fragment cache to speed up our render times,
we need some kind of cache-store. Other gov.uk Rails apps are using
memcached which is available to backend services without further
configuration, making it an easy choice.

As this change touched the Gemfile, it seemed sensible to leave it in a better state than it started.