### PR TITLE
Make specific council page filterable

### DIFF
--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -13,6 +13,7 @@ class LocalAuthoritiesController < ApplicationController
     @link_filter = params[:filter]
     @services = @authority.provided_services.order('services.label ASC')
     @links = links_for_authority.group_by { |link| link.service.id }
+    @link_count = links_for_authority.count
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,13 @@ module ApplicationHelper
   def singular_or_plural(num)
     num == 1 ? 'singular' : 'plural'
   end
+
+  # Used to set a compound cache key for fragment caches.
+  # Namespaced to the controller and action, and with
+  # a possible 'vary' string. The 'obj' parameter is expected to be
+  # an ActiveRecord object, or at least something that implements the
+  # #cache_key method.
+  def namespaced_cache_key(obj, vary)
+    [controller_name, controller.action_name, obj.cache_key, vary.to_s].join('/')
+  end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,7 +3,7 @@ class Link < ApplicationRecord
   before_create :set_time_and_status_on_new_link
 
   belongs_to :local_authority, touch: true
-  belongs_to :service_interaction
+  belongs_to :service_interaction, touch: true
 
   has_one :service, through: :service_interaction
   has_one :interaction, through: :service_interaction

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -23,6 +23,12 @@ class LocalAuthority < ApplicationRecord
     services.enabled
   end
 
+  # returns the Links for this authority,
+  # for the enabled Services that this authority provides.
+  def provided_service_links
+    links.joins(:service).merge(provided_services)
+  end
+
   def update_broken_link_count
     update_attribute(
       :broken_link_count,

--- a/app/models/service_interaction.rb
+++ b/app/models/service_interaction.rb
@@ -2,7 +2,7 @@ class ServiceInteraction < ApplicationRecord
   validates :service_id, :interaction_id, presence: true
   validates :service_id, uniqueness: { scope: :interaction_id }
 
-  belongs_to :service
+  belongs_to :service, touch: true
   belongs_to :interaction
   has_many :links
 

--- a/app/views/local_authorities/_link_filter_nav.html.erb
+++ b/app/views/local_authorities/_link_filter_nav.html.erb
@@ -1,0 +1,7 @@
+<nav class="link-nav">
+  <ul class="nav nav-tabs">
+    <li role="presentation" class="<%= 'active' if @link_filter == 'broken_links' %>"><%= link_to 'Broken links', local_authority_path(@authority, filter: 'broken_links' ) %></li>
+    <li role="presentation" class="<%= 'active' if @link_filter == 'good_links' %>"><%= link_to 'Good links', local_authority_path(@authority, filter: 'good_links') %></li>
+    <li role="presentation" class="<%= 'active' if @link_filter.nil? %>"><%= link_to 'All links', local_authority_path(@authority) %></li>
+  </ul>
+</nav>

--- a/app/views/local_authorities/_service.html.erb
+++ b/app/views/local_authorities/_service.html.erb
@@ -1,0 +1,10 @@
+<% links_by_service = links[service.id] %>
+<% unless links_by_service.blank? %>
+  <% cache namespaced_cache_key(service, @link_filter) do %>
+    <% first_link, *remaining_links = links_by_service %>
+    <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(first_link, view_context: self, first: true) %>
+    <% remaining_links.each do |link| %>
+      <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(link, view_context: self, first: false) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -26,7 +26,7 @@
     <% @authorities.each do |authority| %>
       <tr>
         <td>
-          <%= link_to authority.name, local_authority_path(authority.slug), class: 'js-open-on-submit name' %>
+          <%= link_to authority.name, local_authority_path(authority.slug, filter: 'broken_links'), class: 'js-open-on-submit name' %>
           <div class="center count <%= singular_or_plural(authority.broken_link_count) %>">
             <span><%= authority.broken_link_count %></span>
           </div>

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -10,8 +10,19 @@
 
 <%= render partial: 'link_filter_nav' %>
 
-<table class="table table-bordered table-service">
+<table class="table table-bordered table-service table-with-counts" data-module="filterable-table">
   <thead>
+    <tr class="table-header">
+      <th colspan='4'>
+        <div class='filter-control'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a council or link here' } %>
+        </div>
+        <div class='count'>
+          <span><%= @link_count %></span>
+          <%= 'link'.pluralize(@link_count) %>
+        </div>
+      </th>
+    </tr>
     <tr class="table-header">
       <th class='center'>Code</th>
       <th width:'40%'>Services and links</th>

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -18,14 +18,6 @@
     </tr>
   </thead>
   <tbody>
-    <% @services.each do |service| %>
-      <% links_by_service = @links[service.id] %>
-      <% next if links_by_service.blank? %>
-      <% first_link, *remaining_links = links_by_service %>
-      <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(first_link, view_context: self, first: true) %>
-      <% remaining_links.each do |link| %>
-        <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(link, view_context: self, first: false) %>
-      <% end %>
-    <% end %>
+    <%= render partial: 'service', collection: @services, locals: { links: @links } %>
   </tbody>
 </table>

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -8,6 +8,8 @@
 
 <%= render partial: "shared/local_authority_details", locals: { authority: @authority } %>
 
+<%= render partial: 'link_filter_nav' %>
+
 <table class="table table-bordered table-service">
   <thead>
     <tr class="table-header">

--- a/app/views/services/_local_authority.html.erb
+++ b/app/views/services/_local_authority.html.erb
@@ -1,6 +1,6 @@
 <% links_by_authority = @links[local_authority.id] %>
 <% unless links_by_authority.blank? %>
-  <% cache (local_authority.cache_key + @link_filter.to_s) do %>
+  <% cache namespaced_cache_key(local_authority, @link_filter) do %>
     <%= render partial: 'service_links_by_authority', locals: { local_authority: local_authority, links_by_authority: links_by_authority } %>
   <% end %>
 <% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -30,13 +30,13 @@
     <% @services.each do |service| %>
       <tr>
         <td>
-          <div class="center">
+          <div class="text-center">
             <%= service.lgsl_code %>
           </div>
         </td>
         <td>
-          <%= link_to service.label, service %>
-          <div class="center count <%= singular_or_plural(service.broken_link_count) %>">
+          <%= link_to service.label, service_path(service, filter: 'broken_links'), class: 'name' %>
+          <div class="text-center count <%= singular_or_plural(service.broken_link_count) %>">
             <span><%= service.broken_link_count %></span>
           </div>
         </td>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -18,7 +18,7 @@
     <tr class="table-header">
       <th colspan='4'>
         <div class='filter-control'>
-          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a council or link here' } %>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a service or link here' } %>
         </div>
         <div class='count'>
           <span><%= @link_count %></span>

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -19,8 +19,8 @@ feature "The local authorities index page" do
 
   it "shows the available local authorities with links to their respective pages" do
     expect(page).to have_content '2 local authorities'
-    expect(page).to have_link('Angus', href: local_authority_path(@angus.slug))
-    expect(page).to have_link('Zorro Council', href: local_authority_path(@zorro.slug))
+    expect(page).to have_link('Angus', href: local_authority_path(@angus.slug, filter: 'broken_links'))
+    expect(page).to have_link('Zorro Council', href: local_authority_path(@zorro.slug, filter: 'broken_links'))
   end
 
   it "shows the count of broken links for each local authority" do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -64,6 +64,16 @@ feature "The local authority show page" do
 
     let(:http_status) { 200 }
 
+    it 'shows a count of the number of all links for enabled services' do
+      within('thead') do
+        expect(page).to have_content "2 links"
+      end
+    end
+
+    it "displays a filter box" do
+      expect(page).to have_selector('.filter-control')
+    end
+
     it 'has navigation tabs' do
       expect(page).to have_selector('.link-nav')
       within('.link-nav') do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -56,16 +56,26 @@ feature "The local authority show page" do
     before do
       @service = create(:service, :all_tiers)
       @disabled_service = create(:disabled_service)
-      @link = create_service_interaction_link(@service)
-      create_service_interaction_link(@disabled_service)
+      @good_link = create_service_interaction_link(@service, 200)
+      @disabled_link = create_service_interaction_link(@disabled_service, 200)
+      @broken_link = create_service_interaction_link(@service, 500)
       visit local_authority_path(@local_authority)
     end
 
     let(:http_status) { 200 }
 
+    it 'has navigation tabs' do
+      expect(page).to have_selector('.link-nav')
+      within('.link-nav') do
+        expect(page).to have_link 'Broken links'
+        expect(page).to have_link 'Good links'
+        expect(page).to have_link 'All links'
+      end
+    end
+
     it "shows only the enabled services provided by the authority according to its tier with links to their individual pages" do
       expect(page).to have_content 'Services and links'
-      expect(page).to have_link(@link.service.label, href: local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @link.service.slug))
+      expect(page).to have_link(@good_link.service.label, href: local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @good_link.service.slug))
     end
 
     it "does not show the disabled service interaction" do
@@ -74,32 +84,57 @@ feature "The local authority show page" do
 
     it "shows each service's LGSL codes in the table" do
       expect(page).to have_content 'Code'
-      expect(page).to have_css('td.lgsl', text: @link.service.lgsl_code)
+      expect(page).to have_css('td.lgsl', text: @good_link.service.lgsl_code)
     end
 
     it 'shows the link status as Good Link when the status is 200' do
-      within(:css, "tr[data-interaction-id=\"#{@link.interaction.id}\"]") do
+      within(:css, "tr[data-interaction-id=\"#{@good_link.interaction.id}\"]") do
         expect(page).to have_text 'Good'
       end
     end
 
     it 'shows the link last checked details' do
-      expect(page).to have_text @link.link_last_checked
+      expect(page).to have_text @good_link.link_last_checked
     end
 
     it 'should have a link to Edit Link' do
-      expect(page).to have_link 'Edit link', href: edit_link_path(@local_authority, @service, @link.interaction)
+      expect(page).to have_link 'Edit link', href: edit_link_path(@local_authority, @service, @good_link.interaction)
     end
 
-    context "when the status is 404" do
-      let(:http_status) { 404 }
-      it 'shows the link status as Broken Link 404 when the status is 404' do
-        expect(page).to have_text 'Broken Link 404'
+    it 'shows the status of broken links' do
+      expect(page).to have_text "Server Error 500"
+    end
+
+    describe 'broken links' do
+      before do
+        click_link "Broken links"
+      end
+
+      it 'shows non-200 status links' do
+        expect(page).to have_link @broken_link.url
+      end
+
+      it 'doesn\'t show 200 status links' do
+        expect(page).not_to have_link @good_link.url
+      end
+    end
+
+    describe 'good links' do
+      before do
+        click_link "Good links"
+      end
+
+      it 'shows 200 status links' do
+        expect(page).to have_link @good_link.url
+      end
+
+      it 'doesn\'t show non-200 status links' do
+        expect(page).not_to have_link @broken_link.url
       end
     end
   end
 
-  def create_service_interaction_link(service)
+  def create_service_interaction_link(service, http_status)
     service_interaction = create(:service_interaction, service: service)
 
     create(:link, local_authority: @local_authority, service_interaction: service_interaction, status: http_status)


### PR DESCRIPTION
The Local Authority page now shows the Broken links, Good links and All links tabs, as well as total link count sorted alphabetically by service.

<img width="1165" alt="screen shot 2016-11-23 at 14 13 23" src="https://cloud.githubusercontent.com/assets/608867/20564880/0a6b06e0-b187-11e6-981d-b4da02c05758.png">

[Trello Card](https://trello.com/c/0UprwqoR/552-make-specific-council-page-filterable-sortable-and-searchable-2)

Mobbed by @whoojemaflip, @brenetic and @issyl0 