### PR TITLE
Schedule daily upload of bad links to GA

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,6 @@ every :day, at: '5am' do
   rake 'import:google_analytics'
 end
 
+every :day, at: '6am' do
+  rake 'export:google_analytics:bad_links'
+end

--- a/lib/tasks/export/analytics_bad_links_exporter.rake
+++ b/lib/tasks/export/analytics_bad_links_exporter.rake
@@ -4,19 +4,28 @@ namespace :export do
   namespace :google_analytics do
     desc "Export bad links status to Google Analytics"
     task "bad_links": :environment do
-      service_desc = "Export bad links status to Google Analytics"
-      begin
-        Rails.logger.info("Starting link exporter")
-        Services.icinga_check(service_desc, true, "Exporting list of bad links to Google Analytics")
+      if ENV["RUN_LINK_GA_EXPORT"].present? && ENV["RUN_LINK_GA_EXPORT"] == "true"
+        service_desc = "Export bad links status to Google Analytics"
+        LocalLinksManager::DistributedLock.new('bad-links-analytics-export').lock(
+          lock_obtained: ->() {
+            begin
+              Rails.logger.info("Starting link exporter")
+              Services.icinga_check(service_desc, true, "Exporting list of bad links to Google Analytics")
 
-        LocalLinksManager::Export::AnalyticsExporter.export
+              LocalLinksManager::Export::AnalyticsExporter.export
 
-        Rails.logger.info("Bad links export to GA has completed")
-        Services.icinga_check(service_desc, true, "Success")
-      rescue StandardError => e
-        Rails.logger.error("Error while running link exporter\n#{e}")
-        Services.icinga_check(service_desc, false, e.to_s)
-        raise e
+              Rails.logger.info("Bad links export to GA has completed")
+              Services.icinga_check(service_desc, true, "Success")
+            rescue StandardError => e
+              Rails.logger.error("Error while running link exporter\n#{e}")
+              Services.icinga_check(service_desc, false, e.to_s)
+              raise e
+            end
+          },
+          lock_not_obtained: ->() {
+            Services.icinga_check(service_desc, true, "Unable to lock")
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
This will schedule a daily operation to upload a file to Google Analytics. The file will contain a list of broken links and their statuses (reason for being broken). This will allow us to track daily changes to the status of broken links in GA. 

For: https://trello.com/c/9CHX7tje/312-run-daily-scheduled-export-of-bad-links-to-ga