### PR TITLE
Switch to MemCacheStore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    dalli (2.7.10)
+    dalli (2.7.11)
     debug_inspector (0.0.3)
     declarative (0.0.20)
     declarative-option (0.1.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # use memcached in Production
-  config.cache_store = :dalli_store, nil, { namespace: :local_links_manager }
+  config.cache_store = :mem_cache_store, { namespace: :local_links_manager }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
This fixes an issue where the Dalli store is not supported in Rails 6.1: https://github.com/petergoldstein/dalli/issues/771

Will fix https://sentry.io/organizations/govuk/issues/2152177745/?project=202234&query=is%3Aunresolved and https://sentry.io/organizations/govuk/issues/2152223231/?project=202234&query=is%3Aunresolved.