### PR TITLE
Return 404 if resources can't be found

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2,7 +2,7 @@ require 'local-links-manager/export/link_status_exporter'
 require 'local-links-manager/export/bad_links_url_and_status_exporter'
 
 class LinksController < ApplicationController
-  before_action :load_dependencies
+  before_action :load_dependencies, only: [:edit, :update, :destroy]
   before_action :set_back_url_before_post_request, only: [:edit, :update, :destroy]
   helper_method :back_url
 
@@ -59,9 +59,9 @@ class LinksController < ApplicationController
 private
 
   def load_dependencies
-    @local_authority = LocalAuthorityPresenter.new(LocalAuthority.find_by(slug: params[:local_authority_slug]))
-    @interaction = Interaction.find_by(slug: params[:interaction_slug])
-    @service = Service.find_by(slug: params[:service_slug])
+    @local_authority = LocalAuthorityPresenter.new(LocalAuthority.find_by!(slug: params[:local_authority_slug]))
+    @interaction = Interaction.find_by!(slug: params[:interaction_slug])
+    @service = Service.find_by!(slug: params[:service_slug])
     @link = Link.retrieve(params)
   end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -5,7 +5,7 @@ class ServicesController < ApplicationController
   end
 
   def show
-    @service = Service.find_by(slug: params[:service_slug])
+    @service = Service.find_by!(slug: params[:service_slug])
     @local_authorities = @service.local_authorities.order(name: :asc)
     @link_count = links_for_service.count
     @link_filter = params[:filter]

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -128,6 +128,37 @@ feature 'The links for a local authority' do
     end
   end
 
+  describe "when links exist for the service interaction" do
+    before do
+      @link_1 = create(:link, local_authority: @local_authority, service_interaction: @service_interaction_1, status: "200", link_last_checked: @time - (60 * 60))
+      @link_2 = create(:link, local_authority: @local_authority, service_interaction: @service_interaction_2)
+    end
+
+    it "returns a 404 if the supplied local authority doesn't exist" do
+      expect {
+        visit edit_link_path(local_authority_slug: "benidorm",
+                      service_slug: @service.slug,
+                      interaction_slug: @interaction_1.slug)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "returns a 404 if the supplied service doesn't exist" do
+      expect {
+        visit edit_link_path(local_authority_slug: @local_authority.slug,
+                      service_slug: "bed-pans",
+                      interaction_slug: @interaction_1.slug)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "returns a 404 if the supplied interaction doesn't exist" do
+      expect {
+        visit edit_link_path(local_authority_slug: @local_authority.slug,
+                      service_slug: @service.slug,
+                      interaction_slug: "buccaneering")
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe "homepage link status CSV" do
     it "should show a CSV" do
       visit '/check_homepage_links_status.csv'

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -122,6 +122,12 @@ feature 'The services show page' do
     end
   end
 
+  context "when the service doesn't exist" do
+    it "returns a 404" do
+      expect { visit service_path("bed-pans") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   def for_local_authority(council)
     within(".header-row[data-local-authority-id=\"#{council.id}\"]") do
       yield


### PR DESCRIPTION
At present, these two controllers may load nil resources which are then passed
onto the view resulting in 500 errors.  This happens a bit at the moment
because of the way we add missing links.

These will now return a 404 instead if you make a mistake, which is both more
correct and helpful to the end user.