### PR TITLE
Only display links which belong to a service's providing authorities

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -19,6 +19,7 @@ private
   def links_for_service
     @links_for_service ||= filtered_links(@service.links)
       .includes(%i[service interaction local_authority])
+      .where(local_authority: @service.local_authorities)
       .all
   end
 end


### PR DESCRIPTION
There is a mismatch in some link counts.  For example, the broken
links page for `secondary-school-places` says "20 links" but only
displays 16.

The problem is a discrepancy in how local authorities who provide
services are handled:

* `Service.local_authorities` comes from the `service_tiers` model
* `Service.links` comes from the `service_interactions` model

We can have links whose local authority is not in the service's local
authorities list.  However, when rendering the list of links, a link
is only shown if it belongs to a local authority in the *service*'s
local authority list.

I'm not sure where the discrepancy is introduced - perhaps if a
council stops providing a service but the link is not deleted from the
database?

---

[Trello card](https://trello.com/c/PxJEEaLE/603-local-links-manager-broken-links-counts-are-incorrect)