### PR TITLE
Fix broken link to create or enable service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Links for each local authority are available via data replication.
 
 ## Detailed documentation
 
-- [Adding a new LGSL code](/docs/adding-a-new-lgsl-code.md)
+- [Enable or create a service](/docs/enable-or-create-service.md)
 - [Deleting a local transaction link](/docs/deleting-a-link.md)
 - [Importing Local Authorities data](/docs/importing-local-authorities-data.md)
 - [Exporting Local Authority links to services](/docs/exporting-local-authority-links.md)


### PR DESCRIPTION
This fixes a broken link on the README to a document that has now been
superseded by enable-or-create-service.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️