### PR TITLE
Allow API requests with GSS Code instead of slug

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -22,11 +22,11 @@ class ApiController < ApplicationController
 private
 
   def missing_required_params_for_link?
-    params[:authority_slug].blank? || params[:lgsl].blank?
+    (params[:authority_slug].blank? && params[:gss].blank?) || params[:lgsl].blank?
   end
 
   def missing_required_params_for_local_authority?
-    params[:authority_slug].blank?
+    params[:authority_slug].blank? && params[:gss].blank?
   end
 
   def missing_objects_for_link?
@@ -38,7 +38,11 @@ private
   end
 
   def authority
-    @authority ||= LocalAuthority.find_by(slug: params[:authority_slug])
+    @authority ||= if params[:authority_slug]
+                     LocalAuthority.find_by(slug: params[:authority_slug])
+                   elsif params[:gss]
+                     LocalAuthority.find_by(gss: params[:gss])
+                   end
   end
 
   def service

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -24,6 +24,7 @@ private
       "homepage_url" => local_authority.homepage_url,
       "country_name" => local_authority.country_name,
       "tier" => local_authority.tier,
+      "slug" => local_authority.slug,
     }
   end
 

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "find local authority", type: :request do
         slug: "rochester",
         homepage_url: "http://rochester.example.com",
         country_name: "England",
+        gss: "E123",
       )
     end
     let!(:local_authority) do
@@ -17,6 +18,7 @@ RSpec.describe "find local authority", type: :request do
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
         parent_local_authority: parent_local_authority,
+        gss: "E456",
       )
     end
 
@@ -71,8 +73,15 @@ RSpec.describe "find local authority", type: :request do
       }
     end
 
-    it "returns details of the council in the api response" do
+    it "returns details of the council in the api response when using slug" do
       get "/api/local-authority?authority_slug=blackburn"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+
+    it "returns details of the council in the api response when using GSS code" do
+      get "/api/local-authority?gss=E123"
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response)
@@ -89,8 +98,15 @@ RSpec.describe "find local authority", type: :request do
   end
 
   context "for requests with parameters that do not refer to data" do
-    it "returns a 404 status" do
+    it "returns a 404 status when an invalid slug is used" do
       get "/api/local-authority?authority_slug=foobar"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "returns a 404 status when an invalid GSS code is used" do
+      get "/api/local-authority?gss=S999"
 
       expect(response.status).to eq(404)
       expect(JSON.parse(response.body)).to eq({})


### PR DESCRIPTION
We currently assign each local authority a slug. API requests have the GET parameter `authority_slug`.

This allows the use of an alternative data source (e.g. the Ordnance Survey Names API) that provides us with the GSS Code.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/2x6Eh2b3)