### PR TITLE
Add Errors module in errors.rb

### DIFF
--- a/app/lib/local_links_manager/import/errors.rb
+++ b/app/lib/local_links_manager/import/errors.rb
@@ -1,7 +1,9 @@
 module LocalLinksManager
   module Import
-    class MissingIdentifierError < RuntimeError; end
+    module Errors
+      class MissingIdentifierError < RuntimeError; end
 
-    class MissingRecordError < RuntimeError; end
+      class MissingRecordError < RuntimeError; end
+    end
   end
 end

--- a/app/lib/local_links_manager/import/interactions_importer.rb
+++ b/app/lib/local_links_manager/import/interactions_importer.rb
@@ -55,7 +55,7 @@ module LocalLinksManager
     private
 
       def create_or_update_record(item, summariser)
-        raise MissingIdentifierError if item[:lgil_code].blank?
+        raise Errors::MissingIdentifierError if item[:lgil_code].blank?
 
         interaction = Interaction.where(lgil_code: item[:lgil_code]).first_or_initialize
         existing_record = interaction.persisted?

--- a/app/lib/local_links_manager/import/local_authorities_importer.rb
+++ b/app/lib/local_links_manager/import/local_authorities_importer.rb
@@ -65,7 +65,7 @@ module LocalLinksManager
     private
 
       def create_or_update_la(mapit_la, summariser)
-        raise MissingIdentifierError, "Found empty code for local authority: #{mapit_la[:name]}" if mapit_la[:gss].blank? || mapit_la[:snac].blank?
+        raise Errors::MissingIdentifierError, "Found empty code for local authority: #{mapit_la[:name]}" if mapit_la[:gss].blank? || mapit_la[:snac].blank?
 
         la = LocalAuthority.where(gss: mapit_la[:gss]).first_or_initialize
         existing_record = la.persisted?

--- a/app/lib/local_links_manager/import/publishing_api_importer.rb
+++ b/app/lib/local_links_manager/import/publishing_api_importer.rb
@@ -24,7 +24,7 @@ module LocalLinksManager
       end
 
       def import_item(local_transaction, _response, summariser)
-        raise MissingIdentifierError, "Found empty LGSL/LGIL code on local_transaction #{local_transaction['slug']}" if local_transaction["lgil"].blank? || local_transaction["lgsl"].blank?
+        raise Errors::MissingIdentifierError, "Found empty LGSL/LGIL code on local_transaction #{local_transaction['slug']}" if local_transaction["lgil"].blank? || local_transaction["lgsl"].blank?
 
         service = Service.find_by(lgsl_code: local_transaction["lgsl"])
         interaction = Interaction.find_by(lgil_code: local_transaction["lgil"])

--- a/app/lib/local_links_manager/import/service_interactions_importer.rb
+++ b/app/lib/local_links_manager/import/service_interactions_importer.rb
@@ -54,14 +54,14 @@ module LocalLinksManager
     private
 
       def find_associated_records(item)
-        raise MissingIdentifierError, missing_id_error_msg(Service) if item[:lgsl_code].nil?
-        raise MissingIdentifierError, missing_id_error_msg(Interaction) if item[:lgil_code].nil?
+        raise Errors::MissingIdentifierError, missing_id_error_msg(Service) if item[:lgsl_code].nil?
+        raise Errors::MissingIdentifierError, missing_id_error_msg(Interaction) if item[:lgil_code].nil?
 
         service = Service.find_by(lgsl_code: item[:lgsl_code])
         interaction = Interaction.find_by(lgil_code: item[:lgil_code])
 
-        raise MissingRecordError, missing_record_error_msg(Service, :lgsl_code, item[:lgsl_code]) unless service
-        raise MissingRecordError, missing_record_error_msg(Interaction, :lgil_code, item[:lgil_code]) unless interaction
+        raise Errors::MissingRecordError, missing_record_error_msg(Service, :lgsl_code, item[:lgsl_code]) unless service
+        raise Errors::MissingRecordError, missing_record_error_msg(Interaction, :lgil_code, item[:lgil_code]) unless interaction
 
         { service_id: service.id, interaction_id: interaction.id }
       end

--- a/app/lib/local_links_manager/import/services_importer.rb
+++ b/app/lib/local_links_manager/import/services_importer.rb
@@ -56,7 +56,7 @@ module LocalLinksManager
     private
 
       def create_or_update_record(item, summariser)
-        raise MissingIdentifierError if item[:lgsl_code].blank?
+        raise Errors::MissingIdentifierError if item[:lgsl_code].blank?
 
         service = Service.where(lgsl_code: item[:lgsl_code]).first_or_initialize
         existing_record = service.persisted?

--- a/app/lib/local_links_manager/import/services_tier_importer.rb
+++ b/app/lib/local_links_manager/import/services_tier_importer.rb
@@ -37,10 +37,10 @@ module LocalLinksManager
       end
 
       def import_item(item, response, summariser)
-        raise MissingIdentifierError if item[:lgsl_code].blank?
+        raise Errors::MissingIdentifierError if item[:lgsl_code].blank?
 
         service = Service.find_by(lgsl_code: item[:lgsl_code])
-        raise MissingRecordError, "LGSL #{item[:lgsl_code]} is missing" if service.nil?
+        raise Errors::MissingRecordError, "LGSL #{item[:lgsl_code]} is missing" if service.nil?
 
         Rails.logger.info("Updating service '#{service.label}' (lgsl #{service.lgsl_code})")
         checked_services.add(service)

--- a/app/lib/local_links_manager/import/summariser.rb
+++ b/app/lib/local_links_manager/import/summariser.rb
@@ -60,11 +60,11 @@ module LocalLinksManager
 
       def counting_errors(errors_collector)
         yield
-      rescue MissingRecordError => e
+      rescue Errors::MissingRecordError => e
         increment_missing_record_count
         Rails.logger.error e.message
         errors_collector.errors << e.message
-      rescue MissingIdentifierError => e
+      rescue Errors::MissingIdentifierError => e
         increment_missing_id_count
         Rails.logger.error e.message
         errors_collector.errors << e.message


### PR DESCRIPTION
Getting this error on deploying `ERROR -- : uninitialized constant LocalLinksManager::Import::Errors (NameError)` coming from zeitwerk

Zeitwerk expects files to have matching class names, so added an errors module