### PR TITLE
Remove 'import:local_authorities:import_authorities' rake task

### DIFF
--- a/lib/tasks/import/local_authorities.rake
+++ b/lib/tasks/import/local_authorities.rake
@@ -3,13 +3,8 @@ require_relative "../../../app/lib/local_links_manager/import/local_authorities_
 
 namespace :import do
   namespace :local_authorities do
-    desc "Import all local authority properties"
-    task import_all: :environment do
-      Rake::Task["import:local_authorities:import_authorities"].invoke
-    end
-
     desc "Import local authority names, codes and tiers from MapIt"
-    task import_authorities: :environment do
+    task import_all: :environment do
       service_desc = "Import local authorities into local-links-manager"
       response = LocalLinksManager::Import::LocalAuthoritiesImporter.import_from_mapit
       Services.icinga_check(service_desc, response.successful?.to_s, response.message)


### PR DESCRIPTION
All the 'import:local_authorities:import_all' task did was invoke
the 'import_authorities' rake task, which wasn't invoked from
anywhere else.

Both tasks were added in the same commit 6 years ago
(4bb25db537576ad7b0a468f4c4a7e3bf999038a1), but the commit message
offers no insights as to why there may be two tasks doing the same
thing. This therefore looks safe to remove.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️