### PR TITLE
Make it clearer that we show visits to broken links

### DIFF
--- a/app/views/links/_link_table_row.html.erb
+++ b/app/views/links/_link_table_row.html.erb
@@ -2,7 +2,7 @@
     class: link.updated? ? 'success' : '',
     data: link.row_data do
 %>
-  <td class="analytics"><span><%= link.analytics.to_i %></span>this week</td>
+  <td class="analytics"><span><%= link.analytics.to_i %></span>visits this week</td>
   <td class="links">
     <div class="local-authority"><%= link.local_authority.name %></div>
     <div class="govuk"><%= link.govuk_title || link.service_label %>


### PR DESCRIPTION
Branch with one commit started by a product manager :eek:

Content Support weren't aware that we show in the number of visits to broken links in Local Links Manager. They use that information to try and prioritise which broken links to work on.

This small change makes it clear how many visits have resulted in broken links.