### PR TITLE
Fix import command to match rake task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,6 @@ end
 
 # Run the rake task to import Google analytics for local transactions.
 every :day, at: '5am' do
-  rake 'import:analytics'
+  rake 'import:google_analytics'
 end
 


### PR DESCRIPTION
It seems that we've been using the wrong name for the rake task so this
hasn't been running :-(

https://github.com/alphagov/local-links-manager/blob/776000408cde81b276105479e760c7fab9db9bbc/lib/tasks/import/google_analytics.rake#L5

Part of: https://trello.com/c/hwYmLdBN/229-fix-local-links-manager-ga-import-and-run-more-often