### PR TITLE
Allow upload new urls for a local authority links

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -62,7 +62,7 @@ private
     @local_authority = LocalAuthorityPresenter.new(LocalAuthority.find_by!(slug: params[:local_authority_slug]))
     @interaction = Interaction.find_by!(slug: params[:interaction_slug])
     @service = Service.find_by!(slug: params[:service_slug])
-    @link = Link.retrieve(params)
+    @link = Link.retrieve_or_build(params)
   end
 
   def set_back_url_before_post_request

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -1,5 +1,6 @@
 require 'local-links-manager/export/bad_links_url_and_status_exporter'
 require 'local-links-manager/export/links_exporter'
+require 'local-links-manager/import/links'
 
 class LocalAuthoritiesController < ApplicationController
   include LinkFilterHelper
@@ -22,6 +23,19 @@ class LocalAuthoritiesController < ApplicationController
     authority_name = @authority.name.parameterize.underscore
     data = LocalLinksManager::Export::LinksExporter.new.export_links(@authority.id, params)
     send_data data, filename: "#{authority_name}_links.csv"
+  end
+
+  def upload_links_csv
+    authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
+
+    if params[:csv]
+      update_count = LocalLinksManager::Import::Links.new(authority).import_links(params[:csv].read)
+      flash[:success] = "#{update_count} #{'link has'.pluralize(update_count)} been updated"
+    else
+      flash[:danger] = 'A CSV file must be provided.'
+    end
+
+    redirect_to local_authority_path(authority)
   end
 
   def bad_homepage_url_and_status_csv

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -17,7 +17,7 @@ class LocalAuthoritiesController < ApplicationController
     @link_count = links_for_authority.count
   end
 
-  def links_csv
+  def download_links_csv
     @authority = LocalAuthority.find_by_slug!(params[:local_authority_slug])
     authority_name = @authority.name.parameterize.underscore
     data = LocalLinksManager::Export::LinksExporter.new.export_links(@authority.id, params)

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -38,7 +38,7 @@ class Link < ApplicationRecord
     self.joins(:service).where(services: { enabled: true })
   end
 
-  def self.retrieve(params)
+  def self.retrieve_or_build(params)
     self.joins(:local_authority, :service, :interaction).find_by(
       local_authorities: { slug: params[:local_authority_slug] },
       services: { slug: params[:service_slug] },

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -3,6 +3,9 @@
 <% if flash[:success] %>
 <div class="alert alert-success"><%= flash[:success] %></div>
 <% end %>
+<% if flash[:danger] %>
+<div class="alert alert-danger"><%= flash[:danger] %></div>
+<% end %>
 
 <% breadcrumb :local_authority, @authority %>
 

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -2,33 +2,51 @@
 
 <div class="page-title">
   <h1><%= authority.name %></h1>
-  <p>
+
+  <div>
     Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %><br>
     <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
     <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
-    <p>
-      <%= check_box_tag(:ok, :ok, true, class: 'links_status_checkbox') %>
-      <%= label_tag(:ok, 'OK') %>
-      <%= check_box_tag(:broken, :broken, true, class: 'links_status_checkbox') %>
-      <%= label_tag(:broken, 'Broken') %>
-      <%= check_box_tag(:caution, :caution, true, class: 'links_status_checkbox') %>
-      <%= label_tag(:caution, 'Caution') %>
-      <%= check_box_tag(:missing, :missing, true, class: 'links_status_checkbox') %>
-      <%= label_tag(:missing, 'Missing') %>
-      <%= check_box_tag(:pending, :pending, true, class: 'links_status_checkbox') %>
-      <%= label_tag(:pending, 'Pending') %>
-      <%= link_to(
-        'Download links',
-        download_links_csv_local_authority_path(
-          ok: :ok,
-          broken: :broken,
-          caution: :caution,
-          missing: :missing,
-          pending: :pending
-        ),
-        class: "btn btn-default btn-s",
-        id: "links_download_button"
-      ) %>
-    </p>
-  </p>
+
+    <div>
+      <h3>Download links</h3>
+      <p>Produces a CSV which can be altered and uploaded to update your links as a batch.</p>
+      <p>
+        Include links of these types:
+        <%= check_box_tag(:ok, :ok, true, class: 'links_status_checkbox') %>
+        <%= label_tag(:ok, 'OK') %>
+        <%= check_box_tag(:broken, :broken, true, class: 'links_status_checkbox') %>
+        <%= label_tag(:broken, 'Broken') %>
+        <%= check_box_tag(:caution, :caution, true, class: 'links_status_checkbox') %>
+        <%= label_tag(:caution, 'Caution') %>
+        <%= check_box_tag(:missing, :missing, true, class: 'links_status_checkbox') %>
+        <%= label_tag(:missing, 'Missing') %>
+        <%= check_box_tag(:pending, :pending, true, class: 'links_status_checkbox') %>
+        <%= label_tag(:pending, 'Pending') %>
+      </p>
+      <p>
+        <%= link_to(
+          'Download links',
+          download_links_csv_local_authority_path(
+            ok: :ok,
+            broken: :broken,
+            caution: :caution,
+            missing: :missing,
+            pending: :pending
+          ),
+          class: "btn btn-default",
+          id: "links_download_button"
+        ) %>
+      </p>
+    </div>
+
+    <div>
+      <h3>Upload links</h3>
+      <p>Accepts a CSV in the same format as the download option. Will create or overwrite any links provided.</p>
+      <%= form_tag(upload_links_csv_local_authority_path(authority), multipart: true) do %>
+        <p><%= file_field_tag :csv %></p>
+        <p><%= button_tag('Upload links', class: 'btn btn-default') %></p>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -19,7 +19,7 @@
       <%= label_tag(:pending, 'Pending') %>
       <%= link_to(
         'Download links',
-        links_csv_local_authority_path(
+        download_links_csv_local_authority_path(
           ok: :ok,
           broken: :broken,
           caution: :caution,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   resources 'local_authorities', only: [:index, :show], param: :local_authority_slug do
     member do
-      get 'links_csv'
+      get 'download_links_csv'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources 'local_authorities', only: [:index, :show], param: :local_authority_slug do
     member do
       get 'download_links_csv'
+      post 'upload_links_csv'
     end
   end
 

--- a/lib/local-links-manager/import/links.rb
+++ b/lib/local-links-manager/import/links.rb
@@ -1,0 +1,39 @@
+require "csv"
+
+module LocalLinksManager
+  module Import
+    class Links
+      def initialize(local_authority)
+        @local_authority = local_authority
+      end
+
+      def import_links(csv_string)
+        updated = 0
+        CSV.parse(csv_string, headers: true) do |row|
+          next if row["New URL"].blank?
+
+          service = Service.find_by(lgsl_code: row["LGSL"])
+          interaction = Interaction.find_by(lgil_code: row["LGIL"])
+
+          next unless service && interaction
+
+          link = Link.retrieve_or_build(
+            local_authority_slug: local_authority.slug,
+            service_slug: service.slug,
+            interaction_slug: interaction.slug,
+          )
+
+          link.update!(url: row["New URL"])
+
+          updated += 1
+        end
+
+        updated
+      end
+
+    private
+
+      attr_reader :local_authority
+    end
+  end
+end

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -63,4 +63,20 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
       expect(response.headers["Content-Type"]).to eq("text/csv")
     end
   end
+
+  describe "POST upload_links_csv" do
+    before { @local_authority = create(:local_authority) }
+    let(:path) { File.join(Rails.root, 'spec/lib/local-links-manager/import/fixtures/imported_links.csv') }
+    let(:csv) { Rack::Test::UploadedFile.new(path, 'text/csv', true) }
+    let(:url_regex) { /http:\/\/.+\/local_authorities\/#{@local_authority.slug}/ }
+
+    it "retrieves HTTP found" do
+      login_as_stub_user
+      post(:upload_links_csv, params: { local_authority_slug: @local_authority.slug, csv: csv })
+
+      expect(response.status).to eq(302)
+      expect(response.location).to match(url_regex)
+      expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
+    end
+  end
 end

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     end
   end
 
-  describe "GET links_csv" do
+  describe "GET download_links_csv" do
     before do
       @local_authority = create(:local_authority)
     end
@@ -49,7 +49,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     it "retrieves HTTP success" do
       login_as_stub_user
       get(
-        :links_csv,
+        :download_links_csv,
         params: {
           local_authority_slug: @local_authority.slug,
           ok: 'ok',

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -122,11 +122,9 @@ feature "The local authority show page" do
       context "when user leaves all link status checkboxes selected (by default)", js: true do
         it "passes all statuses in params" do
           submit_button = find("a", text: "Download links")
-          expect(submit_button['href']).to match(url_regex)
-
-          submit_button.hover
           params = submit_button['href'].split('?')[-1].split('&')
 
+          expect(submit_button['href']).to match(url_regex)
           status_checkboxes.each do |status|
             expect(params).to include("#{status}=#{status}")
           end
@@ -142,7 +140,6 @@ feature "The local authority show page" do
           expect(submit_button['href']).to match(url_regex)
 
           unchecked_status_checkboxes.each { |status_checkbox| uncheck status_checkbox }
-          submit_button.hover
           params = submit_button['href'].split('?')[-1].split('&')
 
           checked_status_checkboxes.each do |status|

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -111,7 +111,7 @@ feature "The local authority show page" do
 
     describe "CSV download" do
       let(:status_checkboxes) { %w(ok broken caution missing pending) }
-      let(:url_regex) { /http:\/\/.+\/local_authorities\/.+\/links_csv/ }
+      let(:url_regex) { /http:\/\/.+\/local_authorities\/.+\/download_links_csv/ }
 
       it "downloads a CSV" do
         click_on "Download links"

--- a/spec/lib/local-links-manager/import/fixtures/imported_links.csv
+++ b/spec/lib/local-links-manager/import/fixtures/imported_links.csv
@@ -1,0 +1,2 @@
+Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Status,New URL
+blah,blah,blah,blah,blah,blah,blah,blah,blah,blah

--- a/spec/lib/local-links-manager/import/links_spec.rb
+++ b/spec/lib/local-links-manager/import/links_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+require "local-links-manager/import/links"
+
+RSpec.describe LocalLinksManager::Import::Links do
+  let(:local_authority) { create(:local_authority) }
+  subject(:links_importer) { described_class.new(local_authority) }
+  let(:ok_link) { create(:ok_link, local_authority: local_authority) }
+  let(:broken_link) { create(:broken_link, local_authority: local_authority) }
+  let(:caution_link) { create(:caution_link, local_authority: local_authority) }
+  let(:missing_link) { create(:missing_link, local_authority: local_authority) }
+  let(:pending_link) { create(:pending_link, local_authority: local_authority) }
+  let(:links) { [ok_link, broken_link, caution_link, missing_link, pending_link] }
+  let!(:csv) do
+    create_csv(
+      lgsl_codes: links.map(&:service).map(&:lgsl_code),
+      lgil_codes: links.map(&:interaction).map(&:lgil_code),
+      new_urls: links.map { |_| new_url },
+    )
+  end
+
+  describe "#import_links(csv)" do
+    context "when a new URL is provided" do
+      let(:new_url) { "http://example.com/new-url" }
+
+      it "updates the existing links with the new URLs" do
+        old_urls = links.map(&:url)
+
+        expect { links_importer.import_links(csv) }
+          .to change { links.map(&:reload).map(&:url) }
+          .from(old_urls)
+          .to([new_url] * links.count)
+      end
+
+      it "returns the number of updated links" do
+        links_count = csv.split("\n").count - 1 # the number of rows minus the headings
+
+        expect(links_importer.import_links(csv)).to eq(links_count)
+      end
+    end
+
+    context "when no new URL is provided" do
+      let(:new_url) { nil }
+
+      it "does not update the existing links" do
+        expect { links_importer.import_links(csv) }.to_not(change { links.map(&:reload).map(&:url) })
+      end
+
+      it "returns the number of updated links" do
+        expect(links_importer.import_links(csv)).to eq(0)
+      end
+    end
+  end
+
+  def create_csv(lgsl_codes:, lgil_codes:, new_urls:)
+    <<~CSV
+      Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Status,New URL
+      blah,blah,blah,blah,#{lgsl_codes[0]},#{lgil_codes[0]},blah,blah,blah,#{new_urls[0]}
+      blah,blah,blah,blah,#{lgsl_codes[1]},#{lgil_codes[1]},blah,blah,blah,#{new_urls[1]}
+      blah,blah,blah,blah,#{lgsl_codes[2]},#{lgil_codes[2]},blah,blah,blah,#{new_urls[2]}
+      blah,blah,blah,blah,#{lgsl_codes[3]},#{lgil_codes[3]},blah,blah,blah,#{new_urls[3]}
+      blah,blah,blah,blah,#{lgsl_codes[4]},#{lgil_codes[4]},blah,blah,blah,#{new_urls[4]}
+    CSV
+  end
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Link, type: :model do
 
     context 'when the link is not present in the database' do
       it 'does not create a new link' do
-        expect { Link.retrieve_or_build(params) }.to_not change { Link.count }
+        expect { Link.retrieve_or_build(params) }.to_not(change { Link.count })
       end
 
       it 'instantiates a new link with the correct local_authority_id' do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -128,29 +128,37 @@ RSpec.describe Link, type: :model do
     end
   end
 
-  describe '.retrieve' do
-    let!(:service1) { create(:service, label: 'Service 1', lgsl_code: 1) }
-
-    let!(:interaction1) { create(:interaction, label: 'Interaction 1', lgil_code: 1) }
-
-    let!(:service1_interaction1) { create(:service_interaction, service: service1, interaction: interaction1) }
-
-    let!(:local_authority1) { create(:local_authority, name: 'Aberdeen', gss: 'S100000001', snac: '00AB1') }
-
-    let!(:expected_link) { create(:link, local_authority: local_authority1, service_interaction: service1_interaction1) }
-
-    let(:params) {
+  describe '.retrieve_or_build' do
+    let(:local_authority) { create(:local_authority) }
+    let(:service_interaction) { create(:service_interaction) }
+    let!(:params) {
       {
-        local_authority_slug: local_authority1.slug,
-        service_slug: service1.slug,
-        interaction_slug: interaction1.slug
+        local_authority_slug: local_authority.slug,
+        service_slug: service_interaction.service.slug,
+        interaction_slug: service_interaction.interaction.slug
       }
     }
 
-    subject(:link) { Link.retrieve(params) }
+    context 'when the link is present in the database' do
+      let!(:expected_link) { create(:link, local_authority: local_authority, service_interaction: service_interaction) }
 
-    it 'fetches the correct link for the service' do
-      expect(link.url).to eq(expected_link.url)
+      it 'fetches the correct link for the service' do
+        expect(Link.retrieve_or_build(params)).to eq(expected_link)
+      end
+    end
+
+    context 'when the link is not present in the database' do
+      it 'does not create a new link' do
+        expect { Link.retrieve_or_build(params) }.to_not change { Link.count }
+      end
+
+      it 'instantiates a new link with the correct local_authority_id' do
+        expect(Link.retrieve_or_build(params).local_authority_id).to eq(local_authority.id)
+      end
+
+      it 'instantiates a new link with the correct service_interaction_id' do
+        expect(Link.retrieve_or_build(params).service_interaction_id).to eq(service_interaction.id)
+      end
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,10 @@
-require 'simplecov'
-require 'simplecov-rcov'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start 'rails'
+unless ENV["DISABLE_RCOV"]
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)


### PR DESCRIPTION
As users are now able to download a csv with all links for a specific local authority (see #413), we want to give them the ability to also upload that same csv with new links urls to be able to change in batch as many links urls as they want for that specific local authority.

See specific commit messages for more context on other changes.

Trello: https://trello.com/c/wpk9v5S9/877-allow-content-support-to-change-links-by-uploading-a-csv

Co-Authored-By: Elliot Crosby-McCullough <elliot.cm@gmail.com>
