### PR TITLE
Don't send empty batches to the Link Checker API

### DIFF
--- a/lib/local-links-manager/check_links/link_status_requester.rb
+++ b/lib/local-links-manager/check_links/link_status_requester.rb
@@ -9,7 +9,8 @@ module LocalLinksManager
         ServiceInteraction.includes(:service)
           .where(services: { enabled: true })
           .each do |service|
-          check_urls service.links.order(analytics: :asc).map(&:url).uniq
+          urls = service.links.order(analytics: :asc).map(&:url).uniq
+          check_urls(urls) unless urls.empty?
         end
 
         check_urls homepage_urls


### PR DESCRIPTION
Link Checker API doesn't accept empty batches.