### PR TITLE
Enable volunteering service

### DIFF
--- a/db/migrate/20200415103445_enable_service1113.rb
+++ b/db/migrate/20200415103445_enable_service1113.rb
@@ -1,0 +1,18 @@
+class EnableService1113 < ActiveRecord::Migration[6.0]
+  def up
+    service = Service.find_by(lgsl_code: 1113)
+    interaction = Interaction.find_by(lgil_code: 8)
+
+    service.update!(enabled: true)
+    ServiceTier.create_tiers([Tier.district, Tier.unitary, Tier.county], service)
+
+    service_interaction = ServiceInteraction.find_by(service: service, interaction: interaction)
+
+    if service_interaction
+      service_interaction.update!(live: true)
+      puts "Successfully enabled service 1113"
+    else
+      raise "Service 1113 has not been imported from ESD"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_152345) do
+ActiveRecord::Schema.define(version: 2020_04_15_103445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We want to start showing local links for this, so we need to enable it in Local Links Manager.

[Trello Card](https://trello.com/c/h89SwLyy/1908-5-add-a-new-covid-19-volunteering-service-to-local-links-manager)