### PR TITLE
Add import script for COVID-19 URLs for vulnerable people

### DIFF
--- a/lib/tasks/import/covid19_shielding.rake
+++ b/lib/tasks/import/covid19_shielding.rake
@@ -1,0 +1,35 @@
+SERVICE_MAPPINGS = {
+    "shielding"    => { lgsl: 1287, lgil: 8 },
+    "vulnerable"   => { lgsl: 1287, lgil: 6 },
+    "volunteering" => { lgsl: 1113, lgil: 8 },
+}.freeze
+
+namespace :import do
+  desc "Imports COVID-19 shielding links from TheyHelpYou"
+  task covid19_shielding: :environment do
+    SERVICE_MAPPINGS.each do |type, codes|
+      puts "Fetching mappings for type #{type}, LGSL=#{codes[:lgsl]} LGIL=#{codes[:lgil]}"
+      service_interaction = ServiceInteraction.find_or_create_by(
+        service: Service.find_by(lgsl_code: codes[:lgsl]),
+        interaction: Interaction.find_by(lgil_code: codes[:lgil]),
+      )
+
+      response = Net::HTTP.get_response(URI.parse("https://www.theyhelpyou.co.uk/api/export-local-links-manager?type=#{type}"))
+      unless response.code_type == Net::HTTPOK
+        raise DownloadError, "Error downloading JSON in #{self.class}"
+      end
+
+      data = JSON.parse(response.body)
+      puts "Got #{data.count} links"
+      data.each do |gss, url|
+        link = Link.find_or_initialize_by(
+          local_authority: LocalAuthority.find_by(gss: gss),
+            service_interaction: service_interaction,
+        )
+        link.url = url
+        link.save!
+      end
+      puts "Done"
+    end
+  end
+end


### PR DESCRIPTION
We have been crowdsourcing URLs for council-provided Community Response
Hubs on [TheyHelpYou][theyhelpyou]. We've been collecting and verifying
these URLs on a publicly open [Google Sheet][sheet]. Updates to this
sheet are automatically added to our database within 15 minutes. We get
alerted to every change and manually check it for validity.

In theory, there are three different needs that councils should be
meeting:
1. Shielding extremely vulnerable people
2. Supporting non-shielded vulnerable people
3. Helping the public volunteer safely to meet the other two needs

We've found that councils at the second tier are meeting these needs, at
least in England. This means that they're being met by:
- Counties (eg [Surrey][county])
- Unitary authorities (eg [Milton Keynes][uta])
- Districts/boroughs (eg [Manchester][district] or [Croydon][borough])

In practice, a lot of councils currently have all three needs on the
same URL, certainly the first 2. Some of them have split volunteering
information into different pages or even sites.

We've exposed the URLs we have on a [new API endpoint][api] suitable for use
with this import script:
```
GET https://www.theyhelpyou.co.uk/api/export-local-links-manager?type=shielding&nation=E
```

The API returns a JSON object mapping GSS codes to URLs, for example:
```json
{
    "E06000047": "https://www.durham.gov.uk/covid19help",
    "W06000009": "https://www.pembrokeshire.gov.uk/coronavirus-covid-19-community-information/i-need-some-help",
    "E08000019": "https://www.sheffield.gov.uk/home/your-city-council/coronavirus-support-for-people",
    ...
}
```

The `type` parameter must be one of `shielding`, `vulnerable` or
`volunteering`. If we don't have a specific URL for a council for the
requested type, the API will not return any data and that GSS code
won't be included in the response.

The `nation` parameter is optional to allow for filtering by Nation. If
provided, it must be one of `E`, `N`, `S`, or `W`.

The import script in this PR accesses this endpoint directly and fetches
data for each type, then creates `Link`s for the relevant
`ServiceInteraction` and `LocalAuthority`.

For demonstration purposes, we've picked some LGSL and LGIL codes.
We've used [LGSL code 1287][1287] (Current emergency situations -
health) for shielded and vulnerable links, as it's intended for "an
ongoing emergency related to public health such as a flu outbreak". For
shielding we're using LGIL code 8, "Find information" as generally this
is informational and councils will engage with residents directly. For
help for non-shielded vulnerable people we've used LGIL code 6,
"Providing access to community, professionals or business networks" as
this is about requesting support.

We've used [LGSL code 1113][1113] (Provision of information on
volunteering opportunities available in the community) and LGIL code 8
for volunteering URLs. This combination isn't currently supported on
GOV.UK, and Local Links Manager only has two links, neither of which are
relevant.

It may be better to create new emergency codes for this or to re-use
others, in which case they're easy to change in a constant hash near the
top of the rake task.

As far as I'm aware, all that would be needed to get this data
accessible via GOV.UK would be to create Local Transactions in
Publisher for these LGSL and LGIL codes, then run this import script.
The "tiering" in [Publisher's Local Services CSV][tiering] would also
need updating to show that the LGSL codes chosen are provided by all
tiers, followed by running the `import:add_service_tiers` rake task.

I've not written an `Import` class for this like in
`LocalAuthoritiesImporter` because I hope this is more of a one-off
disposable task. Converting it to that format should be relatively
straight-forward if that is preferred.

[theyhelpyou]:https://www.theyhelpyou.co.uk/
[sheet]:https://docs.google.com/spreadsheets/d/1uwcEbPob7EcOKBe_H-OiYEP3fITjbZH-ccpc81fMO7s/edit#gid=1418426695

[county]:https://www.surreycc.gov.uk/people-and-community/emergency-planning-and-community-safety/coronavirus/community-support/need-help
[uta]:https://www.milton-keynes.gov.uk/your-council-and-elections/coronavirus-support-and-information
[district]:https://secure.manchester.gov.uk/info/100003/people_and_communities/7941/coronavirus_covid-19_-_manchester_community_response
[borough]:https://www.croydon.gov.uk/healthsocial/phealth/coronavirus-information/support-for-hardship-or-difficulties

[api]:https://github.com/boffbowsh/theyhelpyou/blob/master/api/export_for_llm.py

[1287]:https://standards.esd.org.uk/?uri=service%2F1287
[1113]:https://standards.esd.org.uk/?uri=service%2F1113

[tiering]:https://github.com/alphagov/publisher/blob/master/data/local_services.csv