### PR TITLE
Fix caching issue

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,12 +9,13 @@ module ApplicationHelper
     num == 1 ? 'singular' : 'plural'
   end
 
-  # Used to set a compound cache key for fragment caches.
-  # Namespaced to the controller and action, and with
-  # a possible 'vary' string. The 'obj' parameter is expected to be
-  # an ActiveRecord object, or at least something that implements the
-  # #cache_key method.
-  def namespaced_cache_key(obj, vary)
-    [controller_name, controller.action_name, obj.cache_key, vary.to_s].join('/')
+  # Used to set a compound cache key for fragment caches
+  # that is namespaced to the controller and action.
+  # The 'objs' parameter is expected to be
+  # an array of ActiveRecord objects or strings.
+  def namespaced_cache_key(*objs)
+    [controller_name, controller.action_name].concat(
+      objs.map { |obj| obj.try(:cache_key) || obj.to_s }
+    ).join('/')
   end
 end

--- a/app/views/local_authorities/_service.html.erb
+++ b/app/views/local_authorities/_service.html.erb
@@ -1,6 +1,6 @@
 <% links_by_service = links[service.id] %>
 <% unless links_by_service.blank? %>
-  <% cache namespaced_cache_key(service, @link_filter) do %>
+  <% cache namespaced_cache_key(service, @authority, @link_filter) do %>
     <% first_link, *remaining_links = links_by_service %>
     <%= render 'shared/link_table_row', link: ServiceLinkPresenter.new(first_link, view_context: self, first: true) %>
     <% remaining_links.each do |link| %>

--- a/app/views/services/_local_authority.html.erb
+++ b/app/views/services/_local_authority.html.erb
@@ -1,6 +1,6 @@
 <% links_by_authority = @links[local_authority.id] %>
 <% unless links_by_authority.blank? %>
-  <% cache namespaced_cache_key(local_authority, @link_filter) do %>
+  <% cache namespaced_cache_key(local_authority, @service, @link_filter) do %>
     <%= render partial: 'service_links_by_authority', locals: { local_authority: local_authority, links_by_authority: links_by_authority } %>
   <% end %>
 <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe ApplicationHelper do
+  describe "#namespaced_cache_key" do
+    let(:cacheable_record) { double(:record, cache_key: '123') }
+    let(:string) { double(:string, to_s: '789') }
+    let(:result) do
+      helper.namespaced_cache_key(
+        cacheable_record,
+        string,
+        cacheable_record,
+        string
+      )
+    end
+
+    it "returns a string comprised of the cache-keys of the params" do
+      expect(result).to include "123/789/123/789"
+    end
+  end
+end


### PR DESCRIPTION
The cache-keys for fragments rendered in the Specific Service and
Specific Council pages were incorrectly missing an identifier. This meant
that some services were occasionally appearing for unexpected councils.