### PR TITLE
Fix issue with URLs not showing on the Service `show` page

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -8,7 +8,7 @@ class ServicesController < ApplicationController
 
   def show
     @service = Service.find_by!(slug: params[:service_slug])
-    @local_authorities = @service.local_authorities.order(name: :asc)
+    @local_authorities = @service.local_authority_links.order(name: :asc)
     @link_count = links_for_service.count
     @link_filter = params[:filter]
     @links = links_for_service.group_by(&:local_authority_id)
@@ -19,7 +19,7 @@ private
   def links_for_service
     @links_for_service ||= filtered_links(@service.links)
       .includes(%i[service interaction local_authority])
-      .where(local_authority: @service.local_authorities)
+      .where(local_authority: @service.local_authority_links)
       .all
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,6 +6,7 @@ class Service < ApplicationRecord
   has_many :interactions, through: :service_interactions
   has_many :service_tiers, dependent: :restrict_with_error
   has_many :local_authorities, through: :service_tiers
+  has_many :local_authority_links, through: :links, source: :local_authority
 
   scope :enabled, -> { where(enabled: true) }
 


### PR DESCRIPTION
## What

URL's are not showing on the service by local authority link list on local links manager.  For example: [the Covid-19 lateral flow test site](https://local-links-manager.publishing.service.gov.uk/services/find-covid-19-lateral-flow-test-site).

Service links for a local authority should be visible to the user.

## Why

Users are being incorrectly informed that a service link for a specific local authority does not exist.  However, on [editing](https://local-links-manager.publishing.service.gov.uk/local_authorities/allerdale/services/find-covid-19-lateral-flow-test-site/providing-information/edit) or by navigating to the [local authority link list](https://local-links-manager.publishing.service.gov.uk/local_authorities/allerdale) they find that a URL is present.

This makes the user experience inconsistent and causes confusion.

[Trello](https://trello.com/c/1tCo0ACJ/772-urls-not-showing-in-local-links-manager)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️