### PR TITLE
Resolve links to parent local authority

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,9 +7,9 @@ class ApiController < ApplicationController
     return render json: {}, status: :bad_request if missing_required_params_for_link?
     return render json: {}, status: :not_found if missing_objects_for_link?
 
-    @link = LocalLinksManager::LinkResolver.new(authority, service, interaction).resolve
+    link = LocalLinksManager::LinkResolver.new(authority, service, interaction).resolve
 
-    render json: LinkApiResponsePresenter.new(authority, @link).present
+    render json: LinkApiResponsePresenter.new(authority, link).present
   end
 
   def local_authority

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -1,6 +1,6 @@
 class LinkApiResponsePresenter
-  def initialize(authority, link)
-    @authority = authority
+  def initialize(given_authority, link)
+    @given_authority = given_authority
     @link = link
   end
 
@@ -10,7 +10,11 @@ class LinkApiResponsePresenter
 
 private
 
-  attr_reader :authority, :link
+  attr_reader :given_authority, :link
+
+  def authority
+    link&.local_authority || given_authority
+  end
 
   def local_authority_details
     {

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -5,32 +5,32 @@ class LinkApiResponsePresenter
   end
 
   def present
-    if @link
-      local_authority_details.merge(link_details)
-    else
-      local_authority_details
-    end
+    local_authority_details.merge(link_details)
   end
 
 private
 
+  attr_reader :authority, :link
+
   def local_authority_details
     {
       "local_authority" => {
-        "name" => @authority.name,
-        "snac" => @authority.snac,
-        "tier" => @authority.tier,
-        "homepage_url" => @authority.homepage_url,
+        "name" => authority.name,
+        "snac" => authority.snac,
+        "tier" => authority.tier,
+        "homepage_url" => authority.homepage_url,
       },
     }
   end
 
   def link_details
+    return {} unless link
+
     {
       "local_interaction" => {
-        "lgsl_code" => @link.service.lgsl_code,
-        "lgil_code" => @link.interaction.lgil_code,
-        "url" => @link.url,
+        "lgsl_code" => link.service.lgsl_code,
+        "lgil_code" => link.interaction.lgil_code,
+        "url" => link.url,
       },
     }
   end

--- a/lib/local-links-manager/link_resolver.rb
+++ b/lib/local-links-manager/link_resolver.rb
@@ -17,7 +17,21 @@ module LocalLinksManager
   private
 
     def link_for_interaction
-      @authority.links.lookup_by_service_and_interaction(@service, @interaction)
+      authority = @authority
+      link = authority.links.lookup_by_service_and_interaction(@service, @interaction)
+
+      while link.nil? && can_lookup_link_from_parent(authority)
+        authority = authority.parent_local_authority
+        link = authority.links.lookup_by_service_and_interaction(@service, @interaction)
+      end
+
+      link
+    end
+
+    def can_lookup_link_from_parent(authority)
+      return false unless authority.parent_local_authority
+
+      @service.local_authorities.exists?(authority.parent_local_authority.id)
     end
 
     def fallback_link

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -24,11 +24,20 @@ describe LinkApiResponsePresenter do
       }
     end
 
-    context "link is present" do
+    context "link is present and doesn't belong to the local authority" do
+      let(:link) { create(:link) }
+      let(:expected_response) { presented_local_authority(link.local_authority).merge(presented_link(link)) }
+
+      it "returns combined details for the link's local authority and local interaction" do
+        expect(presenter.present).to eq(expected_response)
+      end
+    end
+
+    context "link is present and belongs to local authority" do
       let(:link) { create(:link, local_authority: authority) }
       let(:expected_response) { presented_local_authority(authority).merge(presented_link(link)) }
 
-      it "returns combined details for the local authority and local interaction" do
+      it "returns combined details for the local authority and link's local interaction" do
         expect(presenter.present).to eq(expected_response)
       end
     end

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -1,25 +1,32 @@
 describe LinkApiResponsePresenter do
   describe "#present" do
     let(:authority) { build(:district_council) }
-    let(:presenter) { described_class.new(authority, link) }
+    subject(:presenter) { described_class.new(authority, link) }
+
+    def presented_local_authority(authority)
+      {
+        "local_authority" => {
+          "name" => authority.name,
+          "snac" => authority.snac,
+          "tier" => authority.tier,
+          "homepage_url" => authority.homepage_url,
+        },
+      }
+    end
+
+    def presented_link(link)
+      {
+        "local_interaction" => {
+          "lgsl_code" => link.service.lgsl_code,
+          "lgil_code" => link.interaction.lgil_code,
+          "url" => link.url,
+        },
+      }
+    end
 
     context "link is present" do
-      let(:link) { create(:link) }
-      let(:expected_response) do
-        {
-          "local_authority" => {
-            "name" => authority.name,
-            "snac" => authority.snac,
-            "tier" => "district",
-            "homepage_url" => authority.homepage_url,
-          },
-          "local_interaction" => {
-            "lgsl_code" => link.service.lgsl_code,
-            "lgil_code" => link.interaction.lgil_code,
-            "url" => link.url,
-          },
-        }
-      end
+      let(:link) { create(:link, local_authority: authority) }
+      let(:expected_response) { presented_local_authority(authority).merge(presented_link(link)) }
 
       it "returns combined details for the local authority and local interaction" do
         expect(presenter.present).to eq(expected_response)
@@ -28,16 +35,7 @@ describe LinkApiResponsePresenter do
 
     context "no link is present" do
       let(:link) { nil }
-      let(:expected_response) do
-        {
-          "local_authority" => {
-            "name" => authority.name,
-            "snac" => authority.snac,
-            "tier" => "district",
-            "homepage_url" => authority.homepage_url,
-          },
-        }
-      end
+      let(:expected_response) { presented_local_authority(authority) }
 
       it "returns details for just the local authority" do
         expect(presenter.present).to eq(expected_response)


### PR DESCRIPTION
This changes the link resolver class to lookup the links of the parent local authority, if the parent local authority tier is a valid tier for this service.

This is useful because it allows users to be shown a more suitable link if the most local council tier has no link set in the cases where the service is provided by multiple council tiers. This has come up recently as we're adding a new service for volunteering, but don't have all the links available at all tiers.

[Trello Card](https://trello.com/c/ahrs9HWd/1919-make-local-links-manager-fallback)