### PR TITLE
Fixes column widths on Links page

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -18,6 +18,7 @@ table.table-service {
     border-top: none !important;
     border-bottom: none !important;
   }
+  td.status { width: 180px; }
 }
 
 table.table-with-counts {

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -13,7 +13,7 @@
 <div class="alert alert-success"><%= flash[:success] %></div>
 <% end %>
 
-<table class="table table-bordered">
+<table class="table table-bordered table-service">
   <thead>
     <tr class="table-header">
       <th>Interactions and links</th>


### PR DESCRIPTION
When rendering a page with a reaaaally long link, the first column was getting out of hand. 

From this:
<img width="1421" alt="screen shot 2016-12-02 at 16 05 07" src="https://cloud.githubusercontent.com/assets/608867/20840742/2f79cbc8-b8a9-11e6-98de-755bbaf2c70e.png">

To this:
<img width="1195" alt="screen shot 2016-12-02 at 16 05 23" src="https://cloud.githubusercontent.com/assets/608867/20840752/34a7c83e-b8a9-11e6-8917-cf9b47c211de.png">

