### PR TITLE
Update edit link page

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -3,6 +3,39 @@ require 'local-links-manager/export/link_status_exporter'
 class LinksController < ApplicationController
   before_action :load_dependencies
 
+  def edit
+    flash[:back] = request.env['HTTP_REFERER']
+    if flash[:link_url]
+      @link.url = flash[:link_url]
+      @link.validate
+    end
+  end
+
+  def update
+    @link.url = link_url
+
+    if @link.save
+      @link.local_authority.update_broken_link_count
+      @link.service.update_broken_link_count
+      redirect
+    else
+      flash[:danger] = "Please enter a valid link."
+      flash[:back] = flash[:back]
+      redirect_back
+    end
+  end
+
+  def destroy
+    if @link.destroy
+      redirect('deleted')
+    else
+      flash.now[:danger] = "Could not delete link."
+      flash[:back] = flash[:back]
+      flash[:danger] = "Could not delete link."
+      redirect_back
+    end
+  end
+
   def homepage_links_status_csv
     data = LocalLinksManager::Export::LinkStatusExporter.homepage_links_status_csv
     send_data data, filename: "homepage_links_status.csv"
@@ -13,30 +46,6 @@ class LinksController < ApplicationController
     send_data data, filename: "links_status.csv"
   end
 
-  def edit; end
-
-  def update
-    @link.url = params[:link][:url].strip
-
-    if @link.save
-      @link.local_authority.update_broken_link_count
-      @link.service.update_broken_link_count
-      redirect
-    else
-      flash.now[:danger] = "Please enter a valid link."
-      render :edit
-    end
-  end
-
-  def destroy
-    if @link.destroy
-      redirect('deleted')
-    else
-      flash.now[:danger] = "Could not delete link."
-      render :edit
-    end
-  end
-
 private
 
   def load_dependencies
@@ -44,6 +53,19 @@ private
     @interaction = Interaction.find_by(slug: params[:interaction_slug])
     @service = Service.find_by(slug: params[:service_slug])
     @link = Link.retrieve(params)
+  end
+
+  def set_back_url_before_post_request
+    flash[:back] = flash[:back] || request.env['HTTP_REFERER']
+  end
+
+  def link_url
+    params[:link][:url].strip
+  end
+
+  def redirect_back
+    flash[:link_url] = link_url
+    redirect_to edit_link_path(@local_authority, @service, @interaction)
   end
 
   def redirect(action = 'saved')

--- a/app/presenters/url_status_presentation.rb
+++ b/app/presenters/url_status_presentation.rb
@@ -23,4 +23,10 @@ module UrlStatusPresentation
       "Link not checked"
     end
   end
+
+  def updated?
+    view_context.flash[:updated].present? &&
+      view_context.flash[:updated]['url'] == url &&
+      view_context.flash[:updated]['lgil'] == interaction.lgil_code
+  end
 end

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -24,7 +24,12 @@
   <tbody>
     <% @interactions.each do |interaction| %>
       <% next if interaction.link_url.nil? %>
-      <tr id="<%= interaction.lgil_code %>" <% if flash[:lgil] == interaction.lgil_code %>class="success"<% end %>>
+      <tr id="<%= interaction.lgil_code %>"
+      <% if flash[:updated].present? &&
+            flash[:updated]['url'] == interaction.link_url &&
+            flash[:updated]['lgil'] == interaction.lgil_code %>
+        class="success"
+      <% end %>>
         <td class="name">
           <%= interaction.label %>
           <p><%= link_to_if interaction.link_url, nil, interaction.link_url %></p>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,30 +1,32 @@
 <% breadcrumb :links, @local_authority, @service, @interaction %>
 
-<%= render partial: "shared/local_authority_details", locals: {authority: @local_authority} %>
-
 <div class="page-title">
-  <h2><%= @interaction.label %></h2>
+  <h1><%= @local_authority.name %></h1>
+
+  <h2><%= @service.label %></h2>
+  <p><b>Service code</b> <%= @service.lgsl_code %></p>
 </div>
+
 
 <% if flash[:danger] %>
 <div class="alert alert-danger"><%= flash[:danger] %></div>
 <% end %>
 
-<p><b>LGSL</b> <%= @service.lgsl_code %><b class="add-left-margin">LGIL</b> <%= @interaction.lgil_code %></p>
+<h3><%= @interaction.label %></h3>
 
 <%= form_for @link, url: link_path(@local_authority.slug, @service.slug, @interaction.slug), method: "put" do |f| %>
   <div class="form-group <% if flash[:danger] %>has-error<% end %>">
     <div class='col-xs-12 no-gutter'>
-      <%= f.label :url, 'URL' %>
+      <%= f.label :url, 'Page URL' %>
 
-      <p class="text-muted">eg http://www.local-authority.gov.uk</p>
+      <p class="text-muted">for example http://www.local-authority.gov.uk</p>
 
       <%= f.text_field :url, class: "form-control" %>
     </div>
 
     <div class='actions add-vertical-margins col-xs-6 no-gutter'>
       <%= link_to 'Cancel', local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
-      <button type='submit' class='btn btn-success'>Save</button>
+      <button type='submit' class='btn btn-success'>Update</button>
     </div>
   </div>
 <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -33,8 +33,6 @@
 
 <% if @link.url %>
   <div class='actions add-vertical-margins col-xs-6 no-gutter'>
-    <%= form_tag(link_path(@local_authority.slug, @service.slug, @interaction.slug), method: :delete) do %>
-      <button name="submit" class="btn btn-danger pull-right">Delete</button>
-    <% end %>
+    <%= button_to 'Delete', link_path(@local_authority.slug, @service.slug, @interaction.slug), method: :delete, class: 'btn btn-danger pull-right', data: { confirm: 'Are you sure you wish to delete this link?' } %>
   </div>
 <% end %>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <div class='actions add-vertical-margins col-xs-6 no-gutter'>
-      <%= link_to 'Cancel', local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug), class: 'btn btn-default add-right-margin' %>
+      <%= link_to 'Cancel', back_url, class: 'btn btn-default add-right-margin' %>
       <button type='submit' class='btn btn-success'>Update</button>
     </div>
   </div>

--- a/app/views/shared/_link_table_row.html.erb
+++ b/app/views/shared/_link_table_row.html.erb
@@ -1,4 +1,10 @@
-<%= content_tag 'tr', class: link.first ? 'first-row' : '', data: link.row_data do %>
+<%= content_tag 'tr',
+    class: [
+      link.first ? 'first-row' : '',
+      link.updated? ? 'success' : ''
+    ].join(' '),
+    data: link.row_data do
+%>
   <td class="text-center lgsl">
     <p><%= link.lgsl_code %></p>
   </td>

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -49,14 +49,16 @@ feature 'The links for a local authority' do
         )
       )
       within('.table') { click_on('Edit link', match: :first) }
+      expect(page).to have_text(@service.label)
+      expect(page).to have_text(@interaction_1.label)
       expect(page).to have_field('link_url', with: @link_1.url.to_s)
-      expect(page).to have_button('Save')
+      expect(page).to have_button('Update')
     end
 
     it "allows us to save an edited link and view it" do
       within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/changed-link')
-      click_on('Save')
+      click_on('Update')
 
       expect(page).to have_table_row("#{@interaction_1.label} http://angus.example.com/changed-link", 'Link not checked', 'Edit link')
       expect(page).to have_table_row("#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
@@ -74,7 +76,7 @@ feature 'The links for a local authority' do
     it "shows a warning if the URL is not a valid URL" do
       within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'linky loo')
-      click_on('Save')
+      click_on('Update')
 
       expect(page).to have_content('Please enter a valid link')
       expect(page).to have_field('link_url', with: 'linky loo')
@@ -84,7 +86,7 @@ feature 'The links for a local authority' do
     it "allows us to delete a link" do
       within('.table') { click_on('Edit link', match: :first) }
       fill_in('link_url', with: 'http://angus.example.com/link-to-delete')
-      click_on('Save')
+      click_on('Update')
 
       expect(page).to have_table_row("#{@interaction_1.label} http://angus.example.com/link-to-delete", 'Link not checked', 'Edit link')
 

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -111,6 +111,23 @@ feature "The local authority show page" do
       expect(page).to have_link 'Edit link', href: edit_link_path(@local_authority, @service, @good_link.interaction)
     end
 
+    context 'editing a link' do
+      it 'returns you to the correct page after updating a link' do
+        within('.table') { click_on('Edit link', match: :first) }
+        fill_in('link_url', with: 'http://angus.example.com/link-to-change')
+        click_on('Update')
+
+        expect(page.current_path).to eq(local_authority_path(@local_authority))
+      end
+
+      it 'returns you to the correct page after cancelling the editing of a link' do
+        within('.table') { click_on('Edit link', match: :first) }
+        click_on('Cancel')
+
+        expect(page.current_path).to eq(local_authority_path(@local_authority))
+      end
+    end
+
     it 'shows the status of broken links' do
       expect(page).to have_text "Server Error 500"
     end


### PR DESCRIPTION
- The edit link page now has both the service title and the interaction
title
- 'LGSL code' is now 'Service code'
- Removed LGIL
- 'URL' is now 'Page URL'
- Removed the ability to edit the homepage url
- 'Save' is now 'Update'
- Confirmation before deletion message
- Return to correct page upon update, cancel and delete of a link

# Before

<img width="1172" alt="before" src="https://cloud.githubusercontent.com/assets/3466862/20602414/f584cfee-b254-11e6-8e5d-1720cae02bc3.png">

# After

<img width="1183" alt="after" src="https://cloud.githubusercontent.com/assets/3466862/20602823/d477defc-b256-11e6-8e16-237b90d8361b.png">

<img width="1170" alt="screen shot 2016-11-25 at 12 34 47" src="https://cloud.githubusercontent.com/assets/3466862/20625494/a0b30244-b30b-11e6-97bc-c44010b51cce.png">


[Trello card](https://trello.com/c/gh6xcdeY/564-update-edit-links-and-add-link-pages-2)