### PR TITLE
Import titles and slugs of local transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '36.0.0'
+  gem 'gds-api-adapters', '~>41.3'
 end
 
 gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20161021)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -97,7 +97,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    gds-api-adapters (36.0.0)
+    gds-api-adapters (41.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -195,7 +195,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (2.0.1)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -231,7 +231,7 @@ GEM
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.1)
-    rest-client (2.0.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -303,7 +303,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.3)
     unicode-display_width (1.1.1)
     unicorn (4.9.0)
       kgio (~> 2.6)
@@ -342,7 +342,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.7)
   faraday
   faraday_middleware
-  gds-api-adapters (= 36.0.0)
+  gds-api-adapters (~> 41.3)
   gds-sso (~> 13.0)
   govuk-lint
   govuk_admin_template (~> 4.2)
@@ -368,5 +368,8 @@ DEPENDENCIES
   webmock (~> 1.2)
   whenever
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.14.5

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,7 +1,0 @@
-GdsApi.configure do |config|
-  # Never return nil when a server responds with 404 or 410.
-  config.always_raise_for_not_found = true
-
-  # Return a hash, not an OpenStruct from a request.
-  config.hash_response_for_requests = true
-end

--- a/db/migrate/20170410075304_add_govuk_slug_and_title_to_service_interactions.rb
+++ b/db/migrate/20170410075304_add_govuk_slug_and_title_to_service_interactions.rb
@@ -1,0 +1,9 @@
+class AddGovukSlugAndTitleToServiceInteractions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :service_interactions, :govuk_slug, :string, unique: true
+    add_column :service_interactions, :govuk_title, :string
+    add_column :service_interactions, :live, :boolean
+
+    add_index :service_interactions, :govuk_slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223163013) do
+ActiveRecord::Schema.define(version: 20170410075304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,10 @@ ActiveRecord::Schema.define(version: 20170223163013) do
     t.integer  "interaction_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.string   "govuk_slug"
+    t.string   "govuk_title"
+    t.boolean  "live"
+    t.index ["govuk_slug"], name: "index_service_interactions_on_govuk_slug", using: :btree
     t.index ["service_id", "interaction_id"], name: "index_service_interactions_on_service_id_and_interaction_id", unique: true, using: :btree
   end
 

--- a/lib/local-links-manager/import/publishing_api_importer.rb
+++ b/lib/local-links-manager/import/publishing_api_importer.rb
@@ -1,0 +1,94 @@
+require_relative 'errors'
+require_relative 'error_message_formatter'
+require_relative 'import_comparer'
+require_relative 'processor'
+require 'gds_api/publishing_api_v2'
+
+module LocalLinksManager
+  module Import
+    class PublishingApiImporter
+      def self.import
+        new.import_data
+      end
+
+      def initialize(import_comparer = ImportComparer.new)
+        @comparer = import_comparer
+      end
+
+      def import_data
+        Processor.new(self).process
+      end
+
+      def each_item(&block)
+        local_transactions.each(&block)
+      end
+
+      def import_item(local_transaction, _response, summariser)
+        raise MissingIdentifierError, "Found empty LGSL/LGIL code on local_transaction #{local_transaction['slug']}" if local_transaction["lgil"].blank? || local_transaction["lgsl"].blank?
+
+        service = Service.find_by(lgsl_code: local_transaction["lgsl"])
+        interaction = Interaction.find_by(lgil_code: local_transaction["lgil"])
+
+        service_interaction = ServiceInteraction.find_by(
+          service: service,
+          interaction: interaction)
+
+        if service_interaction
+          service_interaction.update!(
+            govuk_slug: local_transaction["slug"],
+            govuk_title: local_transaction["title"],
+            live: true)
+
+          summariser.increment_updated_record_count
+          @comparer.add_source_record(service_interaction.govuk_slug)
+
+          Rails.logger.info("Imported title #{local_transaction['title']} and slug #{local_transaction['slug']} for LGSL #{local_transaction['lgsl']} and LGIL #{local_transaction['lgil']}.")
+        else
+          Rails.logger.info("Skipped importing for #{local_transaction['slug']} because it refers to an invalid ServiceInteraction")
+          summariser.increment_invalid_record_count
+        end
+      end
+
+      def all_items_imported(response, _summariser)
+        missing = @comparer.check_missing_records(ServiceInteraction.where(live: true), &:govuk_slug)
+        response.errors << error_message_for_missing(missing) unless missing.empty?
+      end
+
+      def import_name
+        'Local Transaction information import'
+      end
+
+      def import_source_name
+        'content items from Publishing API'
+      end
+
+    private
+
+      def local_transactions
+        @local_transactions ||=
+          publishing_api_response
+            .to_hash["results"]
+            .map do |local_transaction|
+              local_transaction_hash(local_transaction)
+            end
+      end
+
+      def publishing_api_response
+        Services.publishing_api.get_content_items(document_type: 'local_transaction', per_page: 150)
+      end
+
+      def local_transaction_hash(parsed_result)
+        local_transaction = {}
+        local_transaction["title"] = parsed_result["title"]
+        local_transaction["slug"] = parsed_result["base_path"][1..-1]
+        local_transaction["lgsl"] = parsed_result["details"]["lgsl_code"]
+        local_transaction["lgil"] = parsed_result["details"]["lgil_code"]
+        local_transaction
+      end
+
+      def error_message_for_missing(missing)
+        ErrorMessageFormatter.new("Local Transaction", "no longer in the import source.", missing).message
+      end
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,6 @@
 require 'redis'
 require 'gds_api/mapit'
+require 'gds_api/publishing_api_v2'
 
 module Services
   def self.mapit
@@ -19,6 +20,13 @@ module Services
 
       Redis.new(redis_config)
     end
+  end
+
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
   end
 
   def self.icinga_check(service_desc, code, message)

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -4,6 +4,7 @@ require 'local-links-manager/import/interactions_importer'
 require 'local-links-manager/import/service_interactions_importer'
 require 'local-links-manager/import/services_tier_importer'
 require 'local-links-manager/import/enabled_service_checker'
+require 'local-links-manager/import/publishing_api_importer'
 
 namespace :import do
   namespace :service_interactions do
@@ -63,6 +64,13 @@ namespace :import do
     task enable_services: :environment do
       service_desc = 'Enable services in local-links-manager'
       response = LocalLinksManager::Import::EnabledServiceChecker.enable
+      Services.icinga_check(service_desc, response.successful?, response.message)
+    end
+
+    desc "Import LocalTransactions from Publishing API"
+    task import_from_publishingapi: :environment do
+      service_desc = 'Import local_transactions to service_interactions from publishing-api'
+      response = LocalLinksManager::Import::PublishingApiImporter.import
       Services.icinga_check(service_desc, response.successful?, response.message)
     end
   end

--- a/spec/factories/service_interactions.rb
+++ b/spec/factories/service_interactions.rb
@@ -2,5 +2,8 @@ FactoryGirl.define do
   factory :service_interaction do
     association :interaction
     association :service, :all_tiers
+    govuk_slug "a-slug"
+    govuk_title "A title"
+    live false
   end
 end

--- a/spec/lib/local-links-manager/import/publishing_api_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/publishing_api_importer_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require 'local-links-manager/import/publishing_api_importer'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+describe LocalLinksManager::Import::PublishingApiImporter do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  describe 'import of slugs and titles from Publishing API' do
+    context 'when Publishing API returns Local Transactions' do
+      let(:local_transaction) {
+        {
+          "base_path" => "/ring-disposal-services",
+          "description" => "Contact the council of Elrond to discuss disposing of powerful magic rings",
+          "details" => {
+            "lgsl_code" => 111,
+            "lgil_code" => 8
+          },
+          "document_type" => "local_transaction",
+          "title" => "Dispose of The One Ring",
+        }
+      }
+
+      let(:service_0) { create(:service, lgsl_code: 111, label: "Jewellery destruction") }
+      let(:service_1) { create(:service) }
+
+      let(:interaction_0) { create(:interaction, lgil_code: 8, label: "Find out about") }
+      let(:interaction_1) { create(:interaction) }
+
+      before do
+        publishing_api_has_content([local_transaction], "document_type" => "local_transaction", "per_page" => 150)
+        create(:service_interaction, service: service_0, interaction: interaction_0)
+      end
+
+      it 'reports a successful import' do
+        expect(described_class.import).to be_successful
+      end
+
+      it 'imports the local transaction slug and title and enables the service interaction' do
+        described_class.import
+
+        service_interaction = ServiceInteraction.find_by(service: service_0, interaction: interaction_0)
+        expect(service_interaction.govuk_slug).to eq('ring-disposal-services')
+        expect(service_interaction.govuk_title).to eq('Dispose of The One Ring')
+        expect(service_interaction.live).to be true
+      end
+
+      it "warns of live service interactions not in the import" do
+        create(:service_interaction, service: service_1, interaction: interaction_1, live: true)
+
+        response = described_class.import
+
+        expect(response).to_not be_successful
+        expect(response.errors).to include(/1 Local Transaction is no longer in the import source/)
+      end
+    end
+
+    context "Unexpected data from Publishing API" do
+      it "errors if LGIL or LGSL is missing" do
+        duff_local_transaction = {
+          "base_path" => "/not-a-pucka-thing",
+          "description" => "I don't know nuffin about LGIL codes",
+          "details" => {},
+          "document_type" => "local_transaction",
+          "title" => "#Shrug",
+        }
+
+        publishing_api_has_content([duff_local_transaction], "document_type" => "local_transaction", "per_page" => 150)
+
+        response = described_class.import
+
+        expect(response).to_not be_successful
+        expect(response.errors).to include(/Found empty LGSL/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're going to present the title of local transactions above the links which
will be shown on that transaction.  This will help administrators to choose a
more accurate link to match the content on the GOV.UK page.

The slug is to be used to provide a link to the local transaction page so that
an adminstrator can navigate directly to the page and check the body of the
content if necessary.

The slug and the title are both assigned to a local transaction page which has
a combination of LGIL and LGSL code.  This maps closely to the concept of a
service interaction which is why we've added them to that model.

The slug is also going to be used to marry up Google analytics for each page/

We're also tracking which service interactions are actually live on GOV.UK.  We
have a lot of links which correspond to LGSL/LGIL combinations that aren't
ever used.  By using this import we can check which ones are used for GOV.UK,
and only show those ones to administrators.  We can also delete the unused ones
as they will not be curated.

We should track if we consider a service to be enabled, and it then disappears
from the import.  This could be down to user error, or the retiring of a local
transaction.  Either way, we want to know about it - which is why an error will
be raised.

The fallback code will be removed once all local transactions have an LGIL code
assigned.