### PR TITLE
Export broken links for local authority

### DIFF
--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -1,4 +1,5 @@
 require 'local-links-manager/export/bad_links_url_and_status_exporter'
+require 'local-links-manager/export/links_exporter'
 
 class LocalAuthoritiesController < ApplicationController
   include LinkFilterHelper
@@ -14,6 +15,13 @@ class LocalAuthoritiesController < ApplicationController
     @services = @authority.provided_services.order('services.label ASC')
     @links = links_for_authority.group_by { |link| link.service.id }
     @link_count = links_for_authority.count
+  end
+
+  def broken_links_csv
+    @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
+    authority_name = @authority.name.parameterize.underscore
+    data = LocalLinksManager::Export::LinksExporter.new.export_broken_links(@authority)
+    send_data data, filename: "#{authority_name}_broken_links.csv"
   end
 
   def bad_homepage_url_and_status_csv

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -4,5 +4,6 @@
     Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %><br>
     <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
     <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
+    <p><%= link_to('Download broken links', broken_links_csv_local_authority_path, class: "btn btn-default btn-s") %></p>
   </p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
 
-  resources 'local_authorities', only: [:index, :show], param: :local_authority_slug
+  resources 'local_authorities', only: [:index, :show], param: :local_authority_slug do
+    member do
+      get 'broken_links_csv'
+    end
+  end
 
   resources 'services', only: [:index, :show], param: :service_slug
 

--- a/lib/local-links-manager/export/links_exporter.rb
+++ b/lib/local-links-manager/export/links_exporter.rb
@@ -3,7 +3,9 @@ require 'csv'
 module LocalLinksManager
   module Export
     class LinksExporter
-      HEADINGS = ["Authority Name", "SNAC", "GSS", "Description", "LGSL", "LGIL", "URL", "Supported by GOV.UK"].freeze
+      HEADINGS = ["Authority Name", "SNAC", "GSS", "Description", "LGSL", "LGIL", "URL"].freeze
+      ALL_LINKS_HEADINGS = ["Supported by GOV.UK"].freeze
+      BROKEN_LINKS_HEADINGS = ["New URL"].freeze
 
       def self.export_links
         path = Rails.root.join("public", "data", 'links_to_services_provided_by_local_authorities.csv')
@@ -15,12 +17,21 @@ module LocalLinksManager
 
       def export(io)
         output = CSV.generate do |csv|
-          csv << HEADINGS
+          csv << HEADINGS + ALL_LINKS_HEADINGS
           records.each do |record|
-            csv << format(record)
+            csv << format(record).push(record.enabled)
           end
         end
         io.write(output)
+      end
+
+      def export_broken_links(local_authority_id)
+        CSV.generate do |csv|
+          csv << HEADINGS + BROKEN_LINKS_HEADINGS
+          broken_links(local_authority_id).each do |link|
+            csv << format(link)
+          end
+        end
       end
 
       def records
@@ -40,6 +51,22 @@ module LocalLinksManager
 
     private
 
+      def broken_links(local_authority_id)
+        Link.enabled_links.currently_broken
+          .where(local_authority_id: local_authority_id)
+          .joins(:local_authority, :service, :interaction)
+          .select(
+            "local_authorities.name",
+            :snac,
+            :gss,
+            "services.label as service_label",
+            "interactions.label as interaction_label",
+            :lgsl_code,
+            :lgil_code,
+            :url,
+          ).order("services.lgsl_code", "interactions.lgil_code").all
+      end
+
       def format(record)
         [
           record.name,
@@ -49,7 +76,6 @@ module LocalLinksManager
           record.lgsl_code,
           record.lgil_code,
           record.url,
-          record.enabled
         ]
       end
 

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
       expect(response.headers['Content-Type']).to eq('text/csv')
     end
   end
+
+  describe "GET broken_links_csv" do
+    before do
+      @local_authority = create(:local_authority)
+    end
+
+    it "retrieves HTTP success" do
+      login_as_stub_user
+      get :broken_links_csv, params: { local_authority_slug: @local_authority.slug }
+      expect(response).to have_http_status(200)
+      expect(response.headers["Content-Type"]).to eq("text/csv")
+    end
+  end
 end

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -107,6 +107,13 @@ feature "The local authority show page" do
       expect(page).to have_link 'Edit link', href: edit_link_path(@local_authority, @service, @good_link.interaction)
     end
 
+    it "allows user to download a CSV of broken links for the local authority" do
+      click_on "Download broken links"
+      expect(page.response_headers["Content-Type"]).to eq("text/csv")
+      csv = page.body.chomp.split(",")
+      expect(csv).to include(@broken_link.url)
+    end
+
     context 'editing a link' do
       it 'returns you to the correct page after updating a link' do
         within('.table') { click_on('Edit link', match: :first) }

--- a/spec/lib/local-links-manager/export/links_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/links_exporter_spec.rb
@@ -60,4 +60,31 @@ describe LocalLinksManager::Export::LinksExporter do
       end
     end
   end
+
+  describe "#export_broken_links" do
+    let(:la) { create(:local_authority) }
+    let(:service) { create(:service) }
+    let(:disabled_service) { create(:disabled_service) }
+    let(:interaction_1) { create(:interaction) }
+    let(:interaction_2) { create(:interaction) }
+    let(:service_interaction_1) { create(:service_interaction, service: service, interaction: interaction_1) }
+    let(:service_interaction_2) { create(:service_interaction, service: service, interaction: interaction_2) }
+    let(:service_interaction_3) { create(:service_interaction, service: disabled_service, interaction: interaction_1) }
+    let(:broken_link) { create(:broken_link, local_authority: la, url: "http://www.diagonalley.gov.uk/broken-link", service_interaction: service_interaction_1) }
+    let(:ok_link) { create(:link, local_authority: la, url: "http://www.diagonalley.gov.uk/ok-link", status: "ok", service_interaction: service_interaction_2) }
+    let(:disabled_link) { create(:broken_link, local_authority: la, url: "http://www.diagonalley.gov.uk/ok-link", service_interaction: service_interaction_3) }
+
+    it "exports broken links for enabled services for a given local authority to CSV format with headings" do
+      broken_link_data = "#{la.name},#{la.snac},#{la.gss},#{service.label}: #{interaction_1.label},#{service.lgsl_code},#{interaction_1.lgil_code},#{broken_link.url}"
+      ok_link_data = "#{la.name},#{la.snac},#{la.gss},#{service.label}: #{interaction_2.label},#{service.lgsl_code},#{interaction_2.lgil_code},#{ok_link.url}"
+      disabled_link_data = "#{la.name},#{la.snac},#{la.gss},#{disabled_service.label}: #{interaction_1.label},#{disabled_service.lgsl_code},#{interaction_1.lgil_code},#{disabled_link.url}"
+      headings = (LocalLinksManager::Export::LinksExporter::HEADINGS + LocalLinksManager::Export::LinksExporter::BROKEN_LINKS_HEADINGS).join(",")
+      csv = exporter.export_broken_links(la.id).split("\n")
+
+      expect(csv).to include(broken_link_data)
+      expect(csv).not_to include(ok_link_data)
+      expect(csv).not_to include(disabled_link_data)
+      expect(csv).to include(headings)
+    end
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/eGGNb2a4/6-add-button-to-download-all-broken-links-for-a-council

<img width="793" alt="screen shot 2019-01-10 at 15 43 36" src="https://user-images.githubusercontent.com/13434452/50980191-062f9900-14f0-11e9-94a7-3e4beaf8f2bc.png">

This adds a button on local authority show pages which allows users to download a CSV of all the broken links for the given local authority.