### PR TITLE
Fix specs that were checking for nil text

### DIFF
--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -100,7 +100,9 @@ feature "The local authority show page" do
     end
 
     it "shows the link last checked details" do
-      expect(page).to have_text ok_link.link_last_checked
+      within(:css, "tr[data-interaction-id=\"#{ok_link.interaction.id}\"]") do
+        expect(page).to have_text "Link not checked"
+      end
     end
 
     it "should have a link to Edit Link" do

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -107,7 +107,7 @@ feature "The services show page" do
 
     it "shows the link last checked details" do
       for_local_authority_interactions(@council_a, @link1.interaction) do
-        expect(page).to have_text @link1.link_last_checked
+        expect(page).to have_text "Link not checked"
       end
     end
 


### PR DESCRIPTION
The default value for `link_last_checked` is nil so these specs were never going to fail as `has_text?` always returns true for nil.