### PR TITLE
Add rake task to enable or create services

### DIFF
--- a/docs/enable-or-create-service.md
+++ b/docs/enable-or-create-service.md
@@ -1,4 +1,4 @@
-# Adding a new LGSL code
+# Enabling (or creating) a new service
 
 From time to time, we have requests to add new LGSL codes. For this,
 you'll need to know the LGSL code, the description of the service and
@@ -31,10 +31,12 @@ against the Publisher app.
 ## 3. Activate relevant service interactions
 You can either do this by creating a local transaction in Publisher, but this
 may show the transaction on the live site before the links are ready, so check
-with your product manager to make sure this is OK, or use a migration instead.
+with your product manager to make sure this is OK.
 
-See [20190603131841_enable_service1788.rb](../db/migrate/20190603131841_enable_service1788.rb)
-for an example of the data migration.
+Or use the [`service:enable`](../lib/tasks/service.rb) rake task instead. If
+you need to create a new service that has not been defined by the Local
+Government Association, you can specify a dummy LGSL code, along with a label
+and slug to create a new service.
 
 ## 4. Add missing links for new service interaction
 Run the rake task `import:missing_links`.

--- a/lib/tasks/service.rake
+++ b/lib/tasks/service.rake
@@ -1,0 +1,39 @@
+namespace :service do
+  desc "Enable or create a service."
+  task :enable, %i[lgsl lgil label slug] => [:environment] do |_, args|
+    lgsl = args.lgsl
+    # LGIL is deprecated concept, defaults to PROVIDING INFORMATION
+    lgil = args.lgil || Interaction::PROVIDING_INFORMATION_LGIL
+
+    # Provide a label and slug if creating a service that doesn't exist
+    label = args.label
+    slug = args.slug
+
+    service = Service.find_by(lgsl_code: lgsl)
+
+    if slug && label && service.nil?
+      service = Service.create!(
+        lgsl_code: lgsl,
+        label: label,
+        slug: slug,
+      )
+    end
+    abort "Service [#{lgsl}] does not exist" unless service
+
+    interaction = Interaction.find_by(lgil_code: lgil)
+    abort "Interaction [#{lgil}] does not exist" unless interaction
+
+    service.update!(enabled: true)
+
+    # Creating all service tiers (check if your service requires all)
+    ServiceTier.create_tiers([Tier.district, Tier.unitary, Tier.county], service)
+
+    service_interaction = ServiceInteraction.find_or_create_by!(
+      service: service,
+      interaction: interaction,
+    )
+    abort "Service Interaction between [#{lgsl}] and [#{lgil}] does not exist" unless service_interaction
+
+    service_interaction.update!(live: true)
+  end
+end


### PR DESCRIPTION
This adds a rake task that can be used to enable an existing service or create a dummy service (if not defined by LGA). Enabling a service involves making them live and creating the service interaction. This used the "providing information" interaction by default (i.e. argument unspecified). This superseded the migrations used to enable services and makes it easier to enable new services. Migration should probably not be used for defining data added to the database.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️