### PR TITLE
Add country_name to the Local Links Manager API

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ This example is for `GET /api/local-authority?authority_slug=rochford`
   {
     "name" => 'Rochford District Council',
     "homepage_url" => "http://rochford.example.com",
+    "country_name" => "England",
     "tier" => "district"
   },
   {
     "name" => 'Essex County Council',
     "homepage_url" => "http://essex.example.com",
+    "country_name" => "England",
     "tier" => "county"
   }
 ]
@@ -83,6 +85,7 @@ This example is for `GET /api/local-authority?authority_slug=camden`
   {
     "name" => 'Camden Borough Council',
     "homepage_url" => "http://camden.example.com",
+    "country_name" => "England",
     "tier" => "unitary"
   }
 ]
@@ -105,6 +108,7 @@ Returns JSON details for local authority and interaction or just local authority
       "snac" => "00AG",
       "tier" => "unitary",
       "homepage_url" => "http://blackburn.example.com",
+      "country_name" => "England",
   },
     "local_interaction" => {
       "lgsl_code" => 2,

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -23,6 +23,7 @@ private
         "snac" => authority.snac,
         "tier" => authority.tier,
         "homepage_url" => authority.homepage_url,
+        "country_name" => authority.country_name,
       },
     }
   end

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -22,6 +22,7 @@ private
     {
       "name" => local_authority.name,
       "homepage_url" => local_authority.homepage_url,
+      "country_name" => local_authority.country_name,
       "tier" => local_authority.tier,
     }
   end

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -10,6 +10,7 @@ describe LinkApiResponsePresenter do
           "snac" => authority.snac,
           "tier" => authority.tier,
           "homepage_url" => authority.homepage_url,
+          "country_name" => authority.country_name,
         },
       }
     end

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -10,11 +10,13 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
+              "country_name" => authority.country_name,
               "tier" => "district",
             },
             {
               "name" => parent_local_authority.name,
               "homepage_url" => parent_local_authority.homepage_url,
+              "country_name" => parent_local_authority.country_name,
               "tier" => "county",
             },
           ],
@@ -34,6 +36,7 @@ describe LocalAuthorityApiResponsePresenter do
             {
               "name" => authority.name,
               "homepage_url" => authority.homepage_url,
+              "country_name" => authority.country_name,
               "tier" => "unitary",
             },
           ],

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "link path", type: :request do
         name: "Blackburn",
         slug: "blackburn",
         homepage_url: "http://blackburn.example.com",
+        country_name: "England",
         snac: "00AG",
       )
     end
@@ -21,6 +22,7 @@ RSpec.describe "link path", type: :request do
           "snac" => "00AG",
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
+          "country_name" => "England",
         },
         "local_interaction" => {
           "lgsl_code" => 2,
@@ -36,6 +38,7 @@ RSpec.describe "link path", type: :request do
           "snac" => "00AG",
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
+          "country_name" => "England",
         },
       }
     end
@@ -46,6 +49,7 @@ RSpec.describe "link path", type: :request do
           "snac" => "00AG",
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
+          "country_name" => "England",
         },
       }
     end
@@ -109,6 +113,7 @@ RSpec.describe "link path", type: :request do
         name: "Blackburn",
         slug: "blackburn",
         homepage_url: "http://blackburn.gov.uk",
+        country_name: "England",
         snac: "00AG",
       )
     end
@@ -122,6 +127,7 @@ RSpec.describe "link path", type: :request do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
+            "country_name" => "England",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -150,6 +156,7 @@ RSpec.describe "link path", type: :request do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
+            "country_name" => "England",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -180,6 +187,7 @@ RSpec.describe "link path", type: :request do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
+            "country_name" => "England",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -207,6 +215,7 @@ RSpec.describe "link path", type: :request do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
+            "country_name" => "England",
           },
         }
         get "/api/link?authority_slug=blackburn&lgsl=2"

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "find local authority", type: :request do
         name: "Rochester",
         slug: "rochester",
         homepage_url: "http://rochester.example.com",
+        country_name: "England",
       )
     end
     let!(:local_authority) do
@@ -14,6 +15,7 @@ RSpec.describe "find local authority", type: :request do
         name: "Blackburn",
         slug: "blackburn",
         homepage_url: "http://blackburn.example.com",
+        country_name: "England",
         parent_local_authority: parent_local_authority,
       )
     end
@@ -24,11 +26,13 @@ RSpec.describe "find local authority", type: :request do
           {
             "name" => "Blackburn",
             "homepage_url" => "http://blackburn.example.com",
+            "country_name" => "England",
             "tier" => "district",
           },
           {
             "name" => "Rochester",
             "homepage_url" => "http://rochester.example.com",
+            "country_name" => "England",
             "tier" => "county",
           },
         ],
@@ -50,6 +54,7 @@ RSpec.describe "find local authority", type: :request do
         name: "Blackburn",
         slug: "blackburn",
         homepage_url: "http://blackburn.example.com",
+        country_name: "England",
       )
     end
 
@@ -59,6 +64,7 @@ RSpec.describe "find local authority", type: :request do
           {
             "name" => "Blackburn",
             "homepage_url" => "http://blackburn.example.com",
+            "country_name" => "England",
             "tier" => "unitary",
           },
         ],


### PR DESCRIPTION
## What

The country name - which is now available in the Local Links Manager database - is not currently present in the Local Links Manager API.

## Why

So that we can provide a better user experience to applications and services that use the Local Links Manager.

[Trello](https://trello.com/c/QSY1CoAB/643-test-and-trace-nation-validation)