### PR TITLE
Add migration to move service to higher local authority level

### DIFF
--- a/db/migrate/20220221141118_update_leicestershire_street_parties_permission.rb
+++ b/db/migrate/20220221141118_update_leicestershire_street_parties_permission.rb
@@ -1,0 +1,11 @@
+class UpdateLeicestershireStreetPartiesPermission < ActiveRecord::Migration[7.0]
+  def up
+    service = Service.find_by(slug: "street-parties-permission")
+
+    local_authorities = LocalAuthority.where(parent_local_authority: LocalAuthority.find_by(slug: "leicestershire"))
+
+    local_authorities.each do |la|
+      Link.where(local_authority_id: la.id, service_interaction_id: service.service_interaction_ids).destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_173354) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_02_21_141118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Street Party Permissions in Leicestershire are handled at the county council (upper tier) level.

Currently there is a link for each lower tier authority.

Leicestershire County Council would like to display a link to their website instead. Removing the links to each lower tier authority will enable this.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4882121)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️