### PR TITLE
Import COVID-19 local links from TheyHelpYou

### DIFF
--- a/lib/tasks/import/covid19_shielding.rake
+++ b/lib/tasks/import/covid19_shielding.rake
@@ -1,0 +1,35 @@
+SERVICE_MAPPINGS = {
+    "shielding"    => { lgsl: 1287, lgil: 8 },
+    "vulnerable"   => { lgsl: 1287, lgil: 6 },
+    "volunteering" => { lgsl: 1113, lgil: 8 },
+}.freeze
+
+namespace :import do
+  desc "Imports COVID-19 shielding links from TheyHelpYou"
+  task covid19_shielding: :environment do
+    SERVICE_MAPPINGS.each do |type, codes|
+      puts "Fetching mappings for type #{type}, LGSL=#{codes[:lgsl]} LGIL=#{codes[:lgil]}"
+      service_interaction = ServiceInteraction.find_or_create_by(
+        service: Service.find_by(lgsl_code: codes[:lgsl]),
+        interaction: Interaction.find_by(lgil_code: codes[:lgil]),
+      )
+
+      response = Net::HTTP.get_response(URI.parse("https://www.theyhelpyou.co.uk/api/export-local-links-manager?type=#{type}"))
+      unless response.code_type == Net::HTTPOK
+        raise DownloadError, "Error downloading JSON in #{self.class}"
+      end
+
+      data = JSON.parse(response.body)
+      puts "Got #{data.count} links"
+      data.each do |gss, url|
+        link = Link.find_or_initialize_by(
+          local_authority: LocalAuthority.find_by(gss: gss),
+            service_interaction: service_interaction,
+        )
+        link.url = url
+        link.save!
+      end
+      puts "Done"
+    end
+  end
+end

--- a/lib/tasks/import/covid19_shielding.rake
+++ b/lib/tasks/import/covid19_shielding.rake
@@ -10,8 +10,8 @@ namespace :import do
     SERVICE_MAPPINGS.each do |type, codes|
       puts "Fetching mappings for type #{type}, LGSL=#{codes[:lgsl]} LGIL=#{codes[:lgil]}"
       service_interaction = ServiceInteraction.find_or_create_by(
-        service: Service.find_by(lgsl_code: codes[:lgsl]),
-        interaction: Interaction.find_by(lgil_code: codes[:lgil]),
+        service: Service.find_by!(lgsl_code: codes[:lgsl]),
+        interaction: Interaction.find_by!(lgil_code: codes[:lgil]),
       )
 
       response = Net::HTTP.get_response(URI.parse("https://www.theyhelpyou.co.uk/api/export-local-links-manager?type=#{type}"))
@@ -21,10 +21,17 @@ namespace :import do
 
       data = JSON.parse(response.body)
       puts "Got #{data.count} links"
+
       data.each do |gss, url|
+        local_authority = LocalAuthority.find_by(gss: gss)
+        unless local_authority
+          puts "Could not find local authority GSS=#{gss}"
+          next
+        end
+
         link = Link.find_or_initialize_by(
-          local_authority: LocalAuthority.find_by(gss: gss),
-            service_interaction: service_interaction,
+          local_authority: local_authority,
+          service_interaction: service_interaction,
         )
         link.url = url
         link.save!

--- a/lib/tasks/import/covid19_shielding.rake
+++ b/lib/tasks/import/covid19_shielding.rake
@@ -4,6 +4,7 @@ SERVICE_MAPPINGS = {
   "volunteering" => { lgsl: 1113, lgil: 8 },
 }.freeze
 
+# rubocop:disable Metrics/BlockLength
 namespace :import do
   desc "Imports COVID-19 shielding links from TheyHelpYou"
   task covid19_shielding: :environment do
@@ -40,3 +41,4 @@ namespace :import do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/import/covid19_shielding.rake
+++ b/lib/tasks/import/covid19_shielding.rake
@@ -1,7 +1,7 @@
 SERVICE_MAPPINGS = {
-    "shielding"    => { lgsl: 1287, lgil: 8 },
-    "vulnerable"   => { lgsl: 1287, lgil: 6 },
-    "volunteering" => { lgsl: 1113, lgil: 8 },
+  # "shielding"    => { lgsl: 1287, lgil: 8 },
+  # "vulnerable"   => { lgsl: 1287, lgil: 6 },
+  "volunteering" => { lgsl: 1113, lgil: 8 },
 }.freeze
 
 namespace :import do


### PR DESCRIPTION
This is based off #624 but makes a few small changes:

- Only imports volunteering links (we're not quite ready yet to import the other types of links)
- Use `find_by!` to ensure model instances really exist and validate against missing local authorities

I've tested this script in integration and it successfully imported the links into Local Links Manager.

See #624 for more information on the original import script. Thanks @boffbowsh!

[Trello Card](https://trello.com/c/h89SwLyy/1908-5-add-a-new-covid-19-volunteering-service-to-local-links-manager)