### PR TITLE
Add new broken links page

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -47,10 +47,10 @@ table.table-with-counts {
     display: block;
   }
   td .count.plural:after {
-    content: "Broken links";
+    content: "broken links";
   }
   td .count.singular:after {
-    content: "Broken link";
+    content: "broken link";
   }
 }
 
@@ -79,5 +79,75 @@ table.table-with-controls {
     .filter-control-full-width {
       width: 100%;
     }
+  }
+}
+
+.table > tbody > tr > td {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  vertical-align: bottom;
+}
+
+table.table-with-analytics {
+  th .broken-count {
+    float: left;
+    font-size: 2em;
+    font-weight: normal;
+    margin-left: 5px;
+    margin-top: 10px;
+  }
+
+  td {
+    font-size: 14px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+
+  td.analytics {
+    padding-top: 40px;
+    width: 100px;
+    display: block;
+
+    span {
+      font-size: 2em;
+      display: block;
+    }
+  }
+
+  td.count {
+    float:right;
+    font-size: 75%;
+    font-weight: normal;
+    margin-left: 5px;
+    margin-top: 10px;
+
+    span {
+      display: block;
+      font-size: 3.8em;
+      font-weight: bold;
+      margin-left: -11px;
+    }
+  }
+
+  td .govuk {
+    font-size: 1.9em;
+
+    .code {
+      font-size: 14px;
+    }
+  }
+
+  td.name {
+    font-weight: bold;
+    font-size: 1.5em;
+  }
+
+  .label {
+    font-size: 14px;
+  }
+
+  td.status > span {
+    padding-top: 5px;
+    display: block;
   }
 }

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -6,6 +6,12 @@ class LinksController < ApplicationController
   before_action :set_back_url_before_post_request, only: [:edit, :update, :destroy]
   helper_method :back_url
 
+  def index
+    currently_broken = Link.enabled_links.currently_broken
+    @total_broken_links = currently_broken.count
+    @broken_links = currently_broken.order(analytics: :desc).limit(100)
+  end
+
   def edit
     if flash[:link_url]
       @link.url = flash[:link_url]

--- a/app/presenters/service_link_presenter.rb
+++ b/app/presenters/service_link_presenter.rb
@@ -24,6 +24,10 @@ class ServiceLinkPresenter < SimpleDelegator
     service.slug
   end
 
+  def govuk_title
+    service_interaction.govuk_title
+  end
+
   def row_data
     {
       local_authority_id: local_authority.id,

--- a/app/presenters/url_status_presentation.rb
+++ b/app/presenters/url_status_presentation.rb
@@ -4,8 +4,6 @@ module UrlStatusPresentation
   def status_description
     return "" unless status
     return "Good" if status == '200'
-    return "Broken Link #{status}" if status.start_with?('4')
-    return "Server Error #{status}" if status.start_with?('5')
     status
   end
 
@@ -18,7 +16,7 @@ module UrlStatusPresentation
 
   def last_checked
     if link_last_checked
-      "Checked #{time_ago_in_words(link_last_checked)} ago"
+      "#{time_ago_in_words(link_last_checked)} ago"
     else
       "Link not checked"
     end

--- a/app/views/links/_link_table_row.html.erb
+++ b/app/views/links/_link_table_row.html.erb
@@ -1,0 +1,27 @@
+<%= content_tag 'tr',
+    class: link.updated? ? 'success' : '',
+    data: link.row_data do
+%>
+  <td class="analytics"><span><%= link.analytics.to_i %></span>this week</td>
+  <td class="links">
+    <div class="local-authority"><%= link.local_authority.name %></div>
+    <div class="govuk"><%= link.govuk_title || link.service_label %>
+      <span class='code'>code: <%= link.service_interaction.lgsl_code %></span>
+    </div>
+    <div class="detail-links">
+      <a href="https://www.gov.uk/<%= link.service_interaction.govuk_slug %>">GOV.UK</a> &rarr;
+      <% if link.url %>
+        <%= link_to truncate(link.url, length: 80), link.url %>
+      <% end %>
+    </div>
+  </td>
+  <td class="status text-right">
+    <div class="<%= link.label_status_class %>">
+        <b><%= link.status_description %></b>
+    </div>
+    <span><%= link.last_checked %></span>
+  </td>
+  <td class="text-center">
+    <%= link_to("Edit link", link.edit_path, class: "btn btn-default btn-lg") %>
+  </td>
+<% end %>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :page_title, "Broken Links" %>
+
+<% breadcrumb :root %>
+
+<div class="page-title">
+  <h1>Local Links Manager</h1>
+</div>
+
+<%= render partial: 'shared/home_nav' %>
+<table class="table table-with-controls table-with-analytics" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th colspan='4'>
+        <div class='filter-control-full-width'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a service or link here' } %>
+        </div>
+        <p class='broken-count'>
+          <strong><%= @total_broken_links %></strong><%= ' broken links'.pluralize(@total_broken_links) %> (showing top <%= @broken_links.count %>)
+        </p>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% unless @broken_links.blank? %>
+      <% @broken_links.each do |link| %>
+        <% cache namespaced_cache_key('broken_links', link) do %>
+          <%= render 'link_table_row', link: ServiceLinkPresenter.new(link, view_context: self, first: false) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_home_nav.html.erb
+++ b/app/views/shared/_home_nav.html.erb
@@ -1,6 +1,7 @@
 <nav class="home-nav">
   <ul class="nav nav-tabs">
-    <li role="presentation"<% if controller_name == 'local_authorities' %> class="active"<% end %>><%= link_to 'View all councils', local_authorities_path %></li>
-    <li role="presentation"<% if controller_name == 'services' %> class="active"<% end %>><%= link_to 'View all services', services_path %></li>
+    <li role="presentation"<% if controller_name == 'links' %> class="active"<% end %>><%= link_to 'Broken links', root_path %>
+    <li role="presentation"<% if controller_name == 'local_authorities' %> class="active"<% end %>><%= link_to 'Councils', local_authorities_path %></li>
+    <li role="presentation"<% if controller_name == 'services' %> class="active"<% end %>><%= link_to 'Services', services_path %></li>
   </ul>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'local_authorities#index'
+  root to: 'links#index'
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 

--- a/spec/features/links/index_spec.rb
+++ b/spec/features/links/index_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+feature 'The broken links page' do
+  before do
+    User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
+
+    @service = create(:service, :all_tiers)
+    @service_interaction = create(:service_interaction, service: @service)
+    @council_a = create(:unitary_council, name: 'aaa')
+    @council_m = create(:county_council, name: 'mmm')
+    @council_z = create(:district_council, name: 'zzz')
+    @link_1 = create(:link, local_authority: @council_a, service_interaction: @service_interaction, status: 200, link_last_checked: '1 day ago', analytics: 911)
+    @link_2 = create(:link, local_authority: @council_m, service_interaction: @service_interaction, status: 404, analytics: 37)
+    @link_3 = create(:link, local_authority: @council_z, service_interaction: @service_interaction, status: 503, analytics: 823)
+    visit '/'
+  end
+
+  it "has a breadcrumb trail" do
+    expect(page).to have_selector('.breadcrumb')
+  end
+
+  it 'displays the title of the local transaction for each broken link' do
+    expect(page).to have_content('A title')
+  end
+
+  it 'displays the LGSL code for each broken link' do
+    expect(page).to have_content(@service.lgsl_code)
+  end
+
+  it 'shows the council name for each broken link' do
+    expect(page).to have_content(@council_m.name)
+    expect(page).to have_content(@council_z.name)
+  end
+
+  it 'shows non-200 status links' do
+    expect(page).to have_link @link_2.url
+  end
+
+  it 'doesn\'t show 200 status links' do
+    expect(page).not_to have_link @link_1.url
+  end
+
+  it 'lists the links prioritised by analytics count' do
+    expect(@council_z.name).to appear_before(@council_m.name)
+  end
+
+  it 'shows a count of the number of broken links' do
+    within('thead') do
+      expect(page).to have_content "2 broken links"
+    end
+  end
+
+  it "displays a filter box" do
+    expect(page).to have_selector('.filter-control-full-width')
+  end
+
+  it 'has navigation tabs' do
+    expect(page).to have_selector('.nav-tabs')
+    within('.nav-tabs') do
+      expect(page).to have_link 'Broken links'
+      expect(page).to have_link 'Councils'
+      expect(page).to have_link 'Services'
+    end
+  end
+end

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -31,7 +31,7 @@ feature 'The links for a local authority' do
     end
 
     it "shows the url for the link next to the relevant interaction" do
-      expect(page).to have_table_row("#{@interaction_1.label} #{@link_1.url}", 'Good Checked about 1 hour ago', 'Edit link')
+      expect(page).to have_table_row("#{@interaction_1.label} #{@link_1.url}", 'Good about 1 hour ago', 'Edit link')
       expect(page).to have_table_row("#{@interaction_2.label} #{@link_2.url}", 'Link not checked', 'Edit link')
     end
 
@@ -100,7 +100,7 @@ feature 'The links for a local authority' do
       within("##{@interaction_1.lgil_code} .status") do
         expect(page).to have_css(".label-success")
         expect(page).not_to have_css(".label-danger")
-        expect(page).to have_content('Good Checked about 1 hour ago')
+        expect(page).to have_content('Good about 1 hour ago')
       end
     end
 
@@ -121,7 +121,7 @@ feature 'The links for a local authority' do
       visit local_authority_with_service_path(local_authority_slug: @local_authority.slug, service_slug: @service.slug)
 
       within("##{@interaction_1.lgil_code} .status") do
-        expect(page).to have_content("Broken Link 404 Checked about 1 hour ago")
+        expect(page).to have_content("404 about 1 hour ago")
         expect(page).not_to have_css(".label-success")
         expect(page).to have_css(".label-danger")
       end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -6,7 +6,7 @@ feature "The local authorities index page" do
 
     @angus = FactoryGirl.create(:local_authority, name: 'Angus')
     @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', broken_link_count: 1)
-    visit root_path
+    visit local_authorities_path
   end
 
   it 'has a breadcrumb trail' do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -121,7 +121,7 @@ feature "The local authority show page" do
     end
 
     it 'shows the status of broken links' do
-      expect(page).to have_text "Server Error 500"
+      expect(page).to have_text "500"
     end
 
     describe 'broken links' do

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -105,7 +105,7 @@ feature 'The services show page' do
 
     it 'shows the link status as Broken Link 404 when the status is 404' do
       for_local_authority_interactions(@council_z, @link_2.interaction) do
-        expect(page).to have_text 'Broken Link 404'
+        expect(page).to have_text '404'
       end
     end
 

--- a/spec/presenters/local_authority_presenter_spec.rb
+++ b/spec/presenters/local_authority_presenter_spec.rb
@@ -33,7 +33,7 @@ describe LocalAuthorityPresenter do
       allow(local_authority).to receive(:homepage_url).and_return('http://example.com')
       allow(local_authority).to receive(:link_last_checked).and_return(time - (60 * 60))
 
-      expect(presenter.homepage_link_last_checked).to eq('Checked about 1 hour ago')
+      expect(presenter.homepage_link_last_checked).to eq('about 1 hour ago')
     end
 
     it 'returns an empty string if the homepage URL is set to nil' do

--- a/spec/support/url_status_presentation.rb
+++ b/spec/support/url_status_presentation.rb
@@ -14,12 +14,12 @@ RSpec.shared_examples "a UrlStatusPresentation module" do
 
     it 'returns "Broken Link 404" if the status is "404"' do
       @link = double(:Link, status: '404')
-      expect(presenter.status_description).to eq('Broken Link 404')
+      expect(presenter.status_description).to eq('404')
     end
 
     it 'returns "Server Error 503" if the status is "503"' do
       @link = double(:Link, status: '503')
-      expect(presenter.status_description).to eq('Server Error 503')
+      expect(presenter.status_description).to eq('503')
     end
 
     it 'returns the status name if the status is an unexpected status' do
@@ -58,7 +58,7 @@ RSpec.shared_examples "a UrlStatusPresentation module" do
     it 'returns how long ago the link was last checked if it has been checked' do
       time = Timecop.freeze(Time.now)
       @link = double(:Link, link_last_checked: time - (60 * 60))
-      expect(presenter.last_checked).to eq("Checked about 1 hour ago")
+      expect(presenter.last_checked).to eq("about 1 hour ago")
     end
 
     it 'returns "Link not checked if the link has not last checked time' do


### PR DESCRIPTION
This is a new front page to enable GOV.UK administrators to prioritise fixing
links more easily.

The page is linked to the corresponding GOV.UK local transaction and displays
the title to help administrators choose a new link when fixing broken ones.

Links are prioritised by their Google Analytics click rate.

The local authority tests are fixed as this page is no longer the root page.

We only show the top 100 links.  We're prioritising them, so showing more than
that would slow the page rendering down for no real benefit.  Once a link is
fixed it disappears from the top of the page and the (previously) 101st most
important broken link would then appear at the bottom of the page.

This does not include missing links yet (keeping PRs small for review purposes)

Paired with @issyl0 on some of this

New page from this PR:
![screen shot 2017-05-15 at 12 54 47](https://cloud.githubusercontent.com/assets/773037/26197060/dbdad15e-3bb8-11e7-8b66-a6a6d78bd33f.png)

Prototype:
![screen shot 2017-05-15 at 12 54 43](https://cloud.githubusercontent.com/assets/773037/26197061/dbe4a59e-3bb8-11e7-9184-43d928114a75.png)

