### PR TITLE
Lower log level in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
This app is currently outputting an enormous amount of logs in production (integration/staging/production).

```
integration-backend-2:/data/vhost/local-links-manager.integration.publishing.service.gov.uk/shared/log$ cat production.log | wc -l
13169016
```