### PR TITLE
Fix incorrect icinga check names

### DIFF
--- a/lib/tasks/export/link_exporter.rake
+++ b/lib/tasks/export/link_exporter.rake
@@ -5,7 +5,7 @@ namespace :export do
   namespace :links do
     desc "Export links to CSV"
     task "all": :environment do
-      service_desc = "Export links to CSV from local_links_manager"
+      service_desc = "Export links to CSV from local-links-manager"
       begin
         Rails.logger.info("Starting link exporter")
         Services.icinga_check(service_desc, "true", "Starting link exporter")

--- a/lib/tasks/import/local_authorities.rake
+++ b/lib/tasks/import/local_authorities.rake
@@ -10,7 +10,7 @@ namespace :import do
 
     desc "Import local authority names, codes and tiers from MapIt"
     task import_authorities: :environment do
-      service_desc = "Import local authorities into local_links_manager"
+      service_desc = "Import local authorities into local-links-manager"
       response = LocalLinksManager::Import::LocalAuthoritiesImporter.import_from_mapit
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end

--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -35,35 +35,35 @@ namespace :import do
 
     desc "Import Services from standards.esd.org.uk"
     task import_services: :environment do
-      service_desc = "Import services into local_links_manager"
+      service_desc = "Import services into local-links-manager"
       response = LocalLinksManager::Import::ServicesImporter.import
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Import Interactions from standards.esd.org.uk"
     task import_interactions: :environment do
-      service_desc = "Import interactions into local_links_manager"
+      service_desc = "Import interactions into local-links-manager"
       response = LocalLinksManager::Import::InteractionsImporter.import
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Import ServicesInteractions from standards.esd.org.uk"
     task import_service_interactions: :environment do
-      service_desc = "Import service interactions into local_links_manager"
+      service_desc = "Import service interactions into local-links-manager"
       response = LocalLinksManager::Import::ServiceInteractionsImporter.import
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Add tiers from local_services.csv in publisher to the list of Services imported by `import_services`"
     task add_service_tiers: :environment do
-      service_desc = "Add tiers to services into local_links_manager"
+      service_desc = "Add tiers to services into local-links-manager"
       response = LocalLinksManager::Import::ServicesTierImporter.import
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end
 
     desc "Enable services used on Gov.uk"
     task enable_services: :environment do
-      service_desc = "Enable services in local_links_manager"
+      service_desc = "Enable services in local-links-manager"
       response = LocalLinksManager::Import::EnabledServiceChecker.enable
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)
     end


### PR DESCRIPTION
In 35414db8 there was a mass find and replace that changed all instances
of local-links-manager to local_links_manager, this unfortunately had
the consequence that any icinga check communication was being made to a
non-existent check. This reverts the naming to local-links-manager.

/cc @cdccollins just so you're aware.