### PR TITLE
Preload application for unicorn before it forks

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,19 @@
 require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
+
 working_directory File.dirname(File.dirname(__FILE__))
+
+# Preload the entire app
+preload_app true
+
+before_fork do |_server, _worker|
+  # The following is highly recomended for Rails + "preload_app true"
+  # as there's no need for the master process to hold a connection.
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |_server, _worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
To take maximum advantage of the copy-on-write memory feature the app should be preloaded first before unicorn forks any workers.

The before/after_fork hooks are based on the unicorn config for whitehall.