### PR TITLE
Import vulnerable URLs from MHCLG and TheyHelpYou

### DIFF
--- a/lib/tasks/import/covid19_mhclg.rake
+++ b/lib/tasks/import/covid19_mhclg.rake
@@ -1,0 +1,64 @@
+require "csv"
+
+# rubocop:disable Metrics/BlockLength
+namespace :import do
+  desc "Imports COVID-19 shielding links from MHCLG's Google Sheet"
+  task covid19_mhclg: :environment do
+    SERVICE_MAPPINGS = {
+      "Single Vulnerable People URL" => { lgsl: 1287, lgil: 8 },
+      # "volunteering" => { lgsl: 1113, lgil: 8 },
+    }.freeze
+
+    DOC_ID = "10U5nHFusxMPAh93aleuPYpE-l8ZOJGOjClQemoeIx5A".freeze
+    SHEET_ID = "543314380".freeze
+    CSV_URL = URI.parse("https://docs.google.com/spreadsheets/d/#{DOC_ID}/export?gid=#{SHEET_ID}&format=csv&id=#{DOC_ID}")
+
+    response = Net::HTTP.get_response(CSV_URL)
+    unless response.code_type == Net::HTTPOK
+      raise "Error downloading CSV in #{self.class}"
+    end
+
+    csv = CSV.parse(response.body, headers: true)
+
+    # Sanity check
+    raise "Missing 'GSS' column" if csv["GSS"].compact.empty?
+
+    SERVICE_MAPPINGS.keys.each do |k|
+      raise "Missing '#{csv[k]}' column" if csv[k].compact.empty?
+    end
+
+    SERVICE_MAPPINGS.each do |type, codes|
+      service_interaction = ServiceInteraction.find_or_create_by(
+        service: Service.find_by!(lgsl_code: codes[:lgsl]),
+        interaction: Interaction.find_by!(lgil_code: codes[:lgil]),
+      )
+
+      csv.each do |row|
+        url = row[type]&.strip
+        next if url.blank?
+
+        begin
+          URI.parse(url)
+        rescue URI::InvalidURIError
+          puts "Invalid URL '#{url}' for area #{row['GSS']}, skipping"
+          next
+        end
+
+        local_authority = LocalAuthority.find_by(gss: row["GSS"])
+        unless local_authority
+          puts "Could not find local authority GSS=#{row['GSS']}"
+          next
+        end
+
+        link = Link.find_or_initialize_by(
+          local_authority: local_authority,
+          service_interaction: service_interaction,
+        )
+        link.url = url
+        link.save!
+      end
+      puts "Done"
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/import/covid19_theyhelpyou.rake
+++ b/lib/tasks/import/covid19_theyhelpyou.rake
@@ -1,13 +1,13 @@
-SERVICE_MAPPINGS = {
-  # "shielding"    => { lgsl: 1287, lgil: 8 },
-  # "vulnerable"   => { lgsl: 1287, lgil: 6 },
-  "volunteering" => { lgsl: 1113, lgil: 8 },
-}.freeze
-
 # rubocop:disable Metrics/BlockLength
 namespace :import do
   desc "Imports COVID-19 shielding links from TheyHelpYou"
-  task covid19_shielding: :environment do
+  task covid19_theyhelpyou: :environment do
+    SERVICE_MAPPINGS = {
+      # "shielding"    => { lgsl: 1287, lgil: 8 },
+      # "vulnerable"   => { lgsl: 1287, lgil: 6 },
+      "volunteering" => { lgsl: 1113, lgil: 8 },
+    }.freeze
+
     SERVICE_MAPPINGS.each do |type, codes|
       puts "Fetching mappings for type #{type}, LGSL=#{codes[:lgsl]} LGIL=#{codes[:lgil]}"
       service_interaction = ServiceInteraction.find_or_create_by(


### PR DESCRIPTION
MHCLG have been collecting local URLs for supporting vulnerable people
from local council websites in a [Google Sheet][]. This script imports
them into Local Links Manager for LGSL 1287 and LGIL 8, based on the
rationale in [this PR][624]. GOV.UK have decided for now to only import the urls for
the "vulnerable" set and not the "shielded" set, so it makes sense to just use LGIL 8.

The `import:covid19_mhclg` script fetches the CSV directly from Google Docs, which means that
the document first needs to be made publicly downloadable by anyone with
the link. First it performs a sanity check to ensure the sheet is in the
correct format. It next finds any existing `Link`s for each
`LocalAuthority` for the `ServiceInteraction`, overwriting the URL if a
`Link` already exists, or creating it if it doesn't.

The MHCLG sheet only has vulnerable URLs for English councils, which
means we still need to import these URLs from TheyHelpYou for Scotland,
Wales and Northern Ireland.

We can now run the `import:covid19_theyhelpyou` script and specify filters with environment
variables. Both are optional, if either are omitted there isn't any
filtering applied.

Set the `NATION` env var to one of `E`, `N`, `S` or `W` to only import
links for that nation.

Set the `SERVICE_TYPE` to (currently) one of `vulnerable` or
`volunteering` to only import those links.

For the Vulnerable set of links, this script will need to be run
three times, once for each of the nations except England.

[Google Sheet]:
https://docs.google.com/spreadsheets/d/10U5nHFusxMPAh93aleuPYpE-l8ZOJGOjClQemoeIx5A/edit?ts=5eaadb03#gid=2060364237
[624]: https://github.com/alphagov/local-links-manager/pull/624

Relates to Trello card: https://trello.com/c/cqKZXLbE