### PR TITLE
Add country name to LocalAuthority

### DIFF
--- a/app/lib/local_links_manager/import/local_authorities_importer.rb
+++ b/app/lib/local_links_manager/import/local_authorities_importer.rb
@@ -76,6 +76,7 @@ module LocalLinksManager
         la.snac = mapit_la[:snac]
         la.slug = mapit_la[:slug]
         la.tier_id = mapit_la[:tier_id]
+        la.country_name = mapit_la[:country_name]
         la.save!
         if existing_record
           summariser.increment_updated_record_count
@@ -106,6 +107,7 @@ module LocalLinksManager
         authority[:tier_id] = identify_tier_id(parsed_authority["type"])
         authority[:mapit_id] = parsed_authority["id"]
         authority[:parent_mapit_id] = parsed_authority["parent_area"]
+        authority[:country_name] = parsed_authority["country_name"]
         authority
       end
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,6 +1,6 @@
 class LocalAuthority < ApplicationRecord
   validates :gss, :snac, :slug, uniqueness: true
-  validates :gss, :name, :snac, :slug, presence: true
+  validates :gss, :name, :snac, :slug, :country_name, presence: true
   validates :tier_id,
             presence: true,
             inclusion:

--- a/db/migrate/20201218121339_add_country_name_to_local_authority.rb
+++ b/db/migrate/20201218121339_add_country_name_to_local_authority.rb
@@ -1,0 +1,5 @@
+class AddCountryNameToLocalAuthority < ActiveRecord::Migration[6.0]
+  def change
+    add_column :local_authorities, :country_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_05_085759) do
+ActiveRecord::Schema.define(version: 2020_12_18_121339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,9 +33,9 @@ ActiveRecord::Schema.define(version: 2020_11_05_085759) do
     t.datetime "updated_at", null: false
     t.string "status"
     t.datetime "link_last_checked"
-    t.integer "analytics", default: 0, null: false
     t.string "link_errors", default: [], null: false, array: true
     t.string "link_warnings", default: [], null: false, array: true
+    t.integer "analytics", default: 0, null: false
     t.string "problem_summary"
     t.string "suggested_fix"
     t.index ["analytics"], name: "index_links_on_analytics"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2020_11_05_085759) do
     t.string "link_warnings", default: [], null: false, array: true
     t.string "problem_summary"
     t.string "suggested_fix"
+    t.string "country_name"
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true
     t.index ["homepage_url"], name: "index_local_authorities_on_homepage_url"
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     homepage_url { "http://www.angus.gov.uk" }
     status { nil }
     link_last_checked { nil }
+    country_name { "England" }
   end
 
   factory :district_council, parent: :local_authority do

--- a/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
+++ b/spec/lib/local-links-manager/import/local_authorities_importer_spec.rb
@@ -32,6 +32,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.snac).to eq("00QA")
           expect(la.tier).to eq("unitary")
           expect(la.slug).to eq("aberdeen-city-council")
+          expect(la.country_name).to eq("Scotland")
         end
 
         it "updates name, SNAC, slug and tier fields" do
@@ -68,6 +69,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.snac).to eq("XXXX")
           expect(la.slug).to eq("another-slug")
           expect(la.tier).to eq("district")
+          expect(la.country_name).to eq("Scotland")
         end
 
         it "skips updating if GSS or SNAC code is blank" do
@@ -248,6 +250,7 @@ describe LocalLinksManager::Import::LocalAuthoritiesImporter do
           expect(la.snac).to eq("11UB")
           expect(la.tier).to eq("district")
           expect(la.slug).to eq("aylesbury-district-council")
+          expect(la.country_name).to eq("England")
           expect(la.parent_local_authority_id).to eq(parent_local_authority.id)
         end
       end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe LocalAuthority, type: :model do
     it { should validate_presence_of(:gss) }
     it { should validate_presence_of(:snac) }
     it { should validate_presence_of(:slug) }
+    it { should validate_presence_of(:country_name) }
 
     it { should validate_uniqueness_of(:gss) }
     it { should validate_uniqueness_of(:snac) }


### PR DESCRIPTION
## What

The country name - which is available from the [Mapit](https://github.com/alphagov/mapit) API - is not present in the current response.

## Why

So that we can provide a better user experience to applications and services that use the Local Links Manager.

[Trello](https://trello.com/c/QSY1CoAB/643-test-and-trace-nation-validation)