### PR TITLE
Add new test to increase coverage for continuous deployment

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -35,9 +35,6 @@ class LinksController < ApplicationController
   def destroy
     if @link.make_missing
       redirect("deleted")
-    else
-      flash[:danger] = "Could not delete link."
-      redirect_back
     end
   end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -33,9 +33,8 @@ class LinksController < ApplicationController
   end
 
   def destroy
-    if @link.make_missing
-      redirect("deleted")
-    end
+    @link.make_missing
+    redirect("deleted")
   end
 
   def homepage_links_status_csv

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   root to: "links#index"
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::SidekiqRedis,
+  )
 
   resources "local_authorities", only: %i[index show], param: :local_authority_slug do
     member do

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe LinksController, type: :controller do
     @local_authority = create(:local_authority)
     @service = create(:service)
     @interaction = create(:interaction)
+    @service_interaction = create(:service_interaction, service: @service, interaction: @interaction)
+  end
+
+  describe "GET destroy" do
+    it "deletes link and redirects" do
+      get :destroy, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug }
+      expect(response).to have_http_status(302)
+      expect(flash[:success]).to match("Link has been deleted")
+    end
   end
 
   describe "GET edit" do

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,8 +1,21 @@
 RSpec.describe "healthcheck path", type: :request do
-  it "should respond with 'OK'" do
+  before do
     get "/healthcheck"
+  end
 
-    expect(response.status).to eq(200)
-    expect(response.body).to eq("OK")
+  it "returns a 200 HTTP status" do
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "returns postgres connection status" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("database_connectivity")
+  end
+
+  it "returns redis connections status" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("redis_connectivity")
   end
 end


### PR DESCRIPTION
Added a new test that tests the 'destroy' path to delete a given link.

Also removed some redundant code that would previously cause the 'destroy'
method to throw an error and redirect back if an invalid link was given.
Such scenarios are now automatically caught by the ActiveRecord validations
since this change (https://github.com/alphagov/local-links-manager/commit/ac607b4888fecf55b741099428ef18f06e08fc61)

https://trello.com/c/uAx6eKAQ/2276-activate-continuous-deployment-for-local-links-manager