### PR TITLE
Stop links with 0 clicks appearing at the top of the list.

### DIFF
--- a/db/migrate/20200604142453_add_default_to_analytics.rb
+++ b/db/migrate/20200604142453_add_default_to_analytics.rb
@@ -1,0 +1,8 @@
+class AddDefaultToAnalytics < ActiveRecord::Migration[6.0]
+  def up
+    change_column :links, :analytics, :integer, :default => 0
+  end
+  def down
+    change_column :links, :analytics, :integer, :default => nil
+  end
+end

--- a/db/migrate/20200604142453_add_default_to_analytics.rb
+++ b/db/migrate/20200604142453_add_default_to_analytics.rb
@@ -1,8 +1,9 @@
 class AddDefaultToAnalytics < ActiveRecord::Migration[6.0]
   def up
-    change_column :links, :analytics, :integer, :default => 0
+    change_column :links, :analytics, :integer, default: 0
   end
+
   def down
-    change_column :links, :analytics, :integer, :default => nil
+    change_column :links, :analytics, :integer, default: nil
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_124957) do
+ActiveRecord::Schema.define(version: 2020_06_04_142453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_124957) do
     t.datetime "updated_at", null: false
     t.string "status"
     t.datetime "link_last_checked"
-    t.integer "analytics"
+    t.integer "analytics", default: 0
     t.string "link_errors", default: [], null: false, array: true
     t.string "link_warnings", default: [], null: false, array: true
     t.string "problem_summary"

--- a/lib/local-links-manager/import/analytics_importer.rb
+++ b/lib/local-links-manager/import/analytics_importer.rb
@@ -26,7 +26,7 @@ module LocalLinksManager
         link = Link.lookup_by_base_path(item[:base_path])
 
         if link
-          link.update!(analytics: item[:clicks])
+          link.update!(analytics: item[:clicks] || 0)
           summariser.increment_updated_record_count
           @processed_ids.add(link.id)
         else


### PR DESCRIPTION
Made a small change to `anaytics_importer.rb` to prevent the number of clicks
for a given link ever being nil, as when GA shows no clicks for a link it gives
that as `nil`, this breaks the ordering for the links.

The data migration will be the first of two, there will be a second migration adding a constraint to the `analytics` column, but's it's safer to add this separately so that will come in a follow up PR.