### PR TITLE
Set test envars correctly for Jenkins2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,10 +15,6 @@ node {
       govuk.mergeMasterBranch()
     }
 
-    stage('Environment') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-    }
-
     stage('Bundle') {
       govuk.bundleApp()
     }
@@ -32,6 +28,7 @@ node {
     }
 
     stage('Tests') {
+      govuk.setEnvar('RAILS_ENV', 'test')
       govuk.runTests()
     }
 


### PR DESCRIPTION
Envars set in each Jenkins2 stage seem to not be available in other stages. This sets the `RAILS_ENV=test` in the test stage until this can be investigated further.

cc @emmabeynon 