### PR TITLE
Replace deprecated require_signin_permission! with authorise_user!

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,7 @@
 require 'local-links-manager/link_resolver'
 
 class ApiController < ApplicationController
-  skip_before_action :require_signin_permission!
+  skip_before_action :authenticate_user!
 
   def link
     return render json: {}, status: 400 if missing_required_params_for_link?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -2,7 +2,7 @@ require "gds_api/link_checker_api"
 require "local-links-manager/check_links/link_status_updater"
 
 class WebhooksController < ApplicationController
-  skip_before_action :require_signin_permission!
+  skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
   before_action :verify_signature
 


### PR DESCRIPTION
From https://github.com/alphagov/gds-sso:

> The signon application makes sure that only users who have been granted access to the application can access it (e.g. they have the signin permission for your app). This used to be left up to the applications themselves to check with the `require_signin_permission!` method. This is now deprecated and can be removed from your controllers. You should replace it with a call to `authenticate_user!` if you aren't already using that method, otherwise no signon authentication will be performed.