### PR TITLE
Relax authorized host domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,6 +50,9 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/176

This changes the development configuration to allow requests from
any domain. While this will include *.dev.gov.uk, this reduces the
coupling to that specific domain without any extra effort, thus
supporting more use cases like Docker training.