### PR TITLE
Add functionality to change the LGSL code of a service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -4,7 +4,7 @@ class Service < ApplicationRecord
   has_many :service_interactions, dependent: :destroy
   has_many :links, through: :service_interactions
   has_many :interactions, through: :service_interactions
-  has_many :service_tiers, dependent: :restrict_with_error
+  has_many :service_tiers, dependent: :destroy
   has_many :local_authorities, through: :service_tiers
 
   scope :enabled, -> { where(enabled: true) }

--- a/lib/tasks/service.rake
+++ b/lib/tasks/service.rake
@@ -36,4 +36,26 @@ namespace :service do
 
     service_interaction.update!(live: true)
   end
+
+  desc "Duplicates an existing Service"
+  task :duplicate, %w[from_lgsl_code to_lgsl_code] => :environment do |_, args|
+    old_service = Service.find_by!(lgsl_code: args.from_lgsl_code)
+
+    ActiveRecord::Base.transaction do
+      new_service = old_service.dup
+
+      new_service.assign_attributes(
+        lgsl_code: args.to_lgsl_code,
+        label: "Transitioning #{old_service.label}",
+        slug: "transitioning-#{old_service.slug}",
+      )
+      new_service.save!
+
+      new_service.service_interactions = old_service.service_interactions.map do |si|
+        si.dup.tap { |new_si| new_si.links = si.links.map(&:dup) }
+      end
+
+      new_service.service_tiers = old_service.service_tiers.map(&:dup)
+    end
+  end
 end

--- a/lib/tasks/service.rake
+++ b/lib/tasks/service.rake
@@ -64,4 +64,10 @@ namespace :service do
     service = Service.find_by!(lgsl_code: args.lgsl_code)
     service.update!(label: args.label, slug: args.slug)
   end
+
+  desc "Destroys an existing Service and all dependant records"
+  task :destroy, %w[lgsl_code] => :environment do |_, args|
+    service = Service.find_by!(lgsl_code: args.lgsl_code)
+    service.destroy!
+  end
 end

--- a/lib/tasks/service.rake
+++ b/lib/tasks/service.rake
@@ -58,4 +58,10 @@ namespace :service do
       new_service.service_tiers = old_service.service_tiers.map(&:dup)
     end
   end
+
+  desc "Updates the label and slug of an existing Service"
+  task :rename, %w[lgsl_code label slug] => :environment do |_, args|
+    service = Service.find_by!(lgsl_code: args.lgsl_code)
+    service.update!(label: args.label, slug: args.slug)
+  end
 end

--- a/spec/lib/tasks/service_spec.rb
+++ b/spec/lib/tasks/service_spec.rb
@@ -1,0 +1,25 @@
+describe "Service tasks" do
+  describe "service:duplicate" do
+    it "duplicates the service" do
+      old_service = create(:service, :all_tiers, lgsl_code: 1)
+
+      service_interaction1 = create(:service_interaction, service: old_service)
+      create_list(:link, 3, service_interaction: service_interaction1)
+
+      service_interaction2 = create(:service_interaction, service: old_service)
+      create_list(:link, 3, service_interaction: service_interaction2)
+
+      args = Rake::TaskArguments.new(%i[from_lgsl_code to_lgsl_code], [1, 2])
+      Rake::Task["service:duplicate"].execute(args)
+
+      new_service = Service.find_by!(lgsl_code: 2)
+
+      expect(new_service.label).to eq("Transitioning #{old_service.label}")
+      expect(new_service.slug).to eq("transitioning-#{old_service.slug}")
+
+      expect(new_service.interactions.count).to eq(old_service.interactions.count)
+      expect(new_service.service_interactions.count).to eq(old_service.service_interactions.count)
+      expect(new_service.links.count).to eq(old_service.links.count)
+    end
+  end
+end

--- a/spec/lib/tasks/service_spec.rb
+++ b/spec/lib/tasks/service_spec.rb
@@ -33,4 +33,18 @@ describe "Service tasks" do
         .and change { service.reload.slug }.from(service.slug).to("updated-slug")
     end
   end
+
+  describe "service:destroy" do
+    it "should destroy the service" do
+      service = create(:service, :all_tiers, lgsl_code: 1)
+      service_interaction = create(:service_interaction, service: service)
+      create_list(:link, 3, service_interaction: service_interaction)
+      args = Rake::TaskArguments.new(%i[lgsl_code], [1])
+
+      expect { Rake::Task["service:destroy"].execute(args) }
+        .to change { Service.count }.from(1).to(0)
+        .and change { ServiceInteraction.count }.from(1).to(0)
+        .and change { Link.count }.from(3).to(0)
+    end
+  end
 end

--- a/spec/lib/tasks/service_spec.rb
+++ b/spec/lib/tasks/service_spec.rb
@@ -22,4 +22,15 @@ describe "Service tasks" do
       expect(new_service.links.count).to eq(old_service.links.count)
     end
   end
+
+  describe "service:rename" do
+    it "should update the label and the slug" do
+      service = create(:service, :all_tiers, lgsl_code: 1)
+      args = Rake::TaskArguments.new(%i[lgsl_code label slug], [1, "Updated label", "updated-slug"])
+
+      expect { Rake::Task["service:rename"].execute(args) }
+        .to change { service.reload.label }.from(service.label).to("Updated label")
+        .and change { service.reload.slug }.from(service.slug).to("updated-slug")
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,8 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+Rails.application.load_tasks
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
## What

This adds the functionality to change the LGSL code of a service in `LocalLinksManager`.

To change the LGSL code of a service fully it involves at least two systems: `LocalLinksManager` and [`Publisher`](https://github.com/alphagov/publisher).  It may also include [`Frontend`](https://github.com/alphagov/frontend) if the service is a `LocalTransaction` that is not available in one or more of the devolved nations.  

The outline of the overall process is:

1. [OPTIONAL STEP] In `Frontend` - duplicate any configuration that may be required by the service in [`local_transaction_config.yml`](https://github.com/alphagov/frontend/blob/master/lib/config/local_transaction_config.yml) 

2. In `LocalLinksManager` - create a [duplicate](https://github.com/alphagov/local-links-manager/pull/776/commits/c4c3aa37faa3542e1b0b01944b9789b34d478f13) of the service and all its child records.  The child records need to be linked to the new service.  As both the `label` and `slug` of a service must be unique - the duplicate is created with using a temporary `label` and `slug` that is based on the actual one in the old service but different enough to allow the duplication to take place.

3. In `Publisher` - update the LGSL codes so that the equivalent service there points to the new service in `LocalLinksManager`.

4. In `LocalLinksManager` - [remove](https://github.com/alphagov/local-links-manager/pull/776/commits/28edb6aad7f370339f9ff96cbe528b6b5bfada01) the old service and all its child records.  This switches the service over from the old service to the new (duplicated) service.

5. In `LocalLinksManager` - [update](https://github.com/alphagov/local-links-manager/pull/776/commits/0eb817141f1cb7451e73cdae88700a7b62fe3dbf) the service `label` and `slug` to correct the temporary versions given to them in the duplication step above.

6. In `Publisher` - update the service LGSL code in [local_services.csv](https://github.com/alphagov/publisher/blob/master/data/local_services.csv) from the old to the new service.  This is done because if the [`local_transactions:fetch_and_clean`](https://github.com/alphagov/publisher/blob/master/lib/tasks/local_transactions.rake) rake task were to be re-run - the old service would be re-created at that point and the new service would not - leading to an un-desirable state.

7.  [OPTIONAL STEP] In `Frontend` - remove any configuration that may exist for the old service in [`local_transaction_config.yml`](https://github.com/alphagov/frontend/blob/master/lib/config/local_transaction_config.yml) 

## Why

When the [`find-covid-19-lateral-flow-test-site`](https://www.gov.uk/find-covid-19-lateral-flow-test-site) service was originally created, it used a dummy LGSL code (100001).  We now have a real LGSL code for this service (1827) and would like to use this LGSL code instead of the dummy code.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️