### PR TITLE
Upgrade to 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-ruby File.read(".ruby-version").strip
 source "https://rubygems.org"
 
 gem "rails", "6.0.3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,8 +476,5 @@ DEPENDENCIES
   webmock
   whenever
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3

--- a/app/lib/local_authority_redirector.rb
+++ b/app/lib/local_authority_redirector.rb
@@ -4,8 +4,8 @@ class LocalAuthorityRedirector
     @new_local_authority = to
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(*args, **kwargs)
+    new(*args, **kwargs).call
   end
 
   def call

--- a/spec/lib/google_analytics/client_spec.rb
+++ b/spec/lib/google_analytics/client_spec.rb
@@ -40,7 +40,7 @@ describe GoogleAnalytics::Client do
 
       it "uses the given scope" do
         options = { scope: "https://scope.com/analytics" }
-        auth = GoogleAnalytics::Client.new.build(options)
+        auth = GoogleAnalytics::Client.new.build(**options)
 
         expect(auth.authorization.scope).to include("https://scope.com/analytics")
       end


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7

Since there is an automated process for updating Ruby versions in govuk apps, I changed the version locally and have made the necessary updates. The tests should pass for both old and new Ruby versions.

There are some deprecation warnings that relate to Ruby 2.7 coming from sprockets-rails.