### PR TITLE
Log invalid CSVs to Rails logger instead of Sentry

### DIFF
--- a/lib/local-links-manager/import/errors.rb
+++ b/lib/local-links-manager/import/errors.rb
@@ -3,7 +3,5 @@ module LocalLinksManager
     class MissingIdentifierError < RuntimeError; end
 
     class MissingRecordError < RuntimeError; end
-
-    class UrlValidationException < RuntimeError; end
   end
 end

--- a/lib/local-links-manager/import/links.rb
+++ b/lib/local-links-manager/import/links.rb
@@ -35,12 +35,8 @@ module LocalLinksManager
             link.update!(url: new_url)
             updated += 1
           rescue ActiveRecord::RecordInvalid => e
-            GovukError.notify(
-              LocalLinksManager::Import::UrlValidationException.new(e.message),
-              extra: slugs.merge(link_id: link.id),
-            )
-            error_message = "Line #{index}: invalid URL '#{new_url}'"
-            errors << error_message
+            Rails.logger.warn("#{e.message} (#{slugs.merge(link_id: link.id)})")
+            errors << "Line #{index}: invalid URL '#{new_url}'"
           end
         end
 


### PR DESCRIPTION
In https://github.com/alphagov/local-links-manager/pull/682, we caught exceptions raised by invalid CSVs, logged the error to
Sentry and then returned an error message to the user.

In hindsight, we should not have logged to Sentry, as it would
not be an actionable error, as per [RFC-87]. Instead, we should
log to the Rails logger so that we can monitor these events in
Kibana. [Thanks to Kevin for pointing this out][comment].

Now that we're no longer sending to Sentry, we can remove the
'UrlValidationException' error, which was only added as a more
descriptive proxy for Sentry to get around the fact that
[ActiveRecord::RecordInvalid is ignored from Sentry][ignored].

Trello: https://trello.com/c/X6LlnsrM/2046-remove-sentry-logging-from-user-input-error-for-local-links-manager

[comment]: https://github.com/alphagov/local-links-manager/pull/682#discussion_r450083512
[ignored]: https://github.com/alphagov/govuk_app_config/blob/9dd5e51a1b3c7401dd3aae6ff29a64ffa9e7cd76/lib/govuk_app_config/configure.rb/#L30
[RFC-87]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md#2-notifications-should-be-actionable