### PR TITLE
Change link checking strategy

### DIFF
--- a/lib/local-links-manager/check_links/link_status_requester.rb
+++ b/lib/local-links-manager/check_links/link_status_requester.rb
@@ -6,16 +6,35 @@ module LocalLinksManager
       delegate :url_helpers, to: "Rails.application.routes"
 
       def call
-        LocalAuthority.all.each do |local_authority|
-          link_checker_api.create_batch(
-            urls_for_local_authority(local_authority),
-            webhook_uri: webhook_uri,
-            webhook_secret_token: webhook_secret_token
-          )
+        Service.enabled.each do |service|
+          check_urls service.links.order(analytics: :asc).map(&:url).uniq
         end
+
+        check_urls homepage_urls
+      end
+
+      def check_authority_urls(authority_slug)
+        check_urls urls_for_authority(authority_slug).uniq
       end
 
     private
+
+      def urls_for_authority(authority_slug)
+        local_authority = LocalAuthority.find_by(slug: authority_slug)
+        local_authority.links.map(&:url) << local_authority.homepage_url
+      end
+
+      def homepage_urls
+        LocalAuthority.all.map(&:homepage_url)
+      end
+
+      def check_urls(urls)
+        link_checker_api.create_batch(
+          urls,
+          webhook_uri: webhook_uri,
+          webhook_secret_token: webhook_secret_token
+        )
+      end
 
       def webhook_uri
         Plek.find("local-links-manager") + url_helpers.link_checker_webhook_path
@@ -23,11 +42,6 @@ module LocalLinksManager
 
       def webhook_secret_token
         Rails.application.secrets.link_checker_api_secret_token
-      end
-
-      def urls_for_local_authority(local_authority)
-        (local_authority.provided_service_links.map(&:url) +
-          [local_authority.homepage_url]).uniq
       end
 
       def link_checker_api

--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -1,7 +1,7 @@
 require 'local-links-manager/distributed_lock'
 require 'local-links-manager/check_links/link_status_requester'
 
-desc "Check links"
+desc "Check all links for enabled services"
 task "check-links": :environment do
   service_desc = "Local Links Manager link checker rake task"
   LocalLinksManager::DistributedLock.new("check-links").lock(
@@ -24,4 +24,12 @@ task "check-links": :environment do
       Services.icinga_check(service_desc, true, "Unable to lock")
     }
   )
+end
+
+namespace :"check-links" do
+  desc "Check links for a single local authority"
+  task :local_authority, [:authority_slug] => :environment do
+    checker = LocalLinksManager::CheckLinks::LinkStatusRequester.new
+    checker.check_authority_urls(args[:authority_slug])
+  end
 end


### PR DESCRIPTION
If we submit all the links for a local authority at once, we have noticed that
several authorities fail link checking for lots of their links.  I guess that
this is because they haven't warmed up sufficiently at 2AM when the link
checker runs.  We run 4 threads on the sidekiq worker (in link checker api) 
at present and it's possible that we are causing our own bottleneck on the 
websites we are checking.  (Some of the links are very slow to respond)

I propose a different strategy where we check links by service instead.  This
spaces out the requests to local authority websites a bit which allows them
extra time to warm up.

I've also changed the order so that the least significant (by GA click count)
is requested first.  I'm hoping that this will contribute to a more accurate
link checker status for the high value links in local links manager which is
what we're after.

We check the home pages last of all as it's most important that they are correct.

I've also added a rake task allowing us to recheck an individual council, as
sometimes they are down for maintenance overnight. There is nothing that our
admins can do, so we should be able to easily recheck.