### PR TITLE
Increase link checker timeout

### DIFF
--- a/db/migrate/20170223163013_add_url_index_to_links.rb
+++ b/db/migrate/20170223163013_add_url_index_to_links.rb
@@ -1,0 +1,5 @@
+class AddUrlIndexToLinks < ActiveRecord::Migration[5.0]
+  def change
+    add_index :links, :url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161212140755) do
+ActiveRecord::Schema.define(version: 20170223163013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20161212140755) do
     t.index ["local_authority_id", "service_interaction_id"], name: "index_links_on_local_authority_id_and_service_interaction_id", unique: true, using: :btree
     t.index ["local_authority_id"], name: "index_links_on_local_authority_id", using: :btree
     t.index ["service_interaction_id"], name: "index_links_on_service_interaction_id", using: :btree
+    t.index ["url"], name: "index_links_on_url", using: :btree
   end
 
   create_table "local_authorities", force: :cascade do |t|

--- a/lib/local-links-manager/check_links/link_checker.rb
+++ b/lib/local-links-manager/check_links/link_checker.rb
@@ -1,7 +1,7 @@
 module LocalLinksManager
   module CheckLinks
     class LinkChecker
-      TIMEOUT = 5
+      TIMEOUT = 10
       REDIRECT_LIMIT = 10
 
       def check_link(link)

--- a/lib/local-links-manager/check_links/link_status_updater.rb
+++ b/lib/local-links-manager/check_links/link_status_updater.rb
@@ -27,7 +27,7 @@ module LocalLinksManager
       end
 
       def urls_for_enabled_services
-        Link.enabled_links.distinct.pluck(:url)
+        Link.enabled_links.pluck(:url).uniq
       end
 
       def update_link(url, link_checker_response)


### PR DESCRIPTION
## Timeout Error

We have a number of sites that persistently fail link checking with a "Timeout Error" status.  I've visited a few pages and found that although they are slow initially, they do render eventually.  I suspect that they are low traffic pages and just need a bit of time to warm up.  These errors are
frustrating as they list as broken links, but there's not much a link administrator can do about them.

We had 284 pages that failed like this last night.  If all of those took the maximum time to open a connection and the maximum response time, then this would increase the link checker time by about 45 minutes (ignoring problems with redirects).  Given that the link checker starts at 2am and usually finishes at approx 8:30am, I don't think this is too bad.

Tim L-B and I will keep an eye on this to see if it improves matters.  It's possible that we might get a really long run once in a while, but I think that's OK.

## Index on Link URL

We also do at least 50,000 Link selects by url every day in [link][1] [checker][2]. It seems fair to add an index on this.  It might save enough time to eradicate any extra added by my increasing Faraday's timeouts in the previous commit.

Queries by url also exist in [the Link model][3], so adding this might shave a little time off the edit cycle too.

[1]: https://github.com/alphagov/local-links-manager/blob/47b420b6a9f16409763bdfc5bcb02492d15d1071/lib/local-links-manager/check_links/link_status_updater.rb#L23
[2]: https://github.com/alphagov/local-links-manager/blob/47b420b6a9f16409763bdfc5bcb02492d15d1071/lib/local-links-manager/check_links/link_status_updater.rb#L34
[3]: https://github.com/alphagov/local-links-manager/blob/8b29a8115936c7f8e9ed229a508dc14b7d977f51/app/models/link.rb#L63

## Uniq vs Distinct

It seems that using `.uniq` on the array of urls is an order of magnitude quicker than using `.distinct` in the query here.  (~50ms vs ~850ms on prod) The number of URLs is likely to stay fairly static (40,000ish) and the number of unique URLs is fairly likely to stay in the 25 - 35,000 range. It doesn't matter very much relative to the length of the task, but since I
spotted it, I wanted to scratch the itch.

