### PR TITLE
Fix clearing non-existant 'default' task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,7 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-Rake::Task[:default].clear
+# RSpec shoves itself into the default task without asking, which confuses the ordering.
+# https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
+Rake::Task[:default].clear unless Rails.env.production?
 task default: %i[lint spec]


### PR DESCRIPTION
Clearing the 'default' rake task throws an error in production,
when RSpec hasn't manipulated it into existance.