### PR TITLE
Add local links for Test and Trace scheme

### DIFF
--- a/lib/tasks/import/covid19_test_and_trace_scheme_links.rake
+++ b/lib/tasks/import/covid19_test_and_trace_scheme_links.rake
@@ -1,0 +1,35 @@
+require "csv"
+
+namespace :import do
+  desc "Imports COVID-19 Test and Trace scheme links from CSV file"
+  task :test_and_trace_links, %i[lgsl_code lgil_code filename] => :environment do |_, args|
+    service_interaction = ServiceInteraction.find_or_create_by!(
+      service: Service.find_by!(lgsl_code: args.lgsl_code),
+      interaction: Interaction.find_by!(lgil_code: args.lgil_code),
+    )
+
+    csv = CSV.read(args.filename, { headers: true })
+
+    puts "Importing [#{csv.count}] links"
+    imported = 0
+
+    csv.each do |row|
+      slug = row["slug"]&.strip
+      url = row["url"]&.strip
+
+      local_authority = LocalAuthority.find_by(slug: slug)
+
+      local_link = Link.find_or_initialize_by(
+        local_authority: local_authority,
+        service_interaction: service_interaction,
+      )
+
+      local_link.url = url
+      local_link.save!
+
+      imported += 1
+    end
+
+    puts "[#{imported}] links imported"
+  end
+end


### PR DESCRIPTION
What

We need to add the local authority links for the test and trace scheme self isolation payments.

The rake task takes 3 params: LGSL code, LGIL code and a filename. The file to which the filename points must be a CSV file with 2 columns and contain a header row of `slug` and `url`. It is expected that this file be available locally, in the `/tmp` directory for example.

Why

The test and trace scheme is newly created.

[Trello](https://trello.com/c/nfP99EZW/609-add-the-local-links-for-service)