### PR TITLE
Remove the service duplicate and rename tasks

### DIFF
--- a/lib/tasks/service.rake
+++ b/lib/tasks/service.rake
@@ -37,34 +37,6 @@ namespace :service do
     service_interaction.update!(live: true)
   end
 
-  desc "Duplicates an existing Service"
-  task :duplicate, %w[from_lgsl_code to_lgsl_code] => :environment do |_, args|
-    old_service = Service.find_by!(lgsl_code: args.from_lgsl_code)
-
-    ActiveRecord::Base.transaction do
-      new_service = old_service.dup
-
-      new_service.assign_attributes(
-        lgsl_code: args.to_lgsl_code,
-        label: "Transitioning #{old_service.label}",
-        slug: "transitioning-#{old_service.slug}",
-      )
-      new_service.save!
-
-      new_service.service_interactions = old_service.service_interactions.map do |si|
-        si.dup.tap { |new_si| new_si.links = si.links.map(&:dup) }
-      end
-
-      new_service.service_tiers = old_service.service_tiers.map(&:dup)
-    end
-  end
-
-  desc "Updates the label and slug of an existing Service"
-  task :rename, %w[lgsl_code label slug] => :environment do |_, args|
-    service = Service.find_by!(lgsl_code: args.lgsl_code)
-    service.update!(label: args.label, slug: args.slug)
-  end
-
   desc "Destroys an existing Service and all dependant records"
   task :destroy, %w[lgsl_code] => :environment do |_, args|
     service = Service.find_by!(lgsl_code: args.lgsl_code)

--- a/spec/lib/tasks/service_spec.rb
+++ b/spec/lib/tasks/service_spec.rb
@@ -1,39 +1,4 @@
 describe "Service tasks" do
-  describe "service:duplicate" do
-    it "duplicates the service" do
-      old_service = create(:service, :all_tiers, lgsl_code: 1)
-
-      service_interaction1 = create(:service_interaction, service: old_service)
-      create_list(:link, 3, service_interaction: service_interaction1)
-
-      service_interaction2 = create(:service_interaction, service: old_service)
-      create_list(:link, 3, service_interaction: service_interaction2)
-
-      args = Rake::TaskArguments.new(%i[from_lgsl_code to_lgsl_code], [1, 2])
-      Rake::Task["service:duplicate"].execute(args)
-
-      new_service = Service.find_by!(lgsl_code: 2)
-
-      expect(new_service.label).to eq("Transitioning #{old_service.label}")
-      expect(new_service.slug).to eq("transitioning-#{old_service.slug}")
-
-      expect(new_service.interactions.count).to eq(old_service.interactions.count)
-      expect(new_service.service_interactions.count).to eq(old_service.service_interactions.count)
-      expect(new_service.links.count).to eq(old_service.links.count)
-    end
-  end
-
-  describe "service:rename" do
-    it "should update the label and the slug" do
-      service = create(:service, :all_tiers, lgsl_code: 1)
-      args = Rake::TaskArguments.new(%i[lgsl_code label slug], [1, "Updated label", "updated-slug"])
-
-      expect { Rake::Task["service:rename"].execute(args) }
-        .to change { service.reload.label }.from(service.label).to("Updated label")
-        .and change { service.reload.slug }.from(service.slug).to("updated-slug")
-    end
-  end
-
   describe "service:destroy" do
     it "should destroy the service" do
       service = create(:service, :all_tiers, lgsl_code: 1)


### PR DESCRIPTION
These rake tasks were created specifically for migrating the dummy LGSL
code (100001) to a real LGSL code (1827).

As the service 100001 no longer exists - it is now 1827 - we can remove
these rake tasks.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️