### PR TITLE
Update the specific council service page based on the prototype

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -49,6 +49,6 @@ private
   def redirect(action = 'saved')
     flash[:success] = "Link has been #{action}."
     flash[:lgil] = @interaction.lgil_code
-    redirect_to interactions_path(local_authority_slug: params[:local_authority_slug], service_slug: params[:service_slug])
+    redirect_to local_authority_with_service_path(local_authority_slug: params[:local_authority_slug], service_slug: params[:service_slug])
   end
 end

--- a/app/presenters/service_link_presenter.rb
+++ b/app/presenters/service_link_presenter.rb
@@ -34,14 +34,14 @@ class ServiceLinkPresenter < SimpleDelegator
   end
 
   def interactions_path
-    view_context.interactions_path(
+    view_context.local_authority_with_service_path(
       local_authority,
       service
     )
   end
 
   def edit_path
-    view_context.edit_interaction_links_path(
+    view_context.edit_link_path(
       local_authority,
       service,
       interaction

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -2,36 +2,30 @@
 
 <% breadcrumb :interactions, @authority, @service %>
 
-<%= render partial: "shared/local_authority_details", locals: {authority: @authority} %>
-
 <div class="page-title">
+  <h1><%= @authority.name %></h1>
+
   <h2><%= @service.label %></h2>
+  <p><b>Service code</b> <%= @service.lgsl_code %></p>
 </div>
 
 <% if flash[:success] %>
 <div class="alert alert-success"><%= flash[:success] %></div>
 <% end %>
 
-<p><b>LGSL</b> <%= @service.lgsl_code %></p>
-
 <% if @interactions.any? %>
-  <table class="table table-striped table-hover table-bordered contacts-table" data-module="filterable-table">
+  <table class="table table-bordered">
     <thead>
       <tr class="table-header">
-        <th>LGIL Code</th>
-        <th>Local Government Interactions (<%= @interactions.count %>)</th>
+        <th>Interactions and links</th>
         <th>Link status</th>
         <th></th>
       </tr>
-      <%= render partial: "govuk_admin_template/table_filter",
-      locals: {placeholder: "Filter list of local interactions"} %>
     </thead>
     <tbody>
       <% @interactions.each do |interaction| %>
+        <% next if interaction.link_url.nil? %>
         <tr id="<%= interaction.lgil_code %>" <% if flash[:lgil] == interaction.lgil_code %>class="success"<% end %>>
-          <td class="lgil_code text-center">
-            <%= interaction.lgil_code %>
-          </td>
           <td class="name">
             <%= interaction.label %>
             <p><%= link_to_if interaction.link_url, nil, interaction.link_url %></p>
@@ -45,7 +39,7 @@
             </p>
           </td>
           <td class='text-center'>
-            <%= link_to(interaction.button_text, edit_interaction_links_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
+            <%= link_to(interaction.button_text, edit_link_path(interaction_slug: interaction.slug), class: "btn btn-default btn-s") %>
           </td>
         </tr>
       <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -12,7 +12,7 @@
 
 <p><b>LGSL</b> <%= @service.lgsl_code %><b class="add-left-margin">LGIL</b> <%= @interaction.lgil_code %></p>
 
-<%= form_for @link, url: interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
+<%= form_for @link, url: link_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
   <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <div class='col-xs-12 no-gutter'>
       <%= f.label :url, 'URL' %>
@@ -23,7 +23,7 @@
     </div>
 
     <div class='actions add-vertical-margins col-xs-6 no-gutter'>
-      <%= link_to 'Cancel', interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
+      <%= link_to 'Cancel', local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
       <button type='submit' class='btn btn-success'>Save</button>
     </div>
   </div>
@@ -31,7 +31,7 @@
 
 <% if @link.url %>
   <div class='actions add-vertical-margins col-xs-6 no-gutter'>
-    <%= form_tag(interaction_links_path(@local_authority.slug, @service.slug, @interaction.slug), method: :delete) do %>
+    <%= form_tag(link_path(@local_authority.slug, @service.slug, @interaction.slug), method: :delete) do %>
       <button name="submit" class="btn btn-danger pull-right">Delete</button>
     <% end %>
   </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -13,11 +13,11 @@ crumb :service do |service|
 end
 
 crumb :interactions do |local_authority, service|
-  link service.label, interactions_path(local_authority.slug, service.slug)
+  link service.label, local_authority_with_service_path(local_authority.slug, service.slug)
   parent :services, local_authority
 end
 
 crumb :links do |local_authority, service, interaction|
-  link interaction.label, interaction_links_path(local_authority.slug, service.slug, interaction.slug)
+  link interaction.label, link_path(local_authority.slug, service.slug, interaction.slug)
   parent :interactions, local_authority, service
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,8 @@ Rails.application.routes.draw do
   resources 'services', only: [:index, :show], param: :service_slug
 
   scope '/local_authorities/:local_authority_slug/services/:service_slug' do
-    resources "interactions", only: [:index], param: :slug do
-      resource "links", only: [:edit, :update, :destroy]
-    end
+    root to: 'interactions#index', as: 'local_authority_with_service'
+    resource ':interaction_slug', only: [:edit, :update, :destroy], controller: 'links', as: 'link'
   end
 
   get '/check_homepage_links_status.csv', to: 'links#homepage_links_status_csv'

--- a/spec/features/interactions/interactions_index_spec.rb
+++ b/spec/features/interactions/interactions_index_spec.rb
@@ -5,11 +5,11 @@ feature "The interactions index page for a service provided by a local authority
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
     @local_authority = FactoryGirl.create(:county_council)
     @service_1 = FactoryGirl.create(:service, :county_unitary)
-    visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
+    visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
   end
 
   it "displays the LGSL code" do
-    expect(page).to have_content("LGSL #{@service_1.lgsl_code}")
+    expect(page).to have_content("Service code #{@service_1.lgsl_code}")
   end
 
   it 'has a list of breadcrumbs pointing back to the authority and service that lead us here' do
@@ -29,27 +29,17 @@ feature "The interactions index page for a service provided by a local authority
   describe "with interactions present" do
     before do
       @interaction_1 = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 3)
-      @interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 4)
       @service_interaction = FactoryGirl.create(:service_interaction, service_id: @service_1.id, interaction_id: @interaction_1.id)
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
+      visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service_1.slug)
     end
 
-    it "shows the local authority name and homepage_url" do
+    it "shows the local authority name" do
       expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.homepage_url)
     end
 
-    it "shows the available interactions for the service" do
-      expect(page).to have_content('Local Government Interactions (1)')
-      expect(page).to have_content('Interaction 1')
-      # Interaction 2 does not belong to service 1, so don't display it.
-      expect(page).not_to have_content('Interaction 2')
-    end
-
-    it "shows each service interaction's LGIL code" do
-      expect(page).to have_content 'LGIL Code'
-      expect(page).to have_css('td.lgil_code', text: 3)
-      expect(page).not_to have_css('td.lgil_code', text: 4)
+    it "doesn't show the available interactions for the service if there aren't any links for them" do
+      expect(page).to have_content('Interactions and links')
+      expect(page).not_to have_content('Interaction 1')
     end
   end
 end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -4,80 +4,35 @@ feature 'The links for a local authority' do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
     @time = Timecop.freeze("2016-07-14 11:34:09 +0100")
-    @local_authority = FactoryGirl.create(:local_authority, status: '200', link_last_checked: @time - (60 * 60))
-    @service = FactoryGirl.create(:service)
-    @interaction_1 = FactoryGirl.create(:interaction)
-    @interaction_2 = FactoryGirl.create(:interaction)
-    @service_interaction_1 = FactoryGirl.create(:service_interaction, service: @service, interaction: @interaction_1)
-    @service_interaction_2 = FactoryGirl.create(:service_interaction, service: @service, interaction: @interaction_2)
+    @local_authority = create(:local_authority, status: '200', link_last_checked: @time - (60 * 60))
+    @service = create(:service)
+    @interaction_1 = create(:interaction)
+    @interaction_2 = create(:interaction)
+    @service_interaction_1 = create(:service_interaction, service: @service, interaction: @interaction_1)
+    @service_interaction_2 = create(:service_interaction, service: @service, interaction: @interaction_2)
   end
 
   describe "when no links exist for the service interaction" do
     before do
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+      visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
     end
 
-    it "shows an empty cell for the link next to the interactions" do
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, @interaction_1.label.to_s, 'No link', 'Add link')
-      expect(page).to have_table_row(@interaction_2.lgil_code.to_s, @interaction_2.label.to_s, 'No link', 'Add link')
-    end
-
-    it "shows an empty cell when editing a blank link" do
-      within('.table') { click_on('Add link', match: :first) }
-      expect(page.find_by_id('link_url').value).to be_blank
-    end
-
-    it "allows us to save a new link and view it" do
-      within('.table') { click_on('Add link', match: :first) }
-      fill_in('link_url', with: 'http://angus.example.com/new-link')
-      click_on('Save')
-
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, "#{@interaction_1.label} http://angus.example.com/new-link", 'Link not checked', 'Edit link')
-      expect(page).to have_content('Link has been saved.')
-    end
-
-    it "shows the name of the local authority" do
-      within('.table') { click_on('Add link', match: :first) }
-      expect(page).to have_css('h1', text: @local_authority.name)
-      expect(page).to have_link(@local_authority.homepage_url)
-      expect(page).to have_content('Good Checked about 1 hour ago')
-      expect(page).to have_css(".label-success")
-      expect(page).not_to have_css(".label-danger")
-    end
-
-    it "does not save invalid links" do
-      within('.table') { click_on('Add link', match: :first) }
-      expect { click_on('Save') }.to change { Link.count }.by(0)
-      expect(page).to have_content('Please enter a valid link')
-    end
-
-    it "does not show a delete button after clicking on add" do
-      within('.table') { click_on('Add link', match: :first) }
-      expect(page).not_to have_button("Delete")
-    end
-
-    it "shows 'No link' in the 'Link status' column if the interaction has no link" do
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
-
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, @interaction_1.label.to_s, 'No link', 'Add link')
-
-      within("##{@interaction_1.lgil_code} .status") do
-        expect(page).not_to have_css(".label-success")
-        expect(page).not_to have_css(".label-danger")
-      end
+    it "does not show the link" do
+      expect(page).not_to have_table_row(@interaction_1.label.to_s)
+      expect(page).not_to have_table_row(@interaction_2.label.to_s)
     end
   end
 
   describe "when links exist for the service interaction" do
     before do
-      @link_1 = FactoryGirl.create(:link, local_authority: @local_authority, service_interaction: @service_interaction_1, status: "200", link_last_checked: @time - (60 * 60))
-      @link_2 = FactoryGirl.create(:link, local_authority: @local_authority, service_interaction: @service_interaction_2)
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+      @link_1 = create(:link, local_authority: @local_authority, service_interaction: @service_interaction_1, status: "200", link_last_checked: @time - (60 * 60))
+      @link_2 = create(:link, local_authority: @local_authority, service_interaction: @service_interaction_2)
+      visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
     end
 
     it "shows the url for the link next to the relevant interaction" do
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, "#{@interaction_1.label} #{@link_1.url}", 'Good Checked about 1 hour ago', 'Edit link')
-      expect(page).to have_table_row(@interaction_2.lgil_code.to_s, "#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_1.label} #{@link_1.url}", 'Good Checked about 1 hour ago', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
     end
 
     it "shows the urls as clickable links" do
@@ -87,7 +42,7 @@ feature 'The links for a local authority' do
 
     it "allows us to edit a link" do
       expect(page).to have_link('Edit link',
-        href: edit_interaction_links_path(
+        href: edit_link_path(
           local_authority_slug: @local_authority.slug,
           service_slug: @service.slug,
           interaction_slug: @interaction_1.slug
@@ -103,8 +58,8 @@ feature 'The links for a local authority' do
       fill_in('link_url', with: 'http://angus.example.com/changed-link')
       click_on('Save')
 
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, "#{@interaction_1.label} http://angus.example.com/changed-link", 'Link not checked', 'Edit link')
-      expect(page).to have_table_row(@interaction_2.lgil_code.to_s, "#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_1.label} http://angus.example.com/changed-link", 'Link not checked', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
       expect(page).to have_content('Link has been saved.')
     end
 
@@ -131,12 +86,12 @@ feature 'The links for a local authority' do
       fill_in('link_url', with: 'http://angus.example.com/link-to-delete')
       click_on('Save')
 
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, "#{@interaction_1.label} http://angus.example.com/link-to-delete", 'Link not checked', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_1.label} http://angus.example.com/link-to-delete", 'Link not checked', 'Edit link')
 
       within('.table') { click_on('Edit link', match: :first) }
       click_on('Delete')
 
-      expect(page).to have_table_row(@interaction_1.lgil_code.to_s, @interaction_1.label.to_s, 'No link', 'Add link')
+      expect(page).not_to have_table_row(@interaction_1.label.to_s)
     end
 
     it "shows a 'Good' link status and time the link was last checked in the 'Link status' column when a link returns a 200 status code" do
@@ -150,7 +105,7 @@ feature 'The links for a local authority' do
     it "shows 'Link not checked' in the 'Link status' column after a link has been updated" do
       @link_1.url = "#{@local_authority.homepage_url}/new-link"
       @link_1.save
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+      visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
 
       within("##{@interaction_1.lgil_code} .status") do
         expect(page).to have_content("Link not checked")
@@ -161,22 +116,12 @@ feature 'The links for a local authority' do
     it "shows a 'Broken Link 404' and the time the link was last checked in the 'Link status' column when a link returns a 404 status code" do
       @link_1.status = '404'
       @link_1.save
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
+      visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
 
       within("##{@interaction_1.lgil_code} .status") do
         expect(page).to have_content("Broken Link 404 Checked about 1 hour ago")
         expect(page).not_to have_css(".label-success")
         expect(page).to have_css(".label-danger")
-      end
-    end
-
-    it "shows 'No link' and no time when there is no link" do
-      @link_1.destroy
-      visit interactions_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
-
-      within("##{@interaction_1.lgil_code} .status") do
-        expect(page).to have_content("No link")
-        expect(page).not_to have_css(".label")
       end
     end
   end
@@ -191,7 +136,7 @@ feature 'The links for a local authority' do
 
   describe "interaction link status CSV" do
     before do
-      FactoryGirl.create(:link, status: '200', link_last_checked: @time - (60 * 60))
+      create(:link, status: '200', link_last_checked: @time - (60 * 60))
     end
 
     it "should show a CSV" do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -71,7 +71,7 @@ feature "The local authority show page" do
 
     it "shows only the enabled services provided by the authority according to its tier with links to their individual pages" do
       expect(page).to have_content 'Services and links'
-      expect(page).to have_link(@link.service.label, href: interactions_path(local_authority_slug: @local_authority.slug, service_slug: @link.service.slug))
+      expect(page).to have_link(@link.service.label, href: local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @link.service.slug))
     end
 
     it "does not show the disabled service interaction" do
@@ -94,7 +94,7 @@ feature "The local authority show page" do
     end
 
     it 'should have a link to Edit Link' do
-      expect(page).to have_link 'Edit link', href: edit_interaction_links_path(@local_authority, @service, @link.interaction)
+      expect(page).to have_link 'Edit link', href: edit_link_path(@local_authority, @service, @link.interaction)
     end
 
     context "when the status is 404" do

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -87,7 +87,7 @@ feature 'The services show page' do
 
     it 'the Service name is linked to the service page for that council' do
       for_local_authority_interactions(@council_a, @link_1.interaction) do
-        expect(page).to have_link @service.label, href: interactions_path(@council_a, @service)
+        expect(page).to have_link @service.label, href: local_authority_with_service_path(@council_a, @service)
       end
     end
 
@@ -117,7 +117,7 @@ feature 'The services show page' do
 
     it 'should have a link to Edit Link' do
       for_local_authority_interactions(@council_a, @link_1.interaction) do
-        expect(page).to have_link 'Edit link', href: edit_interaction_links_path(@council_a, @service, @link_1.interaction)
+        expect(page).to have_link 'Edit link', href: edit_link_path(@council_a, @service, @link_1.interaction)
       end
     end
   end


### PR DESCRIPTION
We've changed the routes to not be
`local-authorities/local_authority_name/services/service_name/interactions`
but instead `local-authorities/local_authority_name/interaction_name` as
per the prototype layout. Fixed all the failing tests as a result of this.

We also took out the LGIL code, and replaced "LGSL" with "Service code" as
a description. We also removed the homepage URL displaying.

Lastly, we removed the ability for people to add new links, pending further
user research.

Trello: https://trello.com/c/zHKGufLG/562-specific-council-and-service-page-2

Mobbed with @deborahchua, @brenetic and @issyl0.