### PR TITLE
Add task to set council homepage URL

### DIFF
--- a/lib/tasks/local_authority.rake
+++ b/lib/tasks/local_authority.rake
@@ -5,4 +5,11 @@ namespace :local_authority do
     new_local_authority = LocalAuthority.find_by!(slug: args.to)
     old_local_authority.redirect(to: new_local_authority)
   end
+
+  desc "Set local authority homepage URL"
+  task :update_homepage, %i(slug new_url) => :environment do |_, args|
+    local_authority = LocalAuthority.find_by!(slug: args.slug)
+    local_authority.homepage_url = args.new_url
+    local_authority.save!
+  end
 end


### PR DESCRIPTION
This is to help devs to update local authority homepage URLs which is an occasional task on 2nd line.

https://govuk.zendesk.com/agent/tickets/3914429