### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(
-    beforeTest: {
-      sh("yarn install")
-    },
-    brakeman: true,
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
Yarn install is now done automatically and brakeman doesn't need to be set as an option to run.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️