### PR TITLE
Change config for development database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,13 +6,16 @@ default: &default
 development:
   <<: *default
   database: local-links-manager_development
+  url: <%= ENV['DATABASE_URL'] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
+
 test: &test
   <<: *default
   database: local-links-manager_test<%= ENV['TEST_ENV_NUMBER'] %>
+  url: <%= ENV['TEST_DATABASE_URL'] %>
 
 cucumber:
   <<: *test


### PR DESCRIPTION
This adds a check to see if a docker database is running, and if so
switches across to using its URL instead