### PR TITLE
Allow editing of missing links

### DIFF
--- a/app/controllers/concerns/link_filter_helper.rb
+++ b/app/controllers/concerns/link_filter_helper.rb
@@ -1,0 +1,10 @@
+module LinkFilterHelper
+  def filtered_links(links)
+    case params[:filter]
+    when 'broken_links'
+      links.broken_or_missing
+    else
+      links
+    end
+  end
+end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -7,7 +7,7 @@ class LinksController < ApplicationController
   helper_method :back_url
 
   def index
-    currently_broken = Link.enabled_links.currently_broken
+    currently_broken = Link.enabled_links.broken_or_missing
     @total_broken_links = currently_broken.count
     @broken_links = currently_broken.order(analytics: :desc).limit(100)
   end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -33,7 +33,7 @@ class LinksController < ApplicationController
   end
 
   def destroy
-    if @link.destroy
+    if @link.make_missing
       redirect('deleted')
     else
       flash[:danger] = "Could not delete link."

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -1,6 +1,8 @@
 require 'local-links-manager/export/bad_links_url_and_status_exporter'
 
 class LocalAuthoritiesController < ApplicationController
+  include LinkFilterHelper
+
   def index
     @authorities = LocalAuthority.order(broken_link_count: :desc)
     raise RuntimeError.new('Missing Data') if @authorities.empty?
@@ -22,19 +24,8 @@ class LocalAuthoritiesController < ApplicationController
 private
 
   def links_for_authority
-    @_links_for_authority ||= filtered_links
+    @_links_for_authority ||= filtered_links(@authority.provided_service_links)
       .includes([:service, :interaction])
       .all
-  end
-
-  def filtered_links
-    links = @authority.provided_service_links
-
-    case params[:filter]
-    when 'broken_links'
-      links.broken_or_missing
-    else
-      links
-    end
   end
 end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -32,7 +32,7 @@ private
 
     case params[:filter]
     when 'broken_links'
-      links.currently_broken
+      links.broken_or_missing
     else
       links
     end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -33,8 +33,6 @@ private
     case params[:filter]
     when 'broken_links'
       links.currently_broken
-    when 'good_links'
-      links.good_links
     else
       links
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -26,8 +26,6 @@ private
     case params[:filter]
     when 'broken_links'
       links.currently_broken
-    when 'good_links'
-      links.good_links
     else
       links
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,4 +1,6 @@
 class ServicesController < ApplicationController
+  include LinkFilterHelper
+
   def index
     @services = Service.enabled.order(broken_link_count: :desc)
     raise RuntimeError.new('Missing Data') if @services.empty?
@@ -15,19 +17,8 @@ class ServicesController < ApplicationController
 private
 
   def links_for_service
-    @_links_for_service ||= filtered_links
+    @_links_for_service ||= filtered_links(@service.links)
       .includes([:service, :interaction, :local_authority])
       .all
-  end
-
-  def filtered_links
-    links = @service.links
-
-    case params[:filter]
-    when 'broken_links'
-      links.broken_or_missing
-    else
-      links
-    end
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -25,7 +25,7 @@ private
 
     case params[:filter]
     when 'broken_links'
-      links.currently_broken
+      links.broken_or_missing
     else
       links
     end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -23,7 +23,6 @@ class Link < ApplicationRecord
 
   scope :currently_broken, -> { where(status: "broken") }
   scope :broken_or_missing, -> { currently_broken.or(without_url) }
-  scope :have_been_checked, -> { where.not(status: nil) }
 
   scope :last_checked_before, -> (last_checked) {
     where("link_last_checked IS NULL OR link_last_checked < ?", last_checked)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -21,7 +21,6 @@ class Link < ApplicationRecord
   scope :with_url, -> { where.not(url: nil) }
   scope :without_url, -> { where(url: nil) }
 
-  scope :good_links, -> { where.not(status: "broken") }
   scope :currently_broken, -> { where(status: "broken") }
   scope :have_been_checked, -> { where.not(status: nil) }
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -68,6 +68,11 @@ class Link < ApplicationRecord
     )
   end
 
+  def make_missing
+    self.url = nil
+    save
+  end
+
 private
 
   def link_with_matching_url

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -21,8 +21,9 @@ class Link < ApplicationRecord
   scope :with_url, -> { where.not(url: nil) }
   scope :without_url, -> { where(url: nil) }
 
+  scope :missing, -> { where(status: "missing") }
   scope :currently_broken, -> { where(status: "broken") }
-  scope :broken_or_missing, -> { currently_broken.or(without_url) }
+  scope :broken_or_missing, -> { currently_broken.or(missing) }
 
   scope :last_checked_before, -> (last_checked) {
     where("link_last_checked IS NULL OR link_last_checked < ?", last_checked)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -22,6 +22,7 @@ class Link < ApplicationRecord
   scope :without_url, -> { where(url: nil) }
 
   scope :currently_broken, -> { where(status: "broken") }
+  scope :broken_or_missing, -> { currently_broken.or(without_url) }
   scope :have_been_checked, -> { where.not(status: nil) }
 
   scope :last_checked_before, -> (last_checked) {
@@ -31,7 +32,7 @@ class Link < ApplicationRecord
   validates :status, inclusion: { in: %w(ok broken caution missing pending) }, allow_nil: true
 
   def self.enabled_links
-    self.with_url.joins(:service).where(services: { enabled: true })
+    self.joins(:service).where(services: { enabled: true })
   end
 
   def self.retrieve(params)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -88,7 +88,16 @@ private
   end
 
   def set_link_check_results_on_updated_link
-    if link_with_matching_url
+    if self.url == nil
+      self.update_columns(
+        status: "missing",
+        link_last_checked: nil,
+        link_errors: [],
+        link_warnings: [],
+        problem_summary: nil,
+        suggested_fix: nil,
+      )
+    elsif link_with_matching_url
       set_link_check_results(link_with_matching_url)
     else
       self.update_columns(

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -29,10 +29,6 @@ class LocalAuthority < ApplicationRecord
   # returns the Links for this authority,
   # for the enabled Services that this authority provides.
   def provided_service_links
-    links.with_url.joins(:service).merge(provided_services)
-  end
-
-  def all_provided_service_links
     links.joins(:service).merge(provided_services)
   end
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -35,7 +35,7 @@ class LocalAuthority < ApplicationRecord
   def update_broken_link_count
     update_attribute(
       :broken_link_count,
-      provided_service_links.have_been_checked.currently_broken.count
+      provided_service_links.broken_or_missing.count
     )
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -18,7 +18,7 @@ class Service < ApplicationRecord
   def update_broken_link_count
     update_attribute(
       :broken_link_count,
-      Link.for_service(self).have_been_checked.currently_broken.count
+      Link.for_service(self).broken_or_missing.count
     )
   end
 

--- a/app/presenters/url_status_presentation.rb
+++ b/app/presenters/url_status_presentation.rb
@@ -9,6 +9,8 @@ module UrlStatusPresentation
       "Note: #{problem_summary}"
     elsif status == "broken"
       "Broken: #{problem_summary}"
+    elsif status == "missing"
+      "Missing"
     else
       problem_summary
     end
@@ -23,6 +25,7 @@ module UrlStatusPresentation
     return "label label-success" if status == "ok"
     return "label label-danger" if status == "broken"
     return "label label-warning" if status == "caution"
+    return "label label-danger" if status == "missing"
     "label label-info"
   end
 

--- a/app/views/links/_link_table_row.html.erb
+++ b/app/views/links/_link_table_row.html.erb
@@ -12,6 +12,8 @@
       <a href="https://www.gov.uk/<%= link.service_interaction.govuk_slug %>">GOV.UK</a> &rarr;
       <% if link.url %>
         <%= link_to truncate(link.url, length: 80), link.url %>
+      <% else %>
+        <%= link_to "No URL", link.local_authority.homepage_url %>
       <% end %>
     </div>
   </td>

--- a/app/views/local_authorities/_link_filter_nav.html.erb
+++ b/app/views/local_authorities/_link_filter_nav.html.erb
@@ -1,7 +1,6 @@
 <nav class="link-nav">
   <ul class="nav nav-tabs">
     <li role="presentation" class="<%= 'active' if @link_filter == 'broken_links' %>"><%= link_to 'Broken links', local_authority_path(@authority, filter: 'broken_links' ) %></li>
-    <li role="presentation" class="<%= 'active' if @link_filter == 'good_links' %>"><%= link_to 'Good links', local_authority_path(@authority, filter: 'good_links') %></li>
     <li role="presentation" class="<%= 'active' if @link_filter.nil? %>"><%= link_to 'All links', local_authority_path(@authority) %></li>
   </ul>
 </nav>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Local Authorities" %>
 
-<% breadcrumb :root %>
+<% breadcrumb :local_authorities %>
 
 <div class="page-title">
   <h1>Local Links Manager</h1>

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -4,7 +4,7 @@
 <div class="alert alert-success"><%= flash[:success] %></div>
 <% end %>
 
-<% breadcrumb :services, @authority %>
+<% breadcrumb :local_authority, @authority %>
 
 <%= render partial: "shared/local_authority_details", locals: { authority: @authority } %>
 

--- a/app/views/services/_link_filter_nav.html.erb
+++ b/app/views/services/_link_filter_nav.html.erb
@@ -1,7 +1,6 @@
 <nav class="link-nav">
   <ul class="nav nav-tabs">
     <li role="presentation" class="<%= 'active' if @link_filter == 'broken_links' %>"><%= link_to 'Broken links', service_path(@service, filter: 'broken_links' ) %></li>
-    <li role="presentation" class="<%= 'active' if @link_filter == 'good_links' %>"><%= link_to 'Good links', service_path(@service, filter: 'good_links') %></li>
     <li role="presentation" class="<%= 'active' if @link_filter.nil? %>"><%= link_to 'All links', service_path(@service) %></li>
   </ul>
 </nav>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, 'Services' %>
 
-<% breadcrumb :root %>
+<% breadcrumb :services %>
 
 <div class="page-title">
   <h1>Local Links Manager</h1>

--- a/app/views/shared/_link_table_row.html.erb
+++ b/app/views/shared/_link_table_row.html.erb
@@ -13,7 +13,11 @@
     <p>
       <%= link.interaction_label %>
       <br>
-      <%= link_to nil, link.url %>
+      <% if link.url %>
+        <%= link_to nil, link.url %>
+      <% else %>
+        <%= link_to "No URL", link.local_authority.homepage_url %>
+      <% end %>
     </p>
   </td>
   <td class="status">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,14 +2,22 @@ crumb :root do
   link "Local links", root_path
 end
 
-crumb :services do |local_authority|
+crumb :local_authorities do
+  link "Local authorities", local_authorities_path
+end
+
+crumb :local_authority do |local_authority|
   link local_authority.name, local_authority_path(local_authority.slug)
-  parent :root
+  parent :local_authorities
+end
+
+crumb :services do
+  link "Services", services_path
 end
 
 crumb :service do |service|
   link service.label, service_path(service)
-  parent :root
+  parent :services
 end
 
 crumb :links do |local_authority, service, interaction|

--- a/db/migrate/20170928143923_add_status_index_to_links.rb
+++ b/db/migrate/20170928143923_add_status_index_to_links.rb
@@ -1,0 +1,5 @@
+class AddStatusIndexToLinks < ActiveRecord::Migration[5.0]
+  def change
+    add_index :links, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926084949) do
+ActiveRecord::Schema.define(version: 20170928143923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20170926084949) do
     t.index ["local_authority_id", "service_interaction_id"], name: "index_links_on_local_authority_id_and_service_interaction_id", unique: true, using: :btree
     t.index ["local_authority_id"], name: "index_links_on_local_authority_id", using: :btree
     t.index ["service_interaction_id"], name: "index_links_on_service_interaction_id", using: :btree
+    t.index ["status"], name: "index_links_on_status", using: :btree
     t.index ["url"], name: "index_links_on_url", using: :btree
   end
 

--- a/lib/local-links-manager/export/link_status_exporter.rb
+++ b/lib/local-links-manager/export/link_status_exporter.rb
@@ -17,7 +17,7 @@ module LocalLinksManager
       def self.links_status_csv
         CSV.generate do |csv|
           csv << HEADINGS
-          Link.enabled_links.group(:problem_summary, :status).count.each do |(problem_summary, status), count|
+          Link.with_url.enabled_links.group(:problem_summary, :status).count.each do |(problem_summary, status), count|
             csv << [problem_summary || "nil", count, status || "nil"]
           end
         end

--- a/lib/local-links-manager/import/missing_links.rb
+++ b/lib/local-links-manager/import/missing_links.rb
@@ -9,7 +9,7 @@ module LocalLinksManager
         ServiceInteraction.where(live: true).each do |service_interaction|
           las_with_no_link(service_interaction).each do |local_authority_id|
             Rails.logger.info "Creating link for #{local_authority_id}, #{service_interaction.govuk_slug}"
-            Link.create!(local_authority_id: local_authority_id, service_interaction: service_interaction, analytics: 0, url: nil)
+            Link.create!(local_authority_id: local_authority_id, service_interaction: service_interaction, analytics: 0, status: "missing", url: nil)
           end
         end
       end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe LinksController, type: :controller do
     end
   end
 
-  describe 'delete links' do
-    it 'handles deletion of links that have already been deleted' do
-      delete :destroy, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug }
-      expect(response).to have_http_status(302)
-      expect(flash[:danger]).not_to be_present
-    end
-  end
-
   describe 'GET homepage_links_status_csv' do
     it "retrieves HTTP success" do
       get :homepage_links_status_csv

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
 
   factory :missing_link, parent: :link do
     url nil
+    status "missing"
   end
 
   factory :link_for_disabled_service, parent: :link do

--- a/spec/features/links/index_spec.rb
+++ b/spec/features/links/index_spec.rb
@@ -42,8 +42,12 @@ feature 'The broken links page' do
     expect(page).not_to have_link @link_1.url
   end
 
-  it 'doesn\'t show missing links' do
-    expect(page).not_to have_content(@council_d.name)
+  it 'shows missing links' do
+    expect(page).to have_link "No URL", href: @link_4.local_authority.homepage_url
+  end
+
+  it 'shows missing status' do
+    expect(page).to have_content "Missing"
   end
 
   it 'lists the links prioritised by analytics count' do
@@ -52,7 +56,7 @@ feature 'The broken links page' do
 
   it 'shows a count of the number of broken links' do
     within('thead') do
-      expect(page).to have_content "2 broken links"
+      expect(page).to have_content "3 broken links"
     end
   end
 

--- a/spec/features/links/index_spec.rb
+++ b/spec/features/links/index_spec.rb
@@ -32,6 +32,7 @@ feature 'The broken links page' do
   it 'shows the council name for each broken link' do
     expect(page).to have_content(@council_b.name)
     expect(page).to have_content(@council_c.name)
+    expect(page).to have_content(@council_d.name)
   end
 
   it 'shows non-200 status links' do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -71,7 +71,6 @@ feature "The local authority show page" do
       expect(page).to have_selector('.link-nav')
       within('.link-nav') do
         expect(page).to have_link 'Broken links'
-        expect(page).to have_link 'Good links'
         expect(page).to have_link 'All links'
       end
     end
@@ -140,24 +139,6 @@ feature "The local authority show page" do
 
       it 'doesn\'t show 200 status links' do
         expect(page).not_to have_link @good_link.url
-      end
-
-      it 'doesn\'t show missing links' do
-        expect(page).not_to have_content("Missing")
-      end
-    end
-
-    describe 'good links' do
-      before do
-        click_link "Good links"
-      end
-
-      it 'shows 200 status links' do
-        expect(page).to have_link @good_link.url
-      end
-
-      it 'doesn\'t show non-200 status links' do
-        expect(page).not_to have_link @broken_link.url
       end
 
       it 'doesn\'t show missing links' do

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -59,7 +59,7 @@ feature "The local authority show page" do
 
     it 'shows a count of the number of all links for enabled services' do
       within('thead') do
-        expect(page).to have_content "2 links"
+        expect(page).to have_content "3 links"
       end
     end
 
@@ -84,8 +84,8 @@ feature "The local authority show page" do
       expect(page).not_to have_content(@disabled_service.label)
     end
 
-    it "does not show missing links" do
-      expect(page).not_to have_content("Missing")
+    it "shows missing links" do
+      expect(page).to have_content("Missing")
     end
 
     it "shows each service's LGSL codes in the table" do
@@ -141,8 +141,8 @@ feature "The local authority show page" do
         expect(page).not_to have_link @good_link.url
       end
 
-      it 'doesn\'t show missing links' do
-        expect(page).not_to have_content("Missing")
+      it 'shows missing links' do
+        expect(page).to have_content("Missing")
       end
     end
   end

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -54,7 +54,6 @@ feature 'The services show page' do
     expect(page).to have_selector('.link-nav')
     within('.link-nav') do
       expect(page).to have_link 'Broken links'
-      expect(page).to have_link 'Good links'
       expect(page).to have_link 'All links'
     end
   end
@@ -70,20 +69,6 @@ feature 'The services show page' do
 
     it 'doesn\'t show 200 status links' do
       expect(page).not_to have_link @link_1.url
-    end
-  end
-
-  describe 'good links' do
-    before do
-      click_link "Good links"
-    end
-
-    it 'shows 200 status links' do
-      expect(page).to have_link @link_1.url
-    end
-
-    it 'doesn\'t show non-200 status links' do
-      expect(page).not_to have_link @link_2.url
     end
   end
 

--- a/spec/lib/local-links-manager/export/links_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/links_exporter_spec.rb
@@ -19,8 +19,10 @@ describe LocalLinksManager::Export::LinksExporter do
       disabled_service = create(:disabled_service, lgsl_code: 666, label: 'Service 666')
       interaction_0 = create(:interaction, lgil_code: 0, label: 'Interaction 0')
       interaction_1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      interaction_2 = create(:interaction, lgil_code: 2, label: 'Interaction 2')
       service_interaction_0 = create(:service_interaction, service: service, interaction: interaction_0)
       service_interaction_1 = create(:service_interaction, service: service, interaction: interaction_1)
+      service_interaction_2 = create(:service_interaction, service: service, interaction: interaction_2)
       disabled_service_interaction = create(:service_interaction, service: disabled_service, interaction: interaction_0)
 
       local_authority_1 = create(:local_authority, name: 'London', snac: '00AB', gss: '123')
@@ -31,7 +33,7 @@ describe LocalLinksManager::Export::LinksExporter do
       create(:link, local_authority: local_authority_2, service_interaction: service_interaction_0, url: test_url(local_authority_2, interaction_0))
       create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1, url: test_url(local_authority_2, interaction_1))
       create(:link, local_authority: local_authority_2, service_interaction: disabled_service_interaction, url: test_url(local_authority_2, disabled_service_interaction))
-      create(:missing_link)
+      create(:missing_link, service_interaction: service_interaction_2)
 
       csv_file = File.read(fixture_file("exported_links.csv"))
 

--- a/spec/lib/local-links-manager/import/missing_links_spec.rb
+++ b/spec/lib/local-links-manager/import/missing_links_spec.rb
@@ -13,7 +13,7 @@ describe LocalLinksManager::Import::MissingLinks do
     it "adds a missing link for each live service interaction that a council does not have a link for" do
       described_class.new.add_missing_links
 
-      expect(council_with_no_links.all_provided_service_links.count).to eq(2)
+      expect(council_with_no_links.provided_service_links.count).to eq(2)
     end
 
     it "does not add a link if the local authority already has one for that service interaction" do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Link, type: :model do
       link.reload
 
       expect(link.url).to be_nil
-      expect(link.status).to be_nil
+      expect(link.status).to eq("missing")
       expect(link.analytics).to eq(73)
     end
   end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Link, type: :model do
     it { is_expected.to have_one(:interaction).through(:service_interaction) }
   end
 
+  describe '.broken_or_missing' do
+    it 'fetches broken and missing links' do
+      link_1 = FactoryGirl.create(:missing_link)
+      link_2 = FactoryGirl.create(:link, status: "broken")
+      FactoryGirl.create(:link)
+
+      expect(Link.broken_or_missing).to match_array([link_1, link_2])
+    end
+  end
+
   describe '.for_service' do
     it 'fetches all the links for the supplied service' do
       service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -120,6 +120,19 @@ RSpec.describe Link, type: :model do
     end
   end
 
+  describe "#make_missing" do
+    it "makes a link into a missing link" do
+      link = create(:link, url: "https://www.gov.uk", status: "ok", analytics: 73)
+
+      link.make_missing
+      link.reload
+
+      expect(link.url).to be_nil
+      expect(link.status).to be_nil
+      expect(link.analytics).to eq(73)
+    end
+  end
+
   describe "before_update" do
     before do
       @problem_summary = "Invalid URL"

--- a/spec/support/url_status_presentation.rb
+++ b/spec/support/url_status_presentation.rb
@@ -29,6 +29,11 @@ RSpec.shared_examples "a UrlStatusPresentation module" do
       )
       expect(presenter.status_description).to eq("Note: Unusual response")
     end
+
+    it 'returns "Missing" if the link is missing' do
+      @link = double(:Link, status: 'missing')
+      expect(presenter.status_description).to eq('Missing')
+    end
   end
 
   describe '#label_status_class' do
@@ -57,6 +62,11 @@ RSpec.shared_examples "a UrlStatusPresentation module" do
     it 'returns "label label-warning" for a caution status' do
       @link = double(:Link, status: 'caution')
       expect(presenter.label_status_class).to eq('label label-warning')
+    end
+
+    it 'returns "label label-danger" for a missing status' do
+      @link = double(:Link, status: 'missing')
+      expect(presenter.label_status_class).to eq('label label-danger')
     end
   end
 


### PR DESCRIPTION
In this PR we enable showing missing links on the three relevant pages: the homepage, services pages and local authority pages.

We tweak the rake task to add missing links so we ensure that a status is set and prevent links from being deleted in the UI (as we'd only have to run the rake task again)

We also remove the "Good Links" tab as it is never used and the "Broken" and "All" tabs are sufficient.

I've also updated the breadcrumbs as the hierarchy was a bit short before.  Now we have a way to navigate from a service to a local authority and back

Screenshots of missing links on each page are below.  We'll update the local authority and service pages in subsequent PRs

Services page
![screen shot 2017-09-28 at 13 57 07](https://user-images.githubusercontent.com/773037/30967898-75cec75c-a455-11e7-97bd-7667f036f8ad.png)

Local authority page
![screen shot 2017-09-28 at 13 56 46](https://user-images.githubusercontent.com/773037/30967900-75d32b1c-a455-11e7-85f2-c227aaeacbf8.png)

Home page
![screen shot 2017-09-28 at 13 56 30](https://user-images.githubusercontent.com/773037/30967899-75d07cf0-a455-11e7-8340-6db717d0acf2.png)
