### PR TITLE
Redirect old local authorities

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -42,4 +42,8 @@ class LocalAuthority < ApplicationRecord
   def to_param
     self.slug
   end
+
+  def redirect(to:)
+    LocalAuthorityRedirector.call(from: self, to: to)
+  end
 end

--- a/lib/local_authority_redirector.rb
+++ b/lib/local_authority_redirector.rb
@@ -1,0 +1,72 @@
+class LocalAuthorityRedirector
+  def initialize(from:, to:)
+    @old_local_authority = from
+    @new_local_authority = to
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    validate_local_authorities
+    publish_redirects
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :old_local_authority, :new_local_authority
+
+  def validate_local_authorities
+    if old_local_authority.tier != new_local_authority.tier
+      raise "Local authority tiers don't match."
+    end
+
+    if old_local_authority.services != new_local_authority.services
+      raise "Local authority services don't match."
+    end
+  end
+
+  def publish_redirects
+    local_authority_redirects(old_local_authority)
+      .each { |redirect| publish_redirect(redirect) }
+  end
+
+  def local_authority_redirects(local_authority)
+    local_authority.services.flat_map { |service| service_redirects(service) }
+  end
+
+  def service_redirects(service)
+    service.service_interactions.map(&:govuk_slug).compact.map do |interaction_slug|
+      ["/#{interaction_slug}/#{old_local_authority.slug}", "/#{interaction_slug}/#{new_local_authority.slug}"]
+    end
+  end
+
+  def publishing_api_redirect_payload(redirect)
+    {
+      "base_path" => redirect.first,
+      "document_type" => "redirect",
+      "schema_name" => "redirect",
+      "publishing_app" => "local-links-manager",
+      "update_type" => "major",
+      "redirects" => [
+        {
+          "path" => redirect.first,
+          "type" => "exact",
+          "segments_mode" => "ignore",
+          "destination" => redirect.second,
+        },
+      ],
+    }
+  end
+
+  def publish_redirect(redirect)
+    puts "#{redirect.first} -> #{redirect.second}"
+    content_id = SecureRandom.uuid
+    payload = publishing_api_redirect_payload(redirect)
+    GdsApi.publishing_api_v2.put_content(content_id, payload)
+    GdsApi.publishing_api_v2.publish(content_id)
+  end
+end

--- a/lib/tasks/local_authority.rake
+++ b/lib/tasks/local_authority.rake
@@ -1,0 +1,8 @@
+namespace :local_authority do
+  desc "Redirect one local authority to another."
+  task :redirect, %i(from to) => [:environment] do |_, args|
+    old_local_authority = LocalAuthority.find_by!(slug: args.from)
+    new_local_authority = LocalAuthority.find_by!(slug: args.to)
+    old_local_authority.redirect(to: new_local_authority)
+  end
+end

--- a/spec/lib/local_authority_redirector_spec.rb
+++ b/spec/lib/local_authority_redirector_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe LocalAuthorityRedirector do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  let(:old_local_authority) { create(:county_council, slug: "old") }
+  let(:new_local_authority) { create(:county_council, slug: "new") }
+
+  subject(:call) do
+    described_class.call(from: old_local_authority, to: new_local_authority)
+  end
+
+  context "given authority tiers don't match" do
+    let(:new_local_authority) { create(:district_council) }
+
+    it "should raise an exception" do
+      expect { call }.to raise_error(/tier/)
+    end
+  end
+
+  context "given a service exists" do
+    let(:service) { create(:service, :all_tiers) }
+
+    let(:content_id) { "dfdb939f-1c0e-4223-81ef-3a8556540ca9" }
+
+    before do
+      create(:service_interaction, service: service, govuk_slug: "interaction")
+      allow(SecureRandom).to receive(:uuid).and_return(content_id)
+    end
+
+    let!(:put_content_request) do
+      body = {
+        "base_path": "/interaction/old",
+        "document_type": "redirect",
+        "schema_name": "redirect",
+        "publishing_app": "local-links-manager",
+        "update_type": "major",
+        "redirects": [
+          {
+            "path": "/interaction/old",
+            "type": "exact",
+            "segments_mode": "ignore",
+            "destination": "/interaction/new",
+          }
+        ]
+      }
+      stub_publishing_api_put_content(content_id, body)
+    end
+
+    let!(:publish_request) { stub_publishing_api_publish(content_id, {}) }
+
+    it "creates a redirect" do
+      call
+
+      expect(put_content_request).to have_been_requested
+      expect(publish_request).to have_been_requested
+    end
+  end
+end

--- a/spec/support/gds_api_adapters.rb
+++ b/spec/support/gds_api_adapters.rb
@@ -1,0 +1,1 @@
+require "gds_api/test_helpers/publishing_api_v2"


### PR DESCRIPTION
If a local authority get absorbed into another, it would be useful to redirect all service links from the old local authority to the new one. This PR adds a Rake task that makes it easy to do that by looking at all the possible service interactions there might be for a local authority and creating redirects in the Publishing API for the new local authority.

It depends on https://github.com/alphagov/govuk-content-schemas/pull/902 being merged.

This does introduce a potential source of confusion because it means that if a user were to edit any details about a local authority service which has been redirected they wouldn't see the changes live, and there's nothing in the UI that would tell them it's been redirected. I think this could be future work and isn't needed immediately because once the redirects are in place, we can remove the old local authorities from local links manager anyway and they'll no longer be returned by mapit.

[Trello Card](https://trello.com/c/rxlRSgAR/988-bulk-url-redirects-from-old-authorities-to-new-incarnations)