### PR TITLE
Add route for new Redis Healthcheck

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
-    GovukHealthcheck::SidekiqRedis,
+    GovukHealthcheck::Redis,
   )
 
   resources "local_authorities", only: %i[index show], param: :local_authority_slug do

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe "healthcheck path", type: :request do
   it "returns redis connections status" do
     json = JSON.parse(response.body)
 
-    expect(json["checks"]).to include("redis_connectivity")
+    expect(json["checks"]).to include("redis")
   end
 end


### PR DESCRIPTION
SidekiqRedis route was added in error, and now the Redis
Healthcheck has now been moved out to `govuk_app_config`
as it is used by more than one application.

Trello: https://trello.com/c/uAx6eKAQ/2276-activate-continuous-deployment-for-local-links-manager