### PR TITLE
Backup airbrake versions a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ else
 end
 
 gem 'addressable'
-gem 'airbrake', '~> 5.6.1'
-gem 'airbrake-ruby', '1.6'
+gem 'airbrake', '~> 5.5'
+gem 'airbrake-ruby', '1.5'
 gem 'dalli'
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    airbrake (5.6.1)
-      airbrake-ruby (~> 1.6)
-    airbrake-ruby (1.6.0)
+    airbrake (5.5.0)
+      airbrake-ruby (~> 1.5)
+    airbrake-ruby (1.5.0)
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
@@ -335,8 +335,8 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
-  airbrake (~> 5.6.1)
-  airbrake-ruby (= 1.6)
+  airbrake (~> 5.5)
+  airbrake-ruby (= 1.5)
   capistrano-rails
   capybara (~> 2.7)
   dalli


### PR DESCRIPTION
We're running an older version of errbit which doesn't seem to like the newer
versions of `airbrake` and `airbrake-ruby`.  These versions are the same as
Specialist-Publisher and Publishing-Api and worked OK when deployed in a
branch.