### PR TITLE
Add bearer tokens for link-checker-api authentication

### DIFF
--- a/lib/local-links-manager/check_links/link_status_requester.rb
+++ b/lib/local-links-manager/check_links/link_status_requester.rb
@@ -48,7 +48,11 @@ module LocalLinksManager
       end
 
       def link_checker_api
-        @link_checker_api ||= GdsApi::LinkCheckerApi.new(link_checker_api_url, timeout: 10)
+        @link_checker_api ||= GdsApi::LinkCheckerApi.new(
+          link_checker_api_url,
+          bearer_token: ENV['LINK_CHECKER_API_BEARER_TOKEN'],
+          timeout: 10
+        )
       end
 
       def link_checker_api_url


### PR DESCRIPTION
Trello: https://trello.com/c/2IdzHdtp

Related to: 
* https://github.com/alphagov/govuk-puppet/pull/8488
* https://github.com/alphagov/link-checker-api/pull/227

Passes the bearer token needed to authenticate with link-checker-api using signon.