### PR TITLE
Move FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ end
 
 group :development, :test do
   gem 'capybara', '~> 3.2'
-  gem 'factory_girl_rails', '~> 4.7'
+  gem 'factory_bot_rails', '~> 4.7'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.5'
   gem 'shoulda-matchers', '~> 3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ end
 
 gem 'addressable', '~> 2.5.1'
 gem 'dalli'
-gem 'faraday'
-gem 'faraday_middleware'
 gem 'google-api-client', '~> 0.23.0'
 gem 'googleauth', '~> 0.6.2'
 gem 'govuk_app_config', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,8 +96,6 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
-      faraday (>= 0.7.4, < 1.0)
     ffi (1.9.23)
     gds-api-adapters (52.5.1)
       addressable
@@ -401,8 +399,6 @@ DEPENDENCIES
   capybara (~> 3.2)
   dalli
   factory_girl_rails (~> 4.7)
-  faraday
-  faraday_middleware
   gds-api-adapters (~> 52.5.1)
   gds-sso (~> 13.6)
   google-api-client (~> 0.23.0)
@@ -431,7 +427,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,10 +89,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.10.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -398,7 +398,7 @@ DEPENDENCIES
   capistrano-rails
   capybara (~> 3.2)
   dalli
-  factory_girl_rails (~> 4.7)
+  factory_bot_rails (~> 4.7)
   gds-api-adapters (~> 52.5.1)
   gds-sso (~> 13.6)
   google-api-client (~> 0.23.0)

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe LinksController, type: :controller do
   before do
     login_as_stub_user
-    @local_authority = FactoryGirl.create(:local_authority)
-    @service = FactoryGirl.create(:service)
-    @interaction = FactoryGirl.create(:interaction)
+    @local_authority = create(:local_authority)
+    @service = create(:service)
+    @interaction = create(:interaction)
   end
 
   describe 'GET edit' do

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe LinksController, type: :controller do
   describe 'GET edit' do
     it 'retrieves HTTP success' do
       get :edit, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
   describe 'GET homepage_links_status_csv' do
     it "retrieves HTTP success" do
       get :homepage_links_status_csv
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe LinksController, type: :controller do
   describe 'GET links_status_csv' do
     it "retrieves HTTP success" do
       get :links_status_csv
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe LinksController, type: :controller do
   describe 'GET bad_links_url_and_status_csv' do
     it "retrieves HTTP success" do
       get :bad_links_url_and_status_csv
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
         login_as_stub_user
         create(:local_authority)
         get :index
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -28,7 +28,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     it "returns http success" do
       login_as_stub_user
       get :show, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     it "retrieves HTTP success" do
       login_as_stub_user
       get :bad_homepage_url_and_status_csv
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
 
   describe "GET #show" do
     before do
-      @local_authority = FactoryGirl.create(:local_authority, name: 'Angus')
-      @service = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
+      @local_authority = create(:local_authority, name: 'Angus')
+      @service = create(:service, label: 'Service 1', lgsl_code: 1)
     end
 
     it "returns http success" do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ServicesController, type: :controller do
   describe "GET #show" do
     it "returns http success" do
       login_as_stub_user
-      service = FactoryGirl.create(:service)
+      service = create(:service)
       get :show, params: { service_slug: service.slug }
       expect(response).to have_http_status(:success)
     end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ServicesController, type: :controller do
         login_as_stub_user
         create(:service)
         get :index
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe ServicesController, type: :controller do
       login_as_stub_user
       service = create(:service)
       get :show, params: { service_slug: service.slug }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/factories/interactions.rb
+++ b/spec/factories/interactions.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :interaction do
     sequence(:lgil_code) { |n| n }
     sequence(:label) { |n| "Interaction Label #{n}" }

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :link do
     association :local_authority
     association :service_interaction

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :local_authority do
     sequence(:name) { |n| "Local Authority Name #{n}" }
     sequence(:gss) { |n| "S%08i" % n }

--- a/spec/factories/service_interactions.rb
+++ b/spec/factories/service_interactions.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :service_interaction do
     association :interaction
     association :service, :all_tiers

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -4,7 +4,7 @@ def create_factory_service_tiers(service, tiers)
   end
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :service do
     sequence(:lgsl_code) { |n| n }
     sequence(:label) { |n| "Service Label #{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name "New User"
     email "user@email.com"

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -4,8 +4,8 @@ feature "The local authorities index page" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
 
-    @angus = FactoryGirl.create(:local_authority, name: 'Angus')
-    @zorro = FactoryGirl.create(:local_authority, name: 'Zorro Council', broken_link_count: 1)
+    @angus = create(:local_authority, name: 'Angus')
+    @zorro = create(:local_authority, name: 'Zorro Council', broken_link_count: 1)
     visit local_authorities_path
   end
 

--- a/spec/features/services/service_index_spec.rb
+++ b/spec/features/services/service_index_spec.rb
@@ -4,9 +4,9 @@ feature "The services index page" do
   before do
     User.create(email: 'user@example.com', name: 'Test User', permissions: ['signin'])
 
-    @aardvark = FactoryGirl.create(:service, label: 'Aardvark Wardens')
-    @zebra = FactoryGirl.create(:service, label: 'Zebra Fouling', broken_link_count: 1)
-    FactoryGirl.create(:disabled_service)
+    @aardvark = create(:service, label: 'Aardvark Wardens')
+    @zebra = create(:service, label: 'Zebra Fouling', broken_link_count: 1)
+    create(:disabled_service)
     visit services_path
   end
 

--- a/spec/lib/local-links-manager/check_links/link_status_requester_spec.rb
+++ b/spec/lib/local-links-manager/check_links/link_status_requester_spec.rb
@@ -8,11 +8,11 @@ describe LocalLinksManager::CheckLinks::LinkStatusRequester do
   subject(:link_status_requester) { described_class.new }
 
   context "with homepage URLs and links for enabled services" do
-    let(:local_authority_1) { FactoryGirl.create(:local_authority, homepage_url: "https://www.ambridge.gov.uk") }
-    let(:local_authority_2) { FactoryGirl.create(:local_authority, homepage_url: "https://www.midsomer.gov.uk") }
-    let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority_1, url: 'http://www.example.com/example1.html') }
-    let!(:link_2) { FactoryGirl.create(:link, local_authority: local_authority_2, url: 'http://www.example.com/example2.html') }
-    let!(:missing_link) { FactoryGirl.create(:missing_link, local_authority: local_authority_1) }
+    let(:local_authority_1) { create(:local_authority, homepage_url: "https://www.ambridge.gov.uk") }
+    let(:local_authority_2) { create(:local_authority, homepage_url: "https://www.midsomer.gov.uk") }
+    let!(:link_1) { create(:link, local_authority: local_authority_1, url: 'http://www.example.com/example1.html') }
+    let!(:link_2) { create(:link, local_authority: local_authority_2, url: 'http://www.example.com/example2.html') }
+    let!(:missing_link) { create(:missing_link, local_authority: local_authority_1) }
 
     it "makes batch requests to the link checker API not including missing links" do
       stub_1 = link_checker_api_create_batch(
@@ -44,7 +44,7 @@ describe LocalLinksManager::CheckLinks::LinkStatusRequester do
   end
 
   context "with homepage URLs and links for disabled Services" do
-    let!(:disabled_service_link) { FactoryGirl.create(:link_for_disabled_service) }
+    let!(:disabled_service_link) { create(:link_for_disabled_service) }
 
     it "does not test links other than the local authority homepage" do
       homepage_stub = link_checker_api_create_batch(
@@ -67,9 +67,9 @@ describe LocalLinksManager::CheckLinks::LinkStatusRequester do
   end
 
   context "links for an authority" do
-    let(:local_authority_1) { FactoryGirl.create(:local_authority, slug: "ambridge", homepage_url: "https://www.ambridge.gov.uk") }
-    let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority_1, url: 'http://www.example.com/example1.html') }
-    let!(:missing_link) { FactoryGirl.create(:missing_link, local_authority: local_authority_1) }
+    let(:local_authority_1) { create(:local_authority, slug: "ambridge", homepage_url: "https://www.ambridge.gov.uk") }
+    let!(:link_1) { create(:link, local_authority: local_authority_1, url: 'http://www.example.com/example1.html') }
+    let!(:missing_link) { create(:missing_link, local_authority: local_authority_1) }
 
     it "makes a batch request to the link checker API not including missing links" do
       stub_1 = link_checker_api_create_batch(

--- a/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
+++ b/spec/lib/local-links-manager/import/enabled_service_checker_spec.rb
@@ -4,10 +4,10 @@ require 'local-links-manager/import/enabled_service_checker'
 describe LocalLinksManager::Import::EnabledServiceChecker, :csv_importer do
   describe '#enabled_services' do
     let(:csv_downloader) { instance_double LocalLinksManager::Import::CsvDownloader }
-    let!(:service_0) { FactoryGirl.create(:disabled_service, lgsl_code: 1614, label: "Bursary Fund Service") }
-    let!(:service_1) { FactoryGirl.create(:disabled_service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
-    let!(:service_2) { FactoryGirl.create(:disabled_service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
-    let!(:service_3) { FactoryGirl.create(:service, lgsl_code: 47) }
+    let!(:service_0) { create(:disabled_service, lgsl_code: 1614, label: "Bursary Fund Service") }
+    let!(:service_1) { create(:disabled_service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+    let!(:service_2) { create(:disabled_service, lgsl_code: 10, label: "Special educational needs - placement in mainstream school") }
+    let!(:service_3) { create(:service, lgsl_code: 47) }
 
     context 'when the csv is downloaded successfully' do
       let(:csv_rows) { [{ "LGSL" => "1614" }, { "LGSL" => "13" }] }

--- a/spec/lib/local-links-manager/import/interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/interactions_importer_spec.rb
@@ -76,8 +76,8 @@ describe LocalLinksManager::Import::InteractionsImporter, :csv_importer do
 
       context 'when an interaction is no longer in the CSV' do
         it 'alerts Icinga that an interaction is now missing and does not delete anything' do
-          FactoryGirl.create(:interaction, lgil_code: "0", label: "Applications for service")
-          FactoryGirl.create(:interaction, lgil_code: "30", label: "Applications for exemption")
+          create(:interaction, lgil_code: "0", label: "Applications for service")
+          create(:interaction, lgil_code: "30", label: "Applications for exemption")
 
           csv_rows = [
             {
@@ -97,7 +97,7 @@ describe LocalLinksManager::Import::InteractionsImporter, :csv_importer do
 
       context 'when no interactions are missing from the CSV' do
         it 'tells Icinga that everything is fine' do
-          FactoryGirl.create(:interaction, lgil_code: "0", label: "Applications for service")
+          create(:interaction, lgil_code: "0", label: "Applications for service")
 
           csv_rows = [
             {

--- a/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
@@ -153,7 +153,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
         context 'when there are no local authorities missing from the import' do
           before do
-            FactoryGirl.create(:local_authority, gss: 'S12000033')
+            create(:local_authority, gss: 'S12000033')
             mapit_has_areas(described_class.local_authority_types, mapit_data)
           end
 
@@ -164,9 +164,9 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
         context 'when a local authority is no longer in the import' do
           before do
-            FactoryGirl.create(:local_authority, gss: 'S12000033')
-            FactoryGirl.create(:local_authority, gss: 'S12000034')
-            FactoryGirl.create(:local_authority, gss: 'S12000035')
+            create(:local_authority, gss: 'S12000033')
+            create(:local_authority, gss: 'S12000034')
+            create(:local_authority, gss: 'S12000035')
             mapit_has_areas(described_class.local_authority_types, mapit_data)
           end
 
@@ -287,9 +287,9 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
 
       context "when there are orphaned and missing local authorities" do
         it "shows both errors in the response" do
-          FactoryGirl.create(:local_authority, gss: 'S12000033', slug: "aberdeen-city-council")
-          FactoryGirl.create(:local_authority, gss: 'S12000034', slug: "gotham-city-council")
-          FactoryGirl.create(:local_authority, gss: 'S12000035', slug: "metropolis-city-council")
+          create(:local_authority, gss: 'S12000033', slug: "aberdeen-city-council")
+          create(:local_authority, gss: 'S12000034', slug: "gotham-city-council")
+          create(:local_authority, gss: 'S12000035', slug: "metropolis-city-council")
 
           orphan_child_authority = {
             "2120": {

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -7,11 +7,11 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
     let(:csv_downloader) { instance_double LocalLinksManager::Import::CsvDownloader }
 
     context 'when service interactions download is successful' do
-      let!(:service_0) { FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
-      let!(:service_1) { FactoryGirl.create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+      let!(:service_0) { create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
+      let!(:service_1) { create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
 
-      let!(:interaction_0) { FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about") }
-      let!(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact") }
+      let!(:interaction_0) { create(:interaction, lgil_code: 0, label: "Find out about") }
+      let!(:interaction_1) { create(:interaction, lgil_code: 30, label: "Contact") }
 
       let(:csv_rows) {
         [
@@ -123,13 +123,13 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
 
       context 'when a service interaction is no longer in the CSV' do
         it 'returns a failure message and does not delete anything' do
-          service_1614 = FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
+          service_1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
 
-          interaction_0 = FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about")
-          interaction_30 = FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact")
+          interaction_0 = create(:interaction, lgil_code: 0, label: "Find out about")
+          interaction_30 = create(:interaction, lgil_code: 30, label: "Contact")
 
-          FactoryGirl.create(:service_interaction, service: service_1614, interaction: interaction_0)
-          FactoryGirl.create(:service_interaction, service: service_1614, interaction: interaction_30)
+          create(:service_interaction, service: service_1614, interaction: interaction_0)
+          create(:service_interaction, service: service_1614, interaction: interaction_30)
 
           csv_rows = [
             { lgsl_code: "1614", lgil_code: "0" },
@@ -146,13 +146,13 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
 
       context 'when no service interactions are missing from the CSV' do
         it 'reports a successful import' do
-          service_1614 = FactoryGirl.create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
+          service_1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
 
-          interaction_0 = FactoryGirl.create(:interaction, lgil_code: 0, label: "Find out about")
-          interaction_30 = FactoryGirl.create(:interaction, lgil_code: 30, label: "Contact")
+          interaction_0 = create(:interaction, lgil_code: 0, label: "Find out about")
+          interaction_30 = create(:interaction, lgil_code: 30, label: "Contact")
 
-          FactoryGirl.create(:service_interaction, service: service_1614, interaction: interaction_0)
-          FactoryGirl.create(:service_interaction, service: service_1614, interaction: interaction_30)
+          create(:service_interaction, service: service_1614, interaction: interaction_0)
+          create(:service_interaction, service: service_1614, interaction: interaction_30)
 
           csv_rows = [
             { lgsl_code: "1614", lgil_code: "0" },

--- a/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/service_interactions_importer_spec.rb
@@ -7,11 +7,11 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
     let(:csv_downloader) { instance_double LocalLinksManager::Import::CsvDownloader }
 
     context 'when service interactions download is successful' do
-      let!(:service_0) { create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
-      let!(:service_1) { create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
+      let!(:service0) { create(:service, lgsl_code: 1614, label: "Bursary Fund Service") }
+      let!(:service1) { create(:service, lgsl_code: 13, label: "Abandoned shopping trolleys") }
 
-      let!(:interaction_0) { create(:interaction, lgil_code: 0, label: "Find out about") }
-      let!(:interaction_1) { create(:interaction, lgil_code: 30, label: "Contact") }
+      let!(:interaction0) { create(:interaction, lgil_code: 0, label: "Find out about") }
+      let!(:interaction1) { create(:interaction, lgil_code: 30, label: "Contact") }
 
       let(:csv_rows) {
         [
@@ -44,8 +44,8 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
         expect(ServiceInteraction.count).to eq(4)
 
         service_interaction = ServiceInteraction.last
-        expect(service_interaction.service_id).to eq(service_0.id)
-        expect(service_interaction.interaction_id).to eq(interaction_1.id)
+        expect(service_interaction.service_id).to eq(service0.id)
+        expect(service_interaction.interaction_id).to eq(interaction1.id)
       end
 
       it 'raises error and logs a warning when Identifier or Mapped Identifier is empty' do
@@ -123,13 +123,13 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
 
       context 'when a service interaction is no longer in the CSV' do
         it 'returns a failure message and does not delete anything' do
-          service_1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
+          service1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
 
-          interaction_0 = create(:interaction, lgil_code: 0, label: "Find out about")
-          interaction_30 = create(:interaction, lgil_code: 30, label: "Contact")
+          interaction0 = create(:interaction, lgil_code: 0, label: "Find out about")
+          interaction30 = create(:interaction, lgil_code: 30, label: "Contact")
 
-          create(:service_interaction, service: service_1614, interaction: interaction_0)
-          create(:service_interaction, service: service_1614, interaction: interaction_30)
+          create(:service_interaction, service: service1614, interaction: interaction0)
+          create(:service_interaction, service: service1614, interaction: interaction30)
 
           csv_rows = [
             { lgsl_code: "1614", lgil_code: "0" },
@@ -146,13 +146,13 @@ describe LocalLinksManager::Import::ServiceInteractionsImporter, :csv_importer d
 
       context 'when no service interactions are missing from the CSV' do
         it 'reports a successful import' do
-          service_1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
+          service1614 = create(:service, lgsl_code: 1614, label: "Bursary Fund Service")
 
-          interaction_0 = create(:interaction, lgil_code: 0, label: "Find out about")
-          interaction_30 = create(:interaction, lgil_code: 30, label: "Contact")
+          interaction0 = create(:interaction, lgil_code: 0, label: "Find out about")
+          interaction30 = create(:interaction, lgil_code: 30, label: "Contact")
 
-          create(:service_interaction, service: service_1614, interaction: interaction_0)
-          create(:service_interaction, service: service_1614, interaction: interaction_30)
+          create(:service_interaction, service: service1614, interaction: interaction0)
+          create(:service_interaction, service: service1614, interaction: interaction30)
 
           csv_rows = [
             { lgsl_code: "1614", lgil_code: "0" },

--- a/spec/lib/local-links-manager/import/services_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/services_importer_spec.rb
@@ -76,9 +76,9 @@ describe LocalLinksManager::Import::ServicesImporter, :csv_importer do
 
       context 'when a service is no longer in the CSV' do
         it 'returns a failure message and does not delete anything' do
-          FactoryGirl.create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
-          FactoryGirl.create(:service, lgsl_code: "13", label: "Abandoned shopping trolleys")
-          FactoryGirl.create(:service, lgsl_code: "427", label: "Overheated porridge")
+          create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
+          create(:service, lgsl_code: "13", label: "Abandoned shopping trolleys")
+          create(:service, lgsl_code: "427", label: "Overheated porridge")
 
           csv_rows = [
             {
@@ -98,7 +98,7 @@ describe LocalLinksManager::Import::ServicesImporter, :csv_importer do
 
       context 'when no services are missing from the CSV' do
         it 'reports a successful import' do
-          FactoryGirl.create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
+          create(:service, lgsl_code: "1614", label: "16 to 19 bursary fund")
 
           csv_rows = [
             {

--- a/spec/lib/local-links-manager/link_resolver_spec.rb
+++ b/spec/lib/local-links-manager/link_resolver_spec.rb
@@ -4,12 +4,12 @@ require 'local-links-manager/link_resolver'
 describe LocalLinksManager::LinkResolver do
   describe "#resolve" do
     context "with interaction" do
-      let(:local_authority) { FactoryGirl.create(:local_authority) }
-      let(:service_interaction) { FactoryGirl.create(:service_interaction) }
+      let(:local_authority) { create(:local_authority) }
+      let(:service_interaction) { create(:service_interaction) }
       let(:link_resolver) { described_class.new(local_authority, service_interaction.service, service_interaction.interaction) }
 
       it "returns a link for matching service and interaction" do
-        link = FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction)
+        link = create(:link, local_authority: local_authority, service_interaction: service_interaction)
 
         expect(link_resolver.resolve).to eq(link)
       end
@@ -26,17 +26,17 @@ describe LocalLinksManager::LinkResolver do
     end
 
     context "without interaction" do
-      let(:local_authority) { FactoryGirl.create(:local_authority) }
-      let(:service) { FactoryGirl.create(:service) }
+      let(:local_authority) { create(:local_authority) }
+      let(:service) { create(:service) }
       let(:link_resolver) { described_class.new(local_authority, service) }
 
       context "there are 2 links" do
-        let(:interaction_1) { FactoryGirl.create(:interaction, lgil_code: 1) }
-        let(:interaction_2) { FactoryGirl.create(:interaction, lgil_code: 2) }
-        let(:service_interaction_1) { FactoryGirl.create(:service_interaction, service: service, interaction: interaction_1) }
-        let(:service_interaction_2) { FactoryGirl.create(:service_interaction, service: service, interaction: interaction_2) }
-        let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_1) }
-        let!(:link_2) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction_2) }
+        let(:interaction_1) { create(:interaction, lgil_code: 1) }
+        let(:interaction_2) { create(:interaction, lgil_code: 2) }
+        let(:service_interaction_1) { create(:service_interaction, service: service, interaction: interaction_1) }
+        let(:service_interaction_2) { create(:service_interaction, service: service, interaction: interaction_2) }
+        let!(:link_1) { create(:link, local_authority: local_authority, service_interaction: service_interaction_1) }
+        let!(:link_2) { create(:link, local_authority: local_authority, service_interaction: service_interaction_2) }
 
         it "returns the link with the lower LGIL" do
           expect(link_resolver.resolve).to eq(link_1)
@@ -60,8 +60,8 @@ describe LocalLinksManager::LinkResolver do
       end
 
       context "there is only one link" do
-        let(:service_interaction) { FactoryGirl.create(:service_interaction, service: service) }
-        let!(:link) { FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction) }
+        let(:service_interaction) { create(:service_interaction, service: service) }
+        let!(:link) { create(:link, local_authority: local_authority, service_interaction: service_interaction) }
 
         it "returns the link" do
           expect(link_resolver.resolve).to eq(link)

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Interaction, type: :model do
   before(:each) do
-    FactoryGirl.create(:interaction)
+    create(:interaction)
   end
 
   it { is_expected.to validate_presence_of(:lgil_code) }

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -37,35 +37,35 @@ RSpec.describe Link, type: :model do
 
   describe '.broken_or_missing' do
     it 'fetches broken and missing links' do
-      link_1 = create(:missing_link)
-      link_2 = create(:link, status: "broken")
+      link1 = create(:missing_link)
+      link2 = create(:link, status: "broken")
       create(:link)
 
-      expect(Link.broken_or_missing).to match_array([link_1, link_2])
+      expect(Link.broken_or_missing).to match_array([link1, link2])
     end
   end
 
   describe '.for_service' do
     it 'fetches all the links for the supplied service' do
-      service_1 = create(:service, label: 'Service 1', lgsl_code: 1)
-      service_2 = create(:service, label: 'Service 2', lgsl_code: 2)
+      service1 = create(:service, label: 'Service 1', lgsl_code: 1)
+      service2 = create(:service, label: 'Service 2', lgsl_code: 2)
 
-      interaction_1 = create(:interaction, label: 'Interaction 1', lgil_code: 1)
-      interaction_2 = create(:interaction, label: 'Interaction 2', lgil_code: 2)
+      interaction1 = create(:interaction, label: 'Interaction 1', lgil_code: 1)
+      interaction2 = create(:interaction, label: 'Interaction 2', lgil_code: 2)
 
-      service_interaction_1_1 = create(:service_interaction, service: service_1, interaction: interaction_1)
-      service_interaction_1_2 = create(:service_interaction, service: service_1, interaction: interaction_2)
-      service_interaction_2_2 = create(:service_interaction, service: service_2, interaction: interaction_1)
+      service1_interaction1 = create(:service_interaction, service: service1, interaction: interaction1)
+      service1_interaction2 = create(:service_interaction, service: service1, interaction: interaction2)
+      service2_interaction2 = create(:service_interaction, service: service2, interaction: interaction1)
 
-      local_authority_1 = create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1')
-      local_authority_2 = create(:local_authority, name: 'Aberdeenshire', gss: 'S100000002', snac: '00AB2')
+      local_authority1 = create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1')
+      local_authority2 = create(:local_authority, name: 'Aberdeenshire', gss: 'S100000002', snac: '00AB2')
 
-      link_1 = create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1)
-      link_2 = create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_2)
-      create(:link, local_authority: local_authority_1, service_interaction: service_interaction_2_2)
-      link_4 = create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1_1)
+      link1 = create(:link, local_authority: local_authority1, service_interaction: service1_interaction1)
+      link2 = create(:link, local_authority: local_authority1, service_interaction: service1_interaction2)
+      create(:link, local_authority: local_authority1, service_interaction: service2_interaction2)
+      link4 = create(:link, local_authority: local_authority2, service_interaction: service1_interaction1)
 
-      expect(Link.for_service(service_1)).to match_array([link_1, link_2, link_4])
+      expect(Link.for_service(service1)).to match_array([link1, link2, link4])
     end
 
     context 'to avoid n+1 queries' do
@@ -95,21 +95,21 @@ RSpec.describe Link, type: :model do
   end
 
   describe '.retrieve' do
-    let!(:service_1) { create(:service, label: 'Service 1', lgsl_code: 1) }
+    let!(:service1) { create(:service, label: 'Service 1', lgsl_code: 1) }
 
-    let!(:interaction_1) { create(:interaction, label: 'Interaction 1', lgil_code: 1) }
+    let!(:interaction1) { create(:interaction, label: 'Interaction 1', lgil_code: 1) }
 
-    let!(:service_interaction_1_1) { create(:service_interaction, service: service_1, interaction: interaction_1) }
+    let!(:service1_interaction1) { create(:service_interaction, service: service1, interaction: interaction1) }
 
-    let!(:local_authority_1) { create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
+    let!(:local_authority1) { create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
 
-    let!(:expected_link) { create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1) }
+    let!(:expected_link) { create(:link, local_authority: local_authority1, service_interaction: service1_interaction1) }
 
     let(:params) {
       {
-        local_authority_slug: local_authority_1.slug,
-        service_slug: service_1.slug,
-        interaction_slug: interaction_1.slug
+        local_authority_slug: local_authority1.slug,
+        service_slug: service1.slug,
+        interaction_slug: interaction1.slug
       }
     }
 
@@ -152,13 +152,13 @@ RSpec.describe Link, type: :model do
 
     it "sets the link status, last checked time and link errors to an existing url's status, last checked time and link errors" do
       time = Timecop.freeze("2016-07-14 11:34:09 +0100")
-      @link_1 = create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
-      @link_2 = create(:link, url: "http://example.com", status: "ok", link_last_checked: time, problem_summary: @problem_summary, link_errors: @errors)
-      @link_1.url = "http://example.com"
-      @link_1.save!
-      expect(@link_1.status).to eq(@link_2.status)
-      expect(@link_1.link_last_checked).to eq(@link_2.link_last_checked)
-      expect(@link_1.link_errors).to eq(@link_2.link_errors)
+      @link1 = create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
+      @link2 = create(:link, url: "http://example.com", status: "ok", link_last_checked: time, problem_summary: @problem_summary, link_errors: @errors)
+      @link1.url = "http://example.com"
+      @link1.save!
+      expect(@link1.status).to eq(@link2.status)
+      expect(@link1.link_last_checked).to eq(@link2.link_last_checked)
+      expect(@link1.link_errors).to eq(@link2.link_errors)
     end
 
     it "sets the link status, link warnings and last checked time to an existing homepage url status, warnings and link last checked time" do
@@ -180,11 +180,11 @@ RSpec.describe Link, type: :model do
     end
 
     it "sets the link's status, link errors and last checked time to an existing url's status, link errors and last checked time" do
-      @link_1 = create(:link, url: "http://example.com/thing", status: "ok", problem_summary: @problem_summary, link_errors: @errors, link_last_checked: "2016-07-14 11:34:09 +0100")
-      @link_2 = create(:link, url: "http://example.com/thing")
-      expect(@link_2.status).to eq(@link_1.status)
-      expect(@link_2.link_errors).to eq(@link_1.link_errors)
-      expect(@link_2.link_last_checked).to eq(@link_1.link_last_checked)
+      @link1 = create(:link, url: "http://example.com/thing", status: "ok", problem_summary: @problem_summary, link_errors: @errors, link_last_checked: "2016-07-14 11:34:09 +0100")
+      @link2 = create(:link, url: "http://example.com/thing")
+      expect(@link2.status).to eq(@link1.status)
+      expect(@link2.link_errors).to eq(@link1.link_errors)
+      expect(@link2.link_last_checked).to eq(@link1.link_last_checked)
     end
   end
 

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Link, type: :model do
   describe 'validations' do
-    subject(:link) { FactoryGirl.create(:link) }
+    subject(:link) { create(:link) }
 
     it { is_expected.to validate_presence_of(:local_authority) }
     it { is_expected.to validate_presence_of(:service_interaction) }
@@ -37,9 +37,9 @@ RSpec.describe Link, type: :model do
 
   describe '.broken_or_missing' do
     it 'fetches broken and missing links' do
-      link_1 = FactoryGirl.create(:missing_link)
-      link_2 = FactoryGirl.create(:link, status: "broken")
-      FactoryGirl.create(:link)
+      link_1 = create(:missing_link)
+      link_2 = create(:link, status: "broken")
+      create(:link)
 
       expect(Link.broken_or_missing).to match_array([link_1, link_2])
     end
@@ -47,35 +47,35 @@ RSpec.describe Link, type: :model do
 
   describe '.for_service' do
     it 'fetches all the links for the supplied service' do
-      service_1 = FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1)
-      service_2 = FactoryGirl.create(:service, label: 'Service 2', lgsl_code: 2)
+      service_1 = create(:service, label: 'Service 1', lgsl_code: 1)
+      service_2 = create(:service, label: 'Service 2', lgsl_code: 2)
 
-      interaction_1 = FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1)
-      interaction_2 = FactoryGirl.create(:interaction, label: 'Interaction 2', lgil_code: 2)
+      interaction_1 = create(:interaction, label: 'Interaction 1', lgil_code: 1)
+      interaction_2 = create(:interaction, label: 'Interaction 2', lgil_code: 2)
 
-      service_interaction_1_1 = FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_1)
-      service_interaction_1_2 = FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_2)
-      service_interaction_2_2 = FactoryGirl.create(:service_interaction, service: service_2, interaction: interaction_1)
+      service_interaction_1_1 = create(:service_interaction, service: service_1, interaction: interaction_1)
+      service_interaction_1_2 = create(:service_interaction, service: service_1, interaction: interaction_2)
+      service_interaction_2_2 = create(:service_interaction, service: service_2, interaction: interaction_1)
 
-      local_authority_1 = FactoryGirl.create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1')
-      local_authority_2 = FactoryGirl.create(:local_authority, name: 'Aberdeenshire', gss: 'S100000002', snac: '00AB2')
+      local_authority_1 = create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1')
+      local_authority_2 = create(:local_authority, name: 'Aberdeenshire', gss: 'S100000002', snac: '00AB2')
 
-      link_1 = FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1)
-      link_2 = FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_2)
-      FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_2_2)
-      link_4 = FactoryGirl.create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1_1)
+      link_1 = create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1)
+      link_2 = create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_2)
+      create(:link, local_authority: local_authority_1, service_interaction: service_interaction_2_2)
+      link_4 = create(:link, local_authority: local_authority_2, service_interaction: service_interaction_1_1)
 
       expect(Link.for_service(service_1)).to match_array([link_1, link_2, link_4])
     end
 
     context 'to avoid n+1 queries' do
-      let(:service) { FactoryGirl.create(:service) }
+      let(:service) { create(:service) }
 
       before do
-        interaction = FactoryGirl.create(:interaction)
-        service_interaction = FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
-        local_authority = FactoryGirl.create(:local_authority)
-        FactoryGirl.create(:link, local_authority: local_authority, service_interaction: service_interaction)
+        interaction = create(:interaction)
+        service_interaction = create(:service_interaction, service: service, interaction: interaction)
+        local_authority = create(:local_authority)
+        create(:link, local_authority: local_authority, service_interaction: service_interaction)
       end
 
       subject(:links) { Link.for_service(service) }
@@ -95,15 +95,15 @@ RSpec.describe Link, type: :model do
   end
 
   describe '.retrieve' do
-    let!(:service_1) { FactoryGirl.create(:service, label: 'Service 1', lgsl_code: 1) }
+    let!(:service_1) { create(:service, label: 'Service 1', lgsl_code: 1) }
 
-    let!(:interaction_1) { FactoryGirl.create(:interaction, label: 'Interaction 1', lgil_code: 1) }
+    let!(:interaction_1) { create(:interaction, label: 'Interaction 1', lgil_code: 1) }
 
-    let!(:service_interaction_1_1) { FactoryGirl.create(:service_interaction, service: service_1, interaction: interaction_1) }
+    let!(:service_interaction_1_1) { create(:service_interaction, service: service_1, interaction: interaction_1) }
 
-    let!(:local_authority_1) { FactoryGirl.create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
+    let!(:local_authority_1) { create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
 
-    let!(:expected_link) { FactoryGirl.create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1) }
+    let!(:expected_link) { create(:link, local_authority: local_authority_1, service_interaction: service_interaction_1_1) }
 
     let(:params) {
       {
@@ -141,7 +141,7 @@ RSpec.describe Link, type: :model do
     end
 
     it "sets the link status, last checked time, errors and warnings to nil if the link is updated and does not already exist" do
-      @link = FactoryGirl.create(:link, status: "ok", link_last_checked: Time.now)
+      @link = create(:link, status: "ok", link_last_checked: Time.now)
       @link.url = "http://example.com"
       @link.save!
       expect(@link.status).to be_nil
@@ -152,8 +152,8 @@ RSpec.describe Link, type: :model do
 
     it "sets the link status, last checked time and link errors to an existing url's status, last checked time and link errors" do
       time = Timecop.freeze("2016-07-14 11:34:09 +0100")
-      @link_1 = FactoryGirl.create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
-      @link_2 = FactoryGirl.create(:link, url: "http://example.com", status: "ok", link_last_checked: time, problem_summary: @problem_summary, link_errors: @errors)
+      @link_1 = create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
+      @link_2 = create(:link, url: "http://example.com", status: "ok", link_last_checked: time, problem_summary: @problem_summary, link_errors: @errors)
       @link_1.url = "http://example.com"
       @link_1.save!
       expect(@link_1.status).to eq(@link_2.status)
@@ -162,8 +162,8 @@ RSpec.describe Link, type: :model do
     end
 
     it "sets the link status, link warnings and last checked time to an existing homepage url status, warnings and link last checked time" do
-      @local_authority = FactoryGirl.create(:local_authority, status: "broken", link_warnings: @warnings, link_last_checked: "2016-07-14 11:34:09 +0100")
-      @link = FactoryGirl.create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
+      @local_authority = create(:local_authority, status: "broken", link_warnings: @warnings, link_last_checked: "2016-07-14 11:34:09 +0100")
+      @link = create(:link, url: "http://example.com/thing", status: "ok", link_last_checked: Time.now)
       @link.url = "http://www.angus.gov.uk"
       @link.save!
 
@@ -180,8 +180,8 @@ RSpec.describe Link, type: :model do
     end
 
     it "sets the link's status, link errors and last checked time to an existing url's status, link errors and last checked time" do
-      @link_1 = FactoryGirl.create(:link, url: "http://example.com/thing", status: "ok", problem_summary: @problem_summary, link_errors: @errors, link_last_checked: "2016-07-14 11:34:09 +0100")
-      @link_2 = FactoryGirl.create(:link, url: "http://example.com/thing")
+      @link_1 = create(:link, url: "http://example.com/thing", status: "ok", problem_summary: @problem_summary, link_errors: @errors, link_last_checked: "2016-07-14 11:34:09 +0100")
+      @link_2 = create(:link, url: "http://example.com/thing")
       expect(@link_2.status).to eq(@link_1.status)
       expect(@link_2.link_errors).to eq(@link_1.link_errors)
       expect(@link_2.link_last_checked).to eq(@link_1.link_last_checked)
@@ -189,7 +189,7 @@ RSpec.describe Link, type: :model do
   end
 
   it "sets the link's status, link errors, link warnings and last checked time to nil if there is not already an existing URL" do
-    @link = FactoryGirl.create(:link, url: "http://example.com/thing")
+    @link = create(:link, url: "http://example.com/thing")
     expect(@link.status).to be nil
     expect(@link.link_last_checked).to be nil
     expect(@link.link_errors).to be_empty

--- a/spec/models/service_interaction_spec.rb
+++ b/spec/models/service_interaction_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe ServiceInteraction, type: :model do
 
   describe '.find_by_lgsl_and_lgil' do
     it 'returns the service interaction with a service matching the supplied lgsl_code and interaction matching the supplied lgil_code' do
-      service_100 = create(:service, lgsl_code: 100, label: 'Service 100')
-      interaction_1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
-      service_interaction_100_1 = create(:service_interaction, service: service_100, interaction: interaction_1)
+      service100 = create(:service, lgsl_code: 100, label: 'Service 100')
+      interaction1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      service100_interaction1 = create(:service_interaction, service: service100, interaction: interaction1)
 
-      expect(described_class.find_by_lgsl_and_lgil(100, 1)).to eq(service_interaction_100_1)
+      expect(described_class.find_by_lgsl_and_lgil(100, 1)).to eq(service100_interaction1)
     end
 
     it 'returns nil if no service interaction exists for the supplied lgsl and lgil codes' do
-      service_100 = create(:service, lgsl_code: 100, label: 'Service 100')
+      service100 = create(:service, lgsl_code: 100, label: 'Service 100')
       create(:service, lgsl_code: 200, label: 'Service 200')
-      interaction_1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      interaction1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
       create(:interaction, lgil_code: 2, label: 'Interaction 2')
-      create(:service_interaction, service: service_100, interaction: interaction_1)
+      create(:service_interaction, service: service100, interaction: interaction1)
 
       # service interactions exist for service, but not interaction
       expect(described_class.find_by_lgsl_and_lgil(100, 2)).to be_nil

--- a/spec/models/service_interaction_spec.rb
+++ b/spec/models/service_interaction_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ServiceInteraction, type: :model do
   describe 'validations' do
     before(:each) do
-      FactoryGirl.create(:service_interaction)
+      create(:service_interaction)
     end
     it { is_expected.to validate_presence_of(:service_id) }
     it { is_expected.to validate_presence_of(:interaction_id) }
@@ -16,19 +16,19 @@ RSpec.describe ServiceInteraction, type: :model do
 
   describe '.find_by_lgsl_and_lgil' do
     it 'returns the service interaction with a service matching the supplied lgsl_code and interaction matching the supplied lgil_code' do
-      service_100 = FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
-      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
-      service_interaction_100_1 = FactoryGirl.create(:service_interaction, service: service_100, interaction: interaction_1)
+      service_100 = create(:service, lgsl_code: 100, label: 'Service 100')
+      interaction_1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      service_interaction_100_1 = create(:service_interaction, service: service_100, interaction: interaction_1)
 
       expect(described_class.find_by_lgsl_and_lgil(100, 1)).to eq(service_interaction_100_1)
     end
 
     it 'returns nil if no service interaction exists for the supplied lgsl and lgil codes' do
-      service_100 = FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
-      FactoryGirl.create(:service, lgsl_code: 200, label: 'Service 200')
-      interaction_1 = FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
-      FactoryGirl.create(:interaction, lgil_code: 2, label: 'Interaction 2')
-      FactoryGirl.create(:service_interaction, service: service_100, interaction: interaction_1)
+      service_100 = create(:service, lgsl_code: 100, label: 'Service 100')
+      create(:service, lgsl_code: 200, label: 'Service 200')
+      interaction_1 = create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      create(:interaction, lgil_code: 2, label: 'Interaction 2')
+      create(:service_interaction, service: service_100, interaction: interaction_1)
 
       # service interactions exist for service, but not interaction
       expect(described_class.find_by_lgsl_and_lgil(100, 2)).to be_nil
@@ -37,22 +37,22 @@ RSpec.describe ServiceInteraction, type: :model do
     end
 
     it 'returns nil if the supplied lgsl is not a valid service' do
-      FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1')
+      create(:interaction, lgil_code: 1, label: 'Interaction 1')
 
       expect(described_class.find_by_lgsl_and_lgil(100, 1)).to be_nil
     end
 
     it 'returns nil if the supplied lgil is not a valid interaction' do
-      FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100')
+      create(:service, lgsl_code: 100, label: 'Service 100')
 
       expect(described_class.find_by_lgsl_and_lgil(100, 1)).to be_nil
     end
 
     context 'to avoid n+1 queries' do
-      let(:service) { FactoryGirl.create(:service, lgsl_code: 100, label: 'Service 100') }
-      let(:interaction) { FactoryGirl.create(:interaction, lgil_code: 1, label: 'Interaction 1') }
+      let(:service) { create(:service, lgsl_code: 100, label: 'Service 100') }
+      let(:interaction) { create(:interaction, lgil_code: 1, label: 'Interaction 1') }
       before do
-        FactoryGirl.create(:service_interaction, service: service, interaction: interaction)
+        create(:service_interaction, service: service, interaction: interaction)
       end
 
       subject(:found_record) { ServiceInteraction.find_by_lgsl_and_lgil(100, 1) }

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Service, type: :model do
   before(:each) do
-    FactoryGirl.create(:service)
+    create(:service)
   end
 
   it { is_expected.to validate_presence_of(:lgsl_code) }
@@ -15,7 +15,7 @@ RSpec.describe Service, type: :model do
   it { is_expected.to have_many(:service_interactions) }
 
   describe '#tiers' do
-    subject { FactoryGirl.create(:service, :all_tiers) }
+    subject { create(:service, :all_tiers) }
     let(:result) { subject.tiers }
 
     it 'returns an array of tier names' do
@@ -25,7 +25,7 @@ RSpec.describe Service, type: :model do
 
   describe "#update_broken_link_count" do
     it "updates the broken_link_count" do
-      link = FactoryGirl.create(:link, status: "broken")
+      link = create(:link, status: "broken")
       service = link.service
       expect { service.update_broken_link_count }
         .to change { service.broken_link_count }
@@ -33,8 +33,8 @@ RSpec.describe Service, type: :model do
     end
 
     it "ignores unchecked links" do
-      service = FactoryGirl.create(:service, broken_link_count: 1)
-      FactoryGirl.create(:link, service: service, status: nil)
+      service = create(:service, broken_link_count: 1)
+      create(:link, service: service, status: nil)
       expect { service.update_broken_link_count }
         .to change { service.broken_link_count }
         .from(1).to(0)
@@ -43,7 +43,7 @@ RSpec.describe Service, type: :model do
 
   describe "#delete_all_tiers" do
     it "deletes all tiers associated with a service" do
-      service = FactoryGirl.create(:service, :all_tiers)
+      service = create(:service, :all_tiers)
       service.delete_all_tiers
       expect(service.tiers).to be_empty
     end
@@ -51,7 +51,7 @@ RSpec.describe Service, type: :model do
 
   describe "#required_tiers" do
     it "returns the correct tiers" do
-      service = FactoryGirl.create(:service)
+      service = create(:service)
       expect(service.required_tiers('all')).to eq([2, 3, 1])
     end
   end

--- a/spec/presenters/interaction_presenter_spec.rb
+++ b/spec/presenters/interaction_presenter_spec.rb
@@ -1,5 +1,5 @@
 describe InteractionPresenter do
-  let(:interaction) { FactoryGirl.create(:interaction) }
+  let(:interaction) { create(:interaction) }
   let(:presented_link) { double(:LinkPresenter, url: 'http://example.com', status_description: 'Good', last_checked: '2016-07-19 16:37:41 +0000', label_status_class: 'label-success') }
   let(:presenter_with_link) { InteractionPresenter.new(interaction, presented_link) }
   let(:presenter_without_link) { InteractionPresenter.new(interaction) }

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe LinkApiResponsePresenter do
   describe '#present' do
-    let(:authority) { FactoryGirl.build(:district_council) }
+    let(:authority) { build(:district_council) }
     let(:presenter) { described_class.new(authority, link) }
 
     context 'link is present' do
-      let(:link) { FactoryGirl.build(:link) }
+      let(:link) { build(:link) }
       let(:expected_response) do
         {
           "local_authority" => {

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe LocalAuthorityApiResponsePresenter do
   describe '#present' do
     context 'when the local authority has a parent' do
-      let(:parent_local_authority) { FactoryGirl.build(:county_council) }
-      let(:authority) { FactoryGirl.build(:district_council, parent_local_authority: parent_local_authority) }
+      let(:parent_local_authority) { build(:county_council) }
+      let(:authority) { build(:district_council, parent_local_authority: parent_local_authority) }
       let(:presenter) { described_class.new(authority) }
       let(:expected_response) do
         {
@@ -28,7 +28,7 @@ describe LocalAuthorityApiResponsePresenter do
     end
 
     context 'when local authority does not have a parent' do
-      let(:authority) { FactoryGirl.build(:unitary_council) }
+      let(:authority) { build(:unitary_council) }
       let(:presenter) { described_class.new(authority) }
       let(:expected_response) do
         {

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe "find local authority", type: :request do
   context "for councils that have a parent authority" do
     let(:parent_local_authority) {
-      FactoryGirl.create(:county_council,
+      create(:county_council,
                          name: 'Rochester',
                          slug: 'rochester',
                          homepage_url: "http://rochester.example.com"
                         )
     }
     let!(:local_authority) {
-      FactoryGirl.create(:district_council,
+      create(:district_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com",
@@ -45,7 +45,7 @@ RSpec.describe "find local authority", type: :request do
 
   context "for councils that do not have a parent authority" do
     let!(:local_authority) {
-      FactoryGirl.create(:unitary_council,
+      create(:unitary_council,
                          name: 'Blackburn',
                          slug: 'blackburn',
                          homepage_url: "http://blackburn.example.com"

--- a/spec/requests/link_checker_api_spec.rb
+++ b/spec/requests/link_checker_api_spec.rb
@@ -38,9 +38,9 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater, type: :request do
           ]
         )
       end
-      let(:local_authority) { FactoryGirl.create(:local_authority) }
-      let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority, url: "http://www.example.com") }
-      let!(:link_2) { FactoryGirl.create(:link, local_authority: local_authority, url: "http://www.example.com/exampl.html") }
+      let(:local_authority) { create(:local_authority) }
+      let!(:link_1) { create(:link, local_authority: local_authority, url: "http://www.example.com") }
+      let!(:link_2) { create(:link, local_authority: local_authority, url: "http://www.example.com/exampl.html") }
 
       it "updates the link's status code and link last checked time in the database" do
         post "/link-check-callback", params: @payload.to_json, headers: { "Content-Type": "application/json", "X-LinkCheckerApi-Signature": generate_signature(@payload.to_json) }
@@ -60,8 +60,8 @@ describe LocalLinksManager::CheckLinks::LinkStatusUpdater, type: :request do
     end
 
     context "with an invalid signature" do
-      let(:local_authority) { FactoryGirl.create(:local_authority) }
-      let!(:link_1) { FactoryGirl.create(:link, local_authority: local_authority, url: "http://www.example.com") }
+      let(:local_authority) { create(:local_authority) }
+      let!(:link_1) { create(:link, local_authority: local_authority, url: "http://www.example.com") }
 
       before do
         @payload = link_checker_api_batch_report_hash(

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -8,7 +8,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    FactoryGirl.create(:user)
+    create(:user)
   end
 
   def login_as_stub_user

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
[FactoryGirl is now FactoryBot](https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md)

All these changes are in tests only apart from the removal of the Faraday gems.  These were used in the first incarnation of link checker before it became an app of its own.  They're not used any more. 