### PR TITLE
Change bundler version to 1.15.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,4 +414,4 @@ RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.15.3
+   1.15.1


### PR DESCRIPTION
The version for bundler should have been bumped from 1.14.5 to 1.15.1, but instead got bumped to 1.15.3.

This commit reverts to version 1.15.1.