### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,6 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - db/migrate/201*.rb
-
 Naming/VariableNumber:
   Exclude:
     - 'spec/lib/local-links-manager/check_links/link_status_requester_spec.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-task default: [:spec]
+task default: %i[spec lint]

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,5 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-task default: %i[spec lint]
+Rake::Task[:default].clear
+task default: %i[lint spec]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Linting"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to
  GitHub Actions. We want one single step bundle exec rake that runs
  everything. This ensures parity between local dev and what CI runs
  (something that we don't always have now).
- Remove old `db/migrate/201*` RuboCop disablement - by default
  it's in the gem now.

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks
