### PR TITLE
Increase link-checker-api timeout

### DIFF
--- a/lib/local-links-manager/check_links/link_status_requester.rb
+++ b/lib/local-links-manager/check_links/link_status_requester.rb
@@ -48,7 +48,7 @@ module LocalLinksManager
       end
 
       def link_checker_api
-        @link_checker_api ||= GdsApi::LinkCheckerApi.new(link_checker_api_url)
+        @link_checker_api ||= GdsApi::LinkCheckerApi.new(link_checker_api_url, timeout: 10)
       end
 
       def link_checker_api_url


### PR DESCRIPTION
For: https://trello.com/c/7WBKFT7W/231-investigate-support-api-timeouts

This is part of the work to move the `check-links` rake task to redis-2. It is currently running on redis-1 which is causing problems because it's enqueueing a lot of jobs which take hours and lead to other applications not being able to use redis-1 even after a few hours.

This will increase the timeout from the default 4 seconds available in `gds-api-adapters` to 10 seconds. The increased time will allow the local-links-manager to send all of its requests when running the `check-links` rake task. `link-checker-api` will then have enough time to receive all the links that need to be checked from `local-links-manager`.