### PR TITLE
Merge in docs from the opsmanual

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ You will also need to [import data from S3](https://github.com/alphagov/mapit/bl
 
 Links for each local authority are available via data replication.
 
+## Detailed documentation
+
+- [Adding a new LGSL code](/docs/adding-a-new-lgsl-code.md)
+- [Deleting a local transaction link](/docs/deleting-a-link.md)
+
 ### Importing Local Authorities data
 
 Before running the import rake tasks make sure you have Mapit running locally and have imported data into it.

--- a/docs/adding-a-new-lgsl-code.md
+++ b/docs/adding-a-new-lgsl-code.md
@@ -1,0 +1,21 @@
+## Adding a new LGSL code
+
+From time to time, we have requests to add new LGSL codes. For this,
+you'll need to know the LGSL code, the description of the service and
+the providing tier.
+
+There is a [CSV
+file](https://github.com/alphagov/publisher/blob/master/data/local_services.csv)
+that contains the LGSL codes that are active on GOV.UK
+
+To add a new LGSL code:
+- Add the code itself in the first column in the CSV file.
+- Add the description in the second column.
+- Add the providing tier in the third column.
+
+Providing tiers can be:
+- `all`
+- `county/unitary`
+- `district/unitary`
+
+Once your pull request has been merged the codes will become active overnight.

--- a/docs/deleting-a-link.md
+++ b/docs/deleting-a-link.md
@@ -1,0 +1,69 @@
+# Deleting a local transaction link
+
+Occasionally we may need to urgently delete a link prevent it being shown as
+the result for its local authority on a local transaction page on GOV.UK (such
+ as [https://www.gov.uk/pay-council-tax/lambeth](https://www.gov.uk/pay-council-tax/lambeth)).
+
+Links to local government are editable using [Local Links Manager](https://local-links-manager.publishing.service.gov.uk),
+ however this does not yet provide an easy way to find and edit URLs in bulk.
+
+Assuming you know the link you want to delete and the page it appears on, in a
+`local-links-manager` Rails console:
+
+
+1.  Construct a variable using the bad URL to use in a `LIKE` query in the following
+    steps:
+
+        domain_pattern = '%horrible.domain.com%'
+
+1.  Find all affected links:
+
+        Link.where('url LIKE ?', domain_pattern).count
+
+1.  Find the LGSL codes and local authority slugs for each of these local
+    interactions. This will help with finding the URLs to cache-bust after
+    you've deleted them:
+
+        lgsl_codes = Link.where('url LIKE ?', domain_pattern).map{ |l| l.service.lgsl_code}.uniq
+
+        la_slugs = Link.where('url LIKE ?', domain_pattern).map{|l| l.local_authority.slug}.uniq
+
+1.  Delete all affected links. (If a link does not exist, there's a fallback
+    process culminating in the local authority homepage):
+
+        Link.where('url LIKE ?', domain_pattern).delete_all
+
+1.  It's possible that the same domain has been used for a local authority
+    homepage, so check them too:
+
+        LocalAuthority.where('homepage_url LIKE ?', domain_pattern).count
+
+1.  If there are any here, set the `homepage_url` to `nil`.  (It's better if
+     you can set it to a real URL, but we can do that through the UI as part
+     of a clean up if necessary)
+
+        LocalAuthority.where('homepage_url LIKE ?', domain_pattern).update_all(homepage_url: nil)
+
+1.  Frontend should now no longer be serving the bad links, but the pages
+    containing them may be cached. You'll need to get a **Publisher** Rails
+    console to find the `artefact-slugs` for the local transactions which use the LGSL codes for the links you've deleted (substituting the values into the array in this query):
+
+        LocalTransactionEdition.where(state: "published").in(:lgsl_code => [ <LGSL codes> ] ).each do |lte|
+          print "LGSL code: #{lte.lgsl_code}    Slug: #{lte.slug}\n"
+        end
+
+1.  Combine the artefact and local authority slugs to build the paths to
+    cache-bust - they're in this form:
+
+        /<artefact-slug>/<local-authority-slug>
+
+    for example
+
+        /pay-council-tax/lambeth
+
+1.  Flush the caches for the affected URLs.
+    (Wildcard purging would make this easier, by allowing us to purge all paths
+    under a local transaction rather than having to do each local authority page
+    individually.)
+
+1.  Now you're done.


### PR DESCRIPTION
The opsmanual is retiring / merging with the developer docs. These two how-tos I found here:
https://github.gds/pages/gds/opsmanual/2nd-line/applications/local-links-manager.html

I've not changed any content.

https://trello.com/c/ZErfvzXs