### PR TITLE
Update broken_link_count to ignore disabled links

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -32,7 +32,7 @@ class LocalAuthority < ApplicationRecord
   def update_broken_link_count
     update_attribute(
       :broken_link_count,
-      links.have_been_checked.currently_broken.count
+      provided_service_links.have_been_checked.currently_broken.count
     )
   end
 

--- a/spec/factories/service_interactions.rb
+++ b/spec/factories/service_interactions.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :service_interaction do
     association :interaction
-    association :service
+    association :service, :all_tiers
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe LocalAuthority, type: :model do
   describe 'validations' do
     before(:each) do
-      FactoryGirl.create(:local_authority)
+      create(:local_authority)
     end
 
     it { should validate_presence_of(:name) }
@@ -38,14 +38,14 @@ RSpec.describe LocalAuthority, type: :model do
   end
 
   describe '#provided_services' do
-    let!(:all_service) { FactoryGirl.create(:service, :all_tiers) }
-    let!(:county_service) { FactoryGirl.create(:service, :county_unitary) }
-    let!(:district_service) { FactoryGirl.create(:service, :district_unitary) }
-    let!(:nil_service) { FactoryGirl.create(:service) }
-    let!(:disabled_service) { FactoryGirl.create(:disabled_service, :district_unitary) }
+    let!(:all_service) { create(:service, :all_tiers) }
+    let!(:county_service) { create(:service, :county_unitary) }
+    let!(:district_service) { create(:service, :district_unitary) }
+    let!(:nil_service) { create(:service) }
+    let!(:disabled_service) { create(:disabled_service, :district_unitary) }
 
     context 'for a "district" LA' do
-      subject { FactoryGirl.create(:district_council) }
+      subject { create(:district_council) }
 
       it 'returns all and district/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, district_service])
@@ -53,7 +53,7 @@ RSpec.describe LocalAuthority, type: :model do
     end
 
     context 'for a "county" LA' do
-      subject { FactoryGirl.create(:county_council) }
+      subject { create(:county_council) }
 
       it 'returns all and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service])
@@ -61,7 +61,7 @@ RSpec.describe LocalAuthority, type: :model do
     end
 
     context 'for a "unitary" LA' do
-      subject { FactoryGirl.create(:unitary_council) }
+      subject { create(:unitary_council) }
 
       it 'returns all, district/unitary, and county/unitary services that are enabled' do
         expect(subject.provided_services).to match_array([all_service, county_service, district_service])
@@ -70,7 +70,7 @@ RSpec.describe LocalAuthority, type: :model do
 
     describe "after_update" do
       it "sets the homepage url status and last checked time to nil if the homepage url is updated" do
-        @local_authority = FactoryGirl.create(:local_authority, status: "200", link_last_checked: Time.now)
+        @local_authority = create(:local_authority, status: "200", link_last_checked: Time.now)
         @local_authority.homepage_url = "http://example.com"
         @local_authority.save!
         expect(@local_authority.status).to be_nil
@@ -81,14 +81,14 @@ RSpec.describe LocalAuthority, type: :model do
 
   describe "#tier" do
     it "is a string representation of the Tier" do
-      local_authority = FactoryGirl.create(:district_council)
+      local_authority = create(:district_council)
       expect(local_authority.tier).to eql 'district'
     end
   end
 
   describe "#update_broken_link_count" do
     it "updates the broken_link_count" do
-      link = FactoryGirl.create(:link, status: 500)
+      link = create(:link, status: 500)
       local_authority = link.local_authority
       expect { local_authority.update_broken_link_count }
         .to change { local_authority.broken_link_count }
@@ -96,11 +96,19 @@ RSpec.describe LocalAuthority, type: :model do
     end
 
     it "ignores unchecked links" do
-      local_authority = FactoryGirl.create(:local_authority, broken_link_count: 1)
-      FactoryGirl.create(:link, local_authority: local_authority, status: nil)
+      local_authority = create(:local_authority, broken_link_count: 1)
+      create(:link, local_authority: local_authority, status: nil)
       expect { local_authority.update_broken_link_count }
         .to change { local_authority.broken_link_count }
         .from(1).to(0)
+    end
+
+    it "ignores broken links that are not provided by the local_authority" do
+      disabled_service_link = create(:link_for_disabled_service, status: 500)
+      local_authority = disabled_service_link.local_authority
+
+      expect { local_authority.update_broken_link_count }
+        .to_not change { local_authority.broken_link_count }
     end
   end
 end


### PR DESCRIPTION
Previously when calculating the broken links count, we would count links that were associated with disabled services. This led to a big discrepancy between link count and the listing of the broken links. This commit fixes the problem by using the `provided_service_links` method which takes enabled services and tiers into consideration. Note that we update the service factory to default to supporting all tiers, otherwise calling `provided_service_links` for a service (when created by Factory) would not return anything.

We also remove the `FactoryGirl.` call which is no longer necessary.