### PR TITLE
Export bad link and homepage URLs and status

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,4 +1,5 @@
 require 'local-links-manager/export/link_status_exporter'
+require 'local-links-manager/export/bad_links_url_and_status_exporter'
 
 class LinksController < ApplicationController
   before_action :load_dependencies
@@ -42,6 +43,11 @@ class LinksController < ApplicationController
   def links_status_csv
     data = LocalLinksManager::Export::LinkStatusExporter.links_status_csv
     send_data data, filename: "links_status.csv"
+  end
+
+  def bad_links_url_and_status_csv
+    data = LocalLinksManager::Export::BadLinksUrlAndStatusExporter.bad_links_url_and_status_csv
+    send_data data, filename: "bad_links_url_status.csv"
   end
 
 private

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -1,3 +1,5 @@
+require 'local-links-manager/export/bad_links_url_and_status_exporter'
+
 class LocalAuthoritiesController < ApplicationController
   def index
     @authorities = LocalAuthority.order(broken_link_count: :desc)
@@ -10,6 +12,11 @@ class LocalAuthoritiesController < ApplicationController
     @services = @authority.provided_services.order('services.label ASC')
     @links = links_for_authority.group_by { |link| link.service.id }
     @link_count = links_for_authority.count
+  end
+
+  def bad_homepage_url_and_status_csv
+    data = LocalLinksManager::Export::BadLinksUrlAndStatusExporter.local_authority_bad_homepage_url_and_status_csv
+    send_data data, filename: "bad_homepage_url_status.csv"
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
   get '/check_homepage_links_status.csv', to: 'links#homepage_links_status_csv'
   get '/check_links_status.csv', to: 'links#links_status_csv'
 
+  get '/bad_links_url_status.csv', to: 'links#bad_links_url_and_status_csv'
+
+  get '/bad_homepage_url_status.csv', to: 'local_authorities#bad_homepage_url_and_status_csv'
+
   get '/api/link', to: 'api#link'
 
   get '/api/local-authority', to: 'api#local_authority'

--- a/lib/local-links-manager/export/bad_links_url_and_status_exporter.rb
+++ b/lib/local-links-manager/export/bad_links_url_and_status_exporter.rb
@@ -1,0 +1,27 @@
+require 'csv'
+
+module LocalLinksManager
+  module Export
+    class BadLinksUrlAndStatusExporter
+      HEADINGS = %w(url status).freeze
+
+      def self.local_authority_bad_homepage_url_and_status_csv
+        CSV.generate do |csv|
+          csv << HEADINGS
+          LocalAuthority.where.not(status: "200").distinct.pluck(:homepage_url, :status).each do |la|
+            csv << la
+          end
+        end
+      end
+
+      def self.bad_links_url_and_status_csv
+        CSV.generate do |csv|
+          csv << HEADINGS
+          Link.enabled_links.currently_broken.distinct.pluck(:url, :status).each do |link|
+            csv << link
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe LinksController, type: :controller do
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end
+
+  describe 'GET bad_links_url_and_status_csv' do
+    it "retrieves HTTP success" do
+      get :bad_links_url_and_status_csv
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Content-Type']).to eq('text/csv')
+    end
+  end
 end

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -31,4 +31,13 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'GET bad_homepage_url_and_status_csv' do
+    it "retrieves HTTP success" do
+      login_as_stub_user
+      get :bad_homepage_url_and_status_csv
+      expect(response).to have_http_status(:success)
+      expect(response.headers['Content-Type']).to eq('text/csv')
+    end
+  end
 end

--- a/spec/lib/local-links-manager/export/bad_links_url_and_status_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/bad_links_url_and_status_exporter_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require 'local-links-manager/export/bad_links_url_and_status_exporter'
+
+describe LocalLinksManager::Export::BadLinksUrlAndStatusExporter do
+  let(:exporter) { LocalLinksManager::Export::BadLinksUrlAndStatusExporter }
+
+
+  describe ".local_authority_bad_homepage_url_and_status_csv" do
+    before do
+      create(:local_authority, homepage_url: "http://www.hogsmeade.gov.uk", status: "403")
+      create(:local_authority, homepage_url: "http://www.godricshollow.gov.uk", status: "Timeout Error")
+      create(:local_authority, homepage_url: "http://www.azkaban.gov.uk/", status: "Connection failed")
+      create(:local_authority, homepage_url: "http://www.littlehangleton.gov.uk", status: "404")
+      create(:local_authority, homepage_url: "http://www.diagonalley.gov.uk", status: "200")
+    end
+
+    it "returns the URL and status for each local authority with a non-200 homepage" do
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).to include("url,status\n")
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).to include("http://www.hogsmeade.gov.uk,403\n")
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).to include("http://www.azkaban.gov.uk/,Connection failed\n")
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).to include("http://www.littlehangleton.gov.uk,404\n")
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).to include("http://www.godricshollow.gov.uk,Timeout Error\n")
+    end
+
+    it "does not return the URL and status for a local authority with a 200 homepage" do
+      expect(exporter.local_authority_bad_homepage_url_and_status_csv).not_to include
+      "http://www.diagonalley.gov.uk,200"
+    end
+  end
+
+  describe ".bad_links_url_and_status_csv" do
+    before do
+      create(:link, url: "http://www.hogsmeade.gov.uk/apply-to-hogwarts", status: "403")
+      create(:link, url: "http://www.godricshollow.gov.uk/report-a-broken-wand", status: "Timeout Error")
+      create(:link, url: "http://www.azkaban.gov.uk/magical-waste", status: "Connection failed")
+      create(:link, url: "http://www.littlehangleton.gov.uk/broomstick-permits", status: "404")
+      create(:link, url: "http://www.diagonalley.gov.uk/report-owl-fouling", status: "200")
+    end
+
+    it "returns the URL and status for each non-200 link" do
+      expect(exporter.bad_links_url_and_status_csv).to include("url,status\n")
+      expect(exporter.bad_links_url_and_status_csv).to include("http://www.littlehangleton.gov.uk/broomstick-permits,404\n")
+      expect(exporter.bad_links_url_and_status_csv).to include("http://www.godricshollow.gov.uk/report-a-broken-wand,Timeout Error\n")
+      expect(exporter.bad_links_url_and_status_csv).to include("http://www.hogsmeade.gov.uk/apply-to-hogwarts,403\n")
+      expect(exporter.bad_links_url_and_status_csv).to include("http://www.azkaban.gov.uk/magical-waste,Connection failed\n")
+    end
+
+    it "does not return the URL and status for a 200 link" do
+      expect(exporter.bad_links_url_and_status_csv).not_to include
+      "http://www.diagonalley.gov.uk/report-owl-fouling,200"
+    end
+  end
+end

--- a/spec/lib/local-links-manager/export/links_status_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/links_status_exporter_spec.rb
@@ -5,18 +5,56 @@ describe LocalLinksManager::Export::LinkStatusExporter do
   let(:exporter) { LocalLinksManager::Export::LinkStatusExporter }
 
   describe ".homepage_links_status_csv" do
-    it "returns aggregate results of homepage links checks" do
-      allow(LocalAuthority).to receive_message_chain("group.count").and_return("Invalid URI" => 11, "Timeout Error" => 10, "Connection failed" => 24, "200" => 371, "404" => 2)
+    before do
+      11.times { create(:local_authority, status: "Invalid URI") }
+      10.times { create(:local_authority, status: "Timeout Error") }
+      24.times { create(:local_authority, status: "Connection failed") }
+      31.times { create(:local_authority, status: "200") }
+      2.times  { create(:local_authority, status: "404") }
+    end
 
-      expect(exporter.homepage_links_status_csv).to eq("status,count\nInvalid URI,11\nTimeout Error,10\nConnection failed,24\n200,371\n404,2\n")
+    it "returns aggregate results of homepage links checks" do
+      expect(exporter.homepage_links_status_csv).to include("status,count\n")
+      expect(exporter.homepage_links_status_csv).to include("Invalid URI,11\n")
+      expect(exporter.homepage_links_status_csv).to include("Timeout Error,10\n")
+      expect(exporter.homepage_links_status_csv).to include("Connection failed,24\n")
+      expect(exporter.homepage_links_status_csv).to include("200,31\n")
+      expect(exporter.homepage_links_status_csv).to include("404,2\n")
     end
   end
 
   describe ".links_status_csv" do
     it "returns aggregate results of links checks" do
-      allow(Link).to receive_message_chain("enabled_links.group.count").and_return(nil => 7155, "Invalid URI" => 61, "Connection failed" => 628, "500" => 167, "400" => 1, "200" => 72246, "Too many redirects" => 6, "503" => 1, "Timeout Error" => 159, "410" => 78, "401" => 6, "404" => 1814, "403" => 30, "SSL Error" => 110)
+      7.times { create(:link, status: nil) }
+      6.times { create(:link, status: "Invalid URI") }
+      2.times { create(:link, status: "Connection failed") }
+      1.times { create(:link, status: "500") }
+      1.times { create(:link, status: "400") }
+      4.times { create(:link, status: "200") }
+      6.times { create(:link, status: "Too many redirects") }
+      5.times { create(:link, status: "503") }
+      8.times { create(:link, status: "Timeout Error") }
+      3.times { create(:link, status: "410") }
+      9.times { create(:link, status: "401") }
+      2.times { create(:link, status: "404") }
+      2.times { create(:link, status: "403") }
+      1.times { create(:link, status: "SSL Error") }
 
-      expect(exporter.links_status_csv).to eq("status,count\nnil,7155\nInvalid URI,61\nConnection failed,628\n500,167\n400,1\n200,72246\nToo many redirects,6\n503,1\nTimeout Error,159\n410,78\n401,6\n404,1814\n403,30\nSSL Error,110\n")
+      expect(exporter.links_status_csv).to include("status,count\n")
+      expect(exporter.links_status_csv).to include("nil,7\n")
+      expect(exporter.links_status_csv).to include("Invalid URI,6\n")
+      expect(exporter.links_status_csv).to include("Connection failed,2\n")
+      expect(exporter.links_status_csv).to include("500,1\n")
+      expect(exporter.links_status_csv).to include("400,1\n")
+      expect(exporter.links_status_csv).to include("200,4\n")
+      expect(exporter.links_status_csv).to include("Too many redirects,6\n")
+      expect(exporter.links_status_csv).to include("503,5\n")
+      expect(exporter.links_status_csv).to include("Timeout Error,8\n")
+      expect(exporter.links_status_csv).to include("410,3\n")
+      expect(exporter.links_status_csv).to include("401,9\n")
+      expect(exporter.links_status_csv).to include("404,2\n")
+      expect(exporter.links_status_csv).to include("403,2\n")
+      expect(exporter.links_status_csv).to include("SSL Error,1\n")
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/SCWYMyWG/572-address-tim-s-llm-data-needs-3)

This adds functionality to export a CSV of non-200 status (aka "bad") link URLs and their status. A similar CSV is available for Local Authority homepages as well. The CSVs are available to download via URLs so that a performance analyst can access the data when required.