### PR TITLE
Downgrade airbrake to 4.x and restore config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ else
 end
 
 gem 'addressable'
-gem 'airbrake', '~> 5.5'
-gem 'airbrake-ruby', '1.5'
+gem 'airbrake', '~> 4.0'
 gem 'dalli'
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    airbrake (5.5.0)
-      airbrake-ruby (~> 1.5)
-    airbrake-ruby (1.5.0)
+    airbrake (4.3.8)
+      builder
+      multi_json
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
@@ -335,8 +335,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
-  airbrake (~> 5.5)
-  airbrake-ruby (= 1.5)
+  airbrake (~> 4.0)
   capistrano-rails
   capybara (~> 2.7)
   dalli

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,11 +24,11 @@ node {
     }
 
     stage('Database') {
-      govuk.setupDb()
+      govuk.setEnvar('RAILS_ENV', 'test')
+      govuk.runRakeTask('db:environment:set db:drop db:create db:schema:load')
     }
 
     stage('Tests') {
-      govuk.setEnvar('RAILS_ENV', 'test')
       govuk.runTests()
     }
 

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.project_key = ENV['ERRBIT_API_KEY']
-    config.project_id = 1 #dummy, not used in Errbit
-    config.host = errbit_uri.to_s
-    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
   end
 end


### PR DESCRIPTION
Our errbit installation doesn't like the airbrake 5.x gem and therefore deploys don't get notified properly. Downgrading to 4.x fixes this.

Inspired by https://github.com/alphagov/specialist-publisher/pull/988