### PR TITLE
Remove sdoc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,3 @@ group :test do
   gem "timecop"
   gem "webmock"
 end
-
-group :doc do
-  gem "sdoc"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.2)
     rake (13.0.6)
-    rdoc (6.2.1)
     redis (4.2.1)
     regexp_parser (1.8.2)
     representable (3.0.4)
@@ -372,8 +371,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (1.1.0)
-      rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -479,7 +476,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
-  sdoc
   shoulda-matchers
   simplecov
   timecop


### PR DESCRIPTION
Nothing is using this. This removal was prompted by: https://github.com/alphagov/local-links-manager/pull/834

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️