### PR TITLE
Add methods to look up local authority (and links) by Local Custodian Code

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -26,7 +26,7 @@ private
   end
 
   def missing_required_params_for_local_authority?
-    params[:authority_slug].blank?
+    params[:authority_slug].blank? && params[:local_custodian_code].blank?
   end
 
   def missing_objects_for_link?
@@ -38,7 +38,11 @@ private
   end
 
   def authority
-    @authority ||= LocalAuthority.find_by(slug: params[:authority_slug])
+    @authority ||= if params[:authority_slug]
+                     LocalAuthority.find_by(slug: params[:authority_slug])
+                   elsif params[:local_custodian_code]
+                     LocalAuthority.find_by(local_custodian_code: params[:local_custodian_code])
+                   end
   end
 
   def service

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -22,11 +22,19 @@ class ApiController < ApplicationController
 private
 
   def missing_required_params_for_link?
-    (params[:authority_slug].blank? && params[:local_custodian_code].blank?) || params[:lgsl].blank?
+    missing_authority_identity? || conflicting_authority_identity? || params[:lgsl].blank?
   end
 
   def missing_required_params_for_local_authority?
+    missing_authority_identity? || conflicting_authority_identity?
+  end
+
+  def missing_authority_identity?
     params[:authority_slug].blank? && params[:local_custodian_code].blank?
+  end
+
+  def conflicting_authority_identity?
+    params[:authority_slug].present? && params[:local_custodian_code].present?
   end
 
   def missing_objects_for_link?

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -22,7 +22,7 @@ class ApiController < ApplicationController
 private
 
   def missing_required_params_for_link?
-    params[:authority_slug].blank? || params[:lgsl].blank?
+    (params[:authority_slug].blank? && params[:local_custodian_code].blank?) || params[:lgsl].blank?
   end
 
   def missing_required_params_for_local_authority?

--- a/app/presenters/link_api_response_presenter.rb
+++ b/app/presenters/link_api_response_presenter.rb
@@ -24,6 +24,7 @@ private
         "tier" => authority.tier,
         "homepage_url" => authority.homepage_url,
         "country_name" => authority.country_name,
+        "slug" => authority.slug,
       },
     }
   end

--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -24,6 +24,7 @@ private
       "homepage_url" => local_authority.homepage_url,
       "country_name" => local_authority.country_name,
       "tier" => local_authority.tier,
+      "slug" => local_authority.slug,
     }
   end
 

--- a/docs/example-api-output.md
+++ b/docs/example-api-output.md
@@ -2,9 +2,12 @@
 
 **Endoint for local authorities**
 
-`GET /api/local-authority?authority_slug=<authority_slug>`
+`GET /api/local-authority`
 
-This takes parameters for Authority Slug.
+This endpoint takes either an `authority_slug` or a `local_custodian_code` endpoint:
+
+- `GET /api/local-authority?authority_slug=<authority_slug>`
+- `GET /api/local-authority?local_custodian_code=<local_custodian_code>`
 
 Returns a JSON array containing details for the local authority and (if appropriate), the county council that contains the district.
 
@@ -15,13 +18,15 @@ This example is for `GET /api/local-authority?authority_slug=rochford`
     "name" => 'Rochford District Council',
     "homepage_url" => "http://rochford.example.com",
     "country_name" => "England",
-    "tier" => "district"
+    "tier" => "district",
+    "slug" => "rochford"
   },
   {
     "name" => 'Essex County Council',
     "homepage_url" => "http://essex.example.com",
     "country_name" => "England",
-    "tier" => "county"
+    "tier" => "county",
+    "slug" => "essex"
   }
 ]
 ```
@@ -33,7 +38,8 @@ This example is for `GET /api/local-authority?authority_slug=camden`
     "name" => 'Camden Borough Council',
     "homepage_url" => "http://camden.example.com",
     "country_name" => "England",
-    "tier" => "unitary"
+    "tier" => "unitary",
+    "slug" => "camden"
   }
 ]
 ```
@@ -44,7 +50,11 @@ We do not require authentication for this request.
 
 `GET /api/link?authority_slug=<authority_slug>&lgsl=<lgsl>&lgil=<lgil>`
 
-This takes parameters for Authority Slug, LGSL and optionally LGIL.
+Or:
+
+`GET /api/link?local_custodian_code=<local_custodian_code>&lgsl=<lgsl>&lgil=<lgil>`
+
+This takes parameters for Authority Slug or Local Custodian Code, as well as LGSL and (optionally) LGIL.
 
 Returns JSON details for local authority and interaction or just local authority depending whether the LGIL parameter is passed in. If the LGIL is passed in we return the link for the LGIL if it exists. If not then only the local authority details are returned. If the LGIL is not passed in it returns the appropriate fallback link. If no appropriate link is found then once again we only return the local authority details.
 
@@ -56,6 +66,7 @@ Returns JSON details for local authority and interaction or just local authority
       "tier" => "unitary",
       "homepage_url" => "http://blackburn.example.com",
       "country_name" => "England",
+      "slug" => "blackburn",
   },
     "local_interaction" => {
       "lgsl_code" => 2,

--- a/spec/presenters/link_api_response_presenter_spec.rb
+++ b/spec/presenters/link_api_response_presenter_spec.rb
@@ -11,6 +11,7 @@ describe LinkApiResponsePresenter do
           "tier" => authority.tier,
           "homepage_url" => authority.homepage_url,
           "country_name" => authority.country_name,
+          "slug" => authority.slug,
         },
       }
     end

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -12,12 +12,14 @@ describe LocalAuthorityApiResponsePresenter do
               "homepage_url" => authority.homepage_url,
               "country_name" => authority.country_name,
               "tier" => "district",
+              "slug" => authority.slug,
             },
             {
               "name" => parent_local_authority.name,
               "homepage_url" => parent_local_authority.homepage_url,
               "country_name" => parent_local_authority.country_name,
               "tier" => "county",
+              "slug" => parent_local_authority.slug,
             },
           ],
         }
@@ -38,6 +40,7 @@ describe LocalAuthorityApiResponsePresenter do
               "homepage_url" => authority.homepage_url,
               "country_name" => authority.country_name,
               "tier" => "unitary",
+              "slug" => authority.slug,
             },
           ],
         }

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -261,6 +261,13 @@ shared_examples_for "link path" do
       expect(JSON.parse(response.body)).to eq({})
     end
 
+    it "responds with 400 and {} if both authority_slug and local_custodian_code params provided" do
+      get "/api/link?authority_slug=blackburn&local_custodian_code=2372&lgsl=2"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
     it "responds with 400 and {} for missing lgsl param" do
       get "/api/link?#{authority_search}"
 

--- a/spec/requests/api/link_spec.rb
+++ b/spec/requests/api/link_spec.rb
@@ -24,6 +24,7 @@ shared_examples_for "link path" do
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
           "country_name" => "England",
+          "slug" => "blackburn",
         },
         "local_interaction" => {
           "lgsl_code" => 2,
@@ -41,6 +42,7 @@ shared_examples_for "link path" do
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
           "country_name" => "England",
+          "slug" => "blackburn",
         },
       }
     end
@@ -52,6 +54,7 @@ shared_examples_for "link path" do
           "tier" => "unitary",
           "homepage_url" => "http://blackburn.example.com",
           "country_name" => "England",
+          "slug" => "blackburn",
         },
       }
     end
@@ -131,6 +134,7 @@ shared_examples_for "link path" do
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
             "country_name" => "England",
+            "slug" => "blackburn",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -161,6 +165,7 @@ shared_examples_for "link path" do
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
             "country_name" => "England",
+            "slug" => "blackburn",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -193,6 +198,7 @@ shared_examples_for "link path" do
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
             "country_name" => "England",
+            "slug" => "blackburn",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -222,6 +228,7 @@ shared_examples_for "link path" do
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.gov.uk",
             "country_name" => "England",
+            "slug" => "blackburn",
           },
         }
         get "/api/link?#{authority_search}&lgsl=2"

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -30,12 +30,14 @@ RSpec.describe "find local authority", type: :request do
             "homepage_url" => "http://blackburn.example.com",
             "country_name" => "England",
             "tier" => "district",
+            "slug" => "blackburn",
           },
           {
             "name" => "Rochester",
             "homepage_url" => "http://rochester.example.com",
             "country_name" => "England",
             "tier" => "county",
+            "slug" => "rochester",
           },
         ],
       }
@@ -76,6 +78,7 @@ RSpec.describe "find local authority", type: :request do
             "homepage_url" => "http://blackburn.example.com",
             "country_name" => "England",
             "tier" => "unitary",
+            "slug" => "blackburn",
           },
         ],
       }

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -108,6 +108,15 @@ RSpec.describe "find local authority", type: :request do
     end
   end
 
+  context "for requests with too many (potentially conflicting) parameters" do
+    it "returns a 400 status" do
+      get "/api/local-authority?authority_slug=blackburn&local_custodian_code=2372"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+
   context "for requests with parameters that do not refer to data" do
     it "returns a 404 status when an invalid slug is used" do
       get "/api/local-authority?authority_slug=foobar"

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "find local authority", type: :request do
         slug: "rochester",
         homepage_url: "http://rochester.example.com",
         country_name: "England",
+        local_custodian_code: "2265",
       )
     end
     let!(:local_authority) do
@@ -17,6 +18,7 @@ RSpec.describe "find local authority", type: :request do
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
         parent_local_authority: parent_local_authority,
+        local_custodian_code: "2372",
       )
     end
 
@@ -39,8 +41,15 @@ RSpec.describe "find local authority", type: :request do
       }
     end
 
-    it "returns details of the child and parent in the api response" do
+    it "returns details of the child and parent in the api response when searching by slug" do
       get "/api/local-authority?authority_slug=blackburn"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+
+    it "returns details of the child and parent in the api response when searching by local custodian code" do
+      get "/api/local-authority?local_custodian_code=2372"
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response)
@@ -55,6 +64,7 @@ RSpec.describe "find local authority", type: :request do
         slug: "blackburn",
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
+        local_custodian_code: "2372",
       )
     end
 
@@ -71,8 +81,15 @@ RSpec.describe "find local authority", type: :request do
       }
     end
 
-    it "returns details of the council in the api response" do
+    it "returns details of the council in the api response when searching by slug" do
       get "/api/local-authority?authority_slug=blackburn"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+
+    it "returns details of the council in the api response when searching by local custodian code" do
+      get "/api/local-authority?local_custodian_code=2372"
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response)
@@ -89,8 +106,15 @@ RSpec.describe "find local authority", type: :request do
   end
 
   context "for requests with parameters that do not refer to data" do
-    it "returns a 404 status" do
+    it "returns a 404 status when an invalid slug is used" do
       get "/api/local-authority?authority_slug=foobar"
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "returns a 404 status when an invalid local custodian code is used" do
+      get "/api/local-authority?local_custodian_code=9999999"
 
       expect(response.status).to eq(404)
       expect(JSON.parse(response.body)).to eq({})


### PR DESCRIPTION
This is needed so that frontend apps can switch from Mapit to Locations API as their postcode results provider.

Trello: https://trello.com/c/S2gw5MAZ/2933-5-add-methods-for-local-links-manager-to-lookup-local-authority-by-local-custodian-code

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️