### PR TITLE
Schedule import of local transactions GA data

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,3 +16,9 @@ end
 every :day, at: '3am' do
   rake 'export:links:all'
 end
+
+# Run the rake task to import Google analytics for local transactions.
+every :day, at: '5am' do
+  rake 'import:analytics'
+end
+

--- a/lib/local-links-manager/import/analytics_importer.rb
+++ b/lib/local-links-manager/import/analytics_importer.rb
@@ -14,6 +14,7 @@ module LocalLinksManager
       end
 
       def import_records
+        @existing_ids_with_analytics = Set.new(Link.where.not(analytics: 0).pluck(:id))
         Processor.new(self).process
       end
 
@@ -50,10 +51,10 @@ module LocalLinksManager
     private
 
       def reset_count_on_links_not_in_analytics
-        Link.all.each do |link|
-          unless @processed_ids.include? link.id
-            link.update!(analytics: 0)
-          end
+        links_to_reset = @existing_ids_with_analytics - @processed_ids
+
+        links_to_reset.each do |id|
+          Link.find(id).update!(analytics: 0)
         end
       end
     end

--- a/lib/tasks/import/google_analytics.rake
+++ b/lib/tasks/import/google_analytics.rake
@@ -4,8 +4,19 @@ namespace :import do
   desc "Imports analytics so that links can be prioritised by usage"
   task google_analytics: :environment do
     service_desc = 'Import Google Analytics to Local Links Manager'
-    response = LocalLinksManager::Import::AnalyticsImporter.import
-    Services.icinga_check(service_desc, response.successful?, response.message)
-    puts response.message
+    LocalLinksManager::DistributedLock.new('analytics-import').lock(
+      lock_obtained: ->() {
+        begin
+          response = LocalLinksManager::Import::AnalyticsImporter.import
+          Services.icinga_check(service_desc, response.successful?, response.message)
+        rescue StandardError => e
+          Services.icinga_check(service_desc, false, e.to_s)
+          raise e
+        end
+      },
+      lock_not_obtained: ->() {
+        Services.icinga_check(service_desc, true, "Unable to lock")
+      }
+    )
   end
 end


### PR DESCRIPTION
Scheduling the analytics import so that we have up to date usage data on our links.

We don't want to reset the analytics count on every link that is not in the GA
import because most of them are already at zero.  Instead, we'll make a note
of which links have a non-zero count beforehand, and just reset those that
haven't been updated in the import.