### PR TITLE
Ensure only strings are sent to icinga check

### DIFF
--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -8,20 +8,20 @@ task "check-links": :environment do
     lock_obtained: ->() {
       begin
         Rails.logger.info("Lock obtained, starting link checker")
-        Services.icinga_check(service_desc, true, "Lock obtained, starting link checker")
+        Services.icinga_check(service_desc, "true", "Lock obtained, starting link checker")
         LocalLinksManager::CheckLinks::LinkStatusRequester.new.call
         Rails.logger.info("Link checker completed")
         # Flag nagios that this server's instance succeeded to stop lingering failures
-        Services.icinga_check(service_desc, true, "Success")
+        Services.icinga_check(service_desc, "true", "Success")
       rescue StandardError => e
         Rails.logger.error("Error while running link checker\n#{e}")
-        Services.icinga_check(service_desc, false, e.to_s)
+        Services.icinga_check(service_desc, "false", e.to_s)
         raise e
       end
     },
     lock_not_obtained: ->() {
       Rails.logger.info("Unable to lock")
-      Services.icinga_check(service_desc, true, "Unable to lock")
+      Services.icinga_check(service_desc, "true", "Unable to lock")
     }
   )
 end

--- a/lib/tasks/export/analytics_bad_links_exporter.rake
+++ b/lib/tasks/export/analytics_bad_links_exporter.rake
@@ -10,20 +10,20 @@ namespace :export do
           lock_obtained: ->() {
             begin
               Rails.logger.info("Starting link exporter")
-              Services.icinga_check(service_desc, true, "Exporting list of bad links to Google Analytics")
+              Services.icinga_check(service_desc, "true", "Exporting list of bad links to Google Analytics")
 
               LocalLinksManager::Export::AnalyticsExporter.export
 
               Rails.logger.info("Bad links export to GA has completed")
-              Services.icinga_check(service_desc, true, "Success")
+              Services.icinga_check(service_desc, "true", "Success")
             rescue StandardError => e
               Rails.logger.error("Error while running link exporter\n#{e}")
-              Services.icinga_check(service_desc, false, e.to_s)
+              Services.icinga_check(service_desc, "false", e.to_s)
               raise e
             end
           },
           lock_not_obtained: ->() {
-            Services.icinga_check(service_desc, true, "Unable to lock")
+            Services.icinga_check(service_desc, "true", "Unable to lock")
           }
         )
       end

--- a/lib/tasks/export/link_exporter.rake
+++ b/lib/tasks/export/link_exporter.rake
@@ -8,14 +8,14 @@ namespace :export do
       service_desc = "Export links to CSV from local-links-manager"
       begin
         Rails.logger.info("Starting link exporter")
-        Services.icinga_check(service_desc, true, "Starting link exporter")
+        Services.icinga_check(service_desc, "true", "Starting link exporter")
 
         LocalLinksManager::Export::LinksExporter.export_links
         Rails.logger.info("Link export to CSV completed")
-        Services.icinga_check(service_desc, true, "Success")
+        Services.icinga_check(service_desc, "true", "Success")
       rescue StandardError => e
         Rails.logger.error("Error while running link exporter\n#{e}")
-        Services.icinga_check(service_desc, false, e.to_s)
+        Services.icinga_check(service_desc, "false", e.to_s)
         raise e
       end
     end

--- a/lib/tasks/import/google_analytics.rake
+++ b/lib/tasks/import/google_analytics.rake
@@ -8,14 +8,14 @@ namespace :import do
       lock_obtained: ->() {
         begin
           response = LocalLinksManager::Import::AnalyticsImporter.import
-          Services.icinga_check(service_desc, response.successful?, response.message)
+          Services.icinga_check(service_desc, response.successful?.to_s, response.message)
         rescue StandardError => e
-          Services.icinga_check(service_desc, false, e.to_s)
+          Services.icinga_check(service_desc, "false", e.to_s)
           raise e
         end
       },
       lock_not_obtained: ->() {
-        Services.icinga_check(service_desc, true, "Unable to lock")
+        Services.icinga_check(service_desc, "true", "Unable to lock")
       }
     )
   end

--- a/lib/tasks/import/local_authorities.rake
+++ b/lib/tasks/import/local_authorities.rake
@@ -12,7 +12,7 @@ namespace :import do
     task import_authorities: :environment do
       service_desc = "Import local authorities into local-links-manager"
       response = LocalLinksManager::Import::LocalAuthoritiesImporter.import_from_mapit
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
   end
 end

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -20,14 +20,14 @@ namespace :import do
             Rake::Task["import:service_interactions:add_service_tiers"].invoke
             Rake::Task["import:service_interactions:enable_services"].invoke
             # Flag nagios that this servers instance succeeded to stop lingering failures
-            Services.icinga_check(service_desc, true, "Success")
+            Services.icinga_check(service_desc, "true", "Success")
           rescue StandardError => e
-            Services.icinga_check(service_desc, false, e.to_s)
+            Services.icinga_check(service_desc, "false", e.to_s)
             raise e
           end
         },
         lock_not_obtained: ->() {
-          Services.icinga_check(service_desc, true, "Unable to lock")
+          Services.icinga_check(service_desc, "true", "Unable to lock")
         }
       )
     end
@@ -36,42 +36,42 @@ namespace :import do
     task import_services: :environment do
       service_desc = 'Import services into local-links-manager'
       response = LocalLinksManager::Import::ServicesImporter.import
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Import Interactions from standards.esd.org.uk"
     task import_interactions: :environment do
       service_desc = 'Import interactions into local-links-manager'
       response = LocalLinksManager::Import::InteractionsImporter.import
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Import ServicesInteractions from standards.esd.org.uk"
     task import_service_interactions: :environment do
       service_desc = 'Import service interactions into local-links-manager'
       response = LocalLinksManager::Import::ServiceInteractionsImporter.import
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Add tiers from local_services.csv in publisher to the list of Services imported by `import_services`"
     task add_service_tiers: :environment do
       service_desc = 'Add tiers to services into local-links-manager'
       response = LocalLinksManager::Import::ServicesTierImporter.import
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Enable services used on Gov.uk"
     task enable_services: :environment do
       service_desc = 'Enable services in local-links-manager'
       response = LocalLinksManager::Import::EnabledServiceChecker.enable
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Import LocalTransactions from Publishing API"
     task import_from_publishingapi: :environment do
       service_desc = 'Import local_transactions to service_interactions from publishing-api'
       response = LocalLinksManager::Import::PublishingApiImporter.import
-      Services.icinga_check(service_desc, response.successful?, response.message)
+      Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
   end
 end


### PR DESCRIPTION
The `code` argument passed to `self.icinga_check` is a boolean value so we
can't call `shellescape` on it. This was causing the `check-links` rake task to
break.

Initially I removed `shellscape` from `code` in the `self.icing_check` method,
however Brakeman is flagging `code` as a potential command injection security
warning because it is a boolean value. The only apparent use of `code` is to be
interpolated in a string which is used to notify Icinga, so it seems reasonable
to send it as a string instead.

This PR also changes other instances of `self.icinga_check` to send `code` as a string.