### PR TITLE
Check services are subsets before redirecting

### DIFF
--- a/lib/local_authority_redirector.rb
+++ b/lib/local_authority_redirector.rb
@@ -20,12 +20,8 @@ private
   attr_reader :old_local_authority, :new_local_authority
 
   def validate_local_authorities
-    if old_local_authority.tier != new_local_authority.tier
-      raise "Local authority tiers don't match."
-    end
-
-    if old_local_authority.services != new_local_authority.services
-      raise "Local authority services don't match."
+    unless old_local_authority.services.to_set.subset?(new_local_authority.services.to_set)
+      raise "#{old_local_authority.name} has some services that #{new_local_authority.name} does not"
     end
   end
 

--- a/spec/lib/local_authority_redirector_spec.rb
+++ b/spec/lib/local_authority_redirector_spec.rb
@@ -10,11 +10,16 @@ RSpec.describe LocalAuthorityRedirector do
     described_class.call(from: old_local_authority, to: new_local_authority)
   end
 
-  context "given authority tiers don't match" do
+  context "given the old local authority has more services than the new one" do
     let(:new_local_authority) { create(:district_council) }
 
+    before do
+      create(:service, :all_tiers)
+      create(:service, :county_unitary)
+    end
+
     it "should raise an exception" do
-      expect { call }.to raise_error(/tier/)
+      expect { call }.to raise_error(/has some services that/)
     end
   end
 


### PR DESCRIPTION
Some local authorities don't match in tier, but as long as the services they provide is a subset of the services the new local authority provides we can perform the redirect.

[Trello Card](https://trello.com/c/rxlRSgAR/988-bulk-url-redirects-from-old-authorities-to-new-incarnations)