### PR TITLE
Schedule deleting uploaded files from GA

### DIFF
--- a/lib/google_analytics/analytics_export_service.rb
+++ b/lib/google_analytics/analytics_export_service.rb
@@ -18,6 +18,7 @@ module GoogleAnalytics
 
     def export_bad_links(data)
       begin
+        delete_previous_uploads
         response = ''
         Tempfile.create('bad_links.csv', Dir.pwd) do |file|
           file.write(data)
@@ -28,8 +29,32 @@ module GoogleAnalytics
                                          upload_source: file.path,
                                          content_type: 'application/octet-stream')
         end
+        Rails.logger.info "A new file has been uploaded for #{Date.today}"
       end
       response
+    end
+
+    def delete_previous_uploads(min_number_to_not_delete = 2)
+      upload_list = service.list_uploads(ENV['GOOGLE_EXPORT_ACCOUNT_ID'],
+                                         ENV['GOOGLE_EXPORT_CUSTOM_DATA_IMPORT_SOURCE_ID'],
+                                         ENV['GOOGLE_EXPORT_TRACKER_ID'])
+
+      number_of_items = upload_list.items.count
+      return "Need more than #{min_number_to_not_delete} to start deleting" if number_of_items <= min_number_to_not_delete
+
+      custom_data_import_uids = upload_list.items.last(number_of_items - min_number_to_not_delete).map(&:id)
+
+      delete_upload_data_request_object = Google::Apis::AnalyticsV3::DeleteUploadDataRequest.new(custom_data_import_uids: custom_data_import_uids)
+
+      response = @service.delete_upload_data(
+        ENV['GOOGLE_EXPORT_ACCOUNT_ID'],
+        ENV['GOOGLE_EXPORT_CUSTOM_DATA_IMPORT_SOURCE_ID'],
+        ENV['GOOGLE_EXPORT_TRACKER_ID'],
+        delete_upload_data_request_object
+      )
+
+      Rails.logger.info "Previous uploaded files are now deleted. We've kept the last #{min_number_to_not_delete}."
+      response == '' ? "Successfully deleted" : response
     end
   end
 end

--- a/spec/lib/google_analytics/analytics_export_service_spec.rb
+++ b/spec/lib/google_analytics/analytics_export_service_spec.rb
@@ -7,6 +7,42 @@ describe GoogleAnalytics::AnalyticsExportService do
   let(:authorizer) { Google::Auth::ServiceAccountCredentials.new }
   let(:data) { "ga:dimension36,ga:dimension37\n'www.google.com','OK'\n" }
   let(:scope) { 'https://www.googleapis.com/auth/analytics.edit' }
+  let(:upload_response) {
+    double(Google::Apis::AnalyticsV3::Upload,
+           account_id: '1234',
+           custom_data_source_id: 'abcdefg',
+           id: 'AbCd-1234',
+           kind: 'analytics#upload',
+           status: 'PENDING')
+  }
+
+  let(:uploaded_item) {
+    double(Google::Apis::AnalyticsV3::Upload,
+           account_id: '1234',
+           custom_data_source_id: 'abcdefg',
+           id: 'AbCd-1234',
+           kind: 'analytics#upload',
+           status: 'COMPLETED')
+  }
+  let(:uploaded_item2) {
+    double(Google::Apis::AnalyticsV3::Upload,
+           account_id: '1234',
+           custom_data_source_id: 'abcdefg',
+           errors: ['Column headers missing for the input file.'],
+           id: 'AbCd-1234',
+           kind: 'analytics#upload',
+           status: 'FAILED',
+           upload_time: 'Thu, 11 Jan 2018 12:36:35 +0000')
+  }
+
+  let(:upload_list) {
+    double(Google::Apis::AnalyticsV3::Upload,
+           items: [uploaded_item, uploaded_item2],
+           items_per_page: 1000,
+           kind: "analytics#uploads",
+           start_index: 1,
+           total_results: 3)
+  }
 
   before do
     ENV['GOOGLE_CLIENT_EMAIL'] = 'email@email.com'
@@ -23,22 +59,56 @@ describe GoogleAnalytics::AnalyticsExportService do
   end
 
   describe '#export_bad_links' do
-    let(:upload_response) { GoogleAnalytics::UploadResponseFactory.build }
-    let(:upload_response) {
-      double(Google::Apis::AnalyticsV3::Upload,
-                                    account_id: '1234',
-                                    custom_data_source_id: 'abcdefg',
-                                    id: 'AbCd-1234',
-                                    kind: 'analytics#upload',
-                                    status: 'PENDING')
-    }
-
     it 'returns a confirmation that the data has been received' do
       subject.build
 
       allow(subject.service).to receive(:upload_data).and_return(upload_response)
+      allow(subject.service).to receive(:list_uploads).and_return(upload_list)
 
       expect(subject.export_bad_links(data)).to eq(upload_response)
+    end
+  end
+
+  describe '#delete_previous_uploads' do
+    let(:uploaded_item3) {
+      double(Google::Apis::AnalyticsV3::Upload,
+             account_id: '1234',
+             custom_data_source_id: 'abcdefg',
+             errors: ['Column headers missing for the input file.'],
+             id: 'AbCd-1234',
+             kind: 'analytics#upload',
+             status: 'FAILED',
+             upload_time: 'Thu, 13 Jan 2018 12:36:35 +0000')
+    }
+
+    let(:upload_list2) {
+      double(Google::Apis::AnalyticsV3::Upload,
+             items: [uploaded_item, uploaded_item2, uploaded_item3],
+             items_per_page: 1000,
+             kind: "analytics#uploads",
+             start_index: 1,
+             total_results: 3)
+    }
+
+    before do
+      subject.build
+      allow(subject.service).to receive(:list_uploads).and_return(upload_list)
+      allow(subject.service).to receive(:delete_upload_data).and_return('')
+    end
+
+    it "doesn't delete any files if 2 files are uploaded to GA if no minimum file limit is provided" do
+      expect(subject.delete_previous_uploads).to eq('Need more than 2 to start deleting')
+    end
+
+    it "doesn't delete any files if 3 files are uploaded to GA and the minimum file limit provided is 3" do
+      allow(subject.service).to receive(:list_uploads).and_return(upload_list2)
+      expect(subject.delete_previous_uploads(3)).to eq('Need more than 3 to start deleting')
+    end
+
+    it "deletes if the number of files is more than the default we expect to leave untouched in GA" do
+      allow(subject.service).to receive(:list_uploads).and_return(upload_list2)
+
+      expect(subject.delete_previous_uploads).to eq('Successfully deleted')
     end
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/NYNZzVyW/315-schedule-deleting-files-from-ga

Because we're now uploading a daily list of bad links to GA, we're going to reach the quota limit if we don't start deleting these files automatically. 

This job will run daily, before we upload a new file. For reference and as a sanity check that the daily upload task is still working, we're going to delete all files but the last 2.

Deleting the files after they've been processed does not get rid of the data that was introduced through them. Processing time when a file has been uploaded only takes a few seconds so we are safe if we delete the file 3 days later. 

## Documentation

Documentation for the GA Management API `deleteUploadData` method we're using can be found here: 
- API docs https://developers.google.com/analytics/devguides/config/mgmt/v3/mgmtReference/management/uploads/deleteUploadData
- Ruby wrapper for API
https://github.com/google/google-api-ruby-client/blob/04f0dbfe7aac8229dabaa5ddee32ea03b2402402/generated/google/apis/analytics_v3/service.rb
