### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-# We seldom check the return value of 'update' to see if
-# the operation was successful. Since we assume success, we
-# should raise an exception if this is not the case.
-#
-# We intend to add this to rubocop-govuk.
-Rails/SaveBang:
-  Enabled: true


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

    This is now enabled by default [1].
    
    [1]: https://github.com/alphagov/rubocop-govuk/pull/98