### PR TITLE
Add a user interface to edit authority homepage URLs

### DIFF
--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -18,6 +18,13 @@ class LocalAuthoritiesController < ApplicationController
     @link_count = links_for_authority.count
   end
 
+  def update
+    authority = LocalAuthority.find_by!(slug: params[:local_authority_slug])
+    authority.update!(homepage_url: params[:authority][:homepage_url])
+
+    redirect_to local_authority_path(authority)
+  end
+
   def download_links_csv
     @authority = LocalAuthority.find_by!(slug: params[:local_authority_slug])
     authority_name = @authority.name.parameterize.underscore

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -5,6 +5,10 @@
 
   <div>
     Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %><br>
+    <%= form_for(authority) do %>
+      <p><%= text_field :authority, :homepage_url %></p>
+      <p><%= button_tag('Edit homepage URL', class: 'btn btn-default') %></p>
+    <% end %>
     <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
     <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
 

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -4,11 +4,12 @@
   <h1><%= authority.name %></h1>
 
   <div>
-    Homepage <%= link_to_if(authority.homepage_url, nil, authority.homepage_url) %><br>
-    <%= form_for(authority) do %>
-      <p><%= text_field :authority, :homepage_url %></p>
-      <p><%= button_tag('Edit homepage URL', class: 'btn btn-default') %></p>
+    <%= form_for(authority, html: { class: "form-inline" }) do %>
+      <label for="authority_homepage_url">Homepage URL</label>
+      <%= text_field :authority, :homepage_url, class: "form-control input-md-7 inline" %>
+      <%= button_tag('Update', class: 'btn btn-default inline') %>
     <% end %>
+    <p><%= link_to_if(authority.homepage_url, "Visit #{authority.homepage_url}", authority.homepage_url) %></label></p>
     <span class="<%= authority.label_status_class %> text-muted"><b><%= authority.homepage_status %></b></span>
     <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     GovukHealthcheck::Redis,
   )
 
-  resources "local_authorities", only: %i[index show], param: :local_authority_slug do
+  resources "local_authorities", only: %i[index show update], param: :local_authority_slug do
     member do
       get "download_links_csv"
       post "upload_links_csv"

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -13,6 +13,18 @@ feature "The local authority show page" do
     end
   end
 
+  describe "editing the homepage URL" do
+    it "has an edit field for the homepage URL" do
+      expect(page).to have_field("Homepage URL", with: local_authority.homepage_url)
+    end
+
+    it "updates the homepage URL" do
+      fill_in "Homepage URL", with: "https://new.root.gov.uk"
+      click_on "Update"
+      expect(page).to have_link "Visit https://new.root.gov.uk", href: "https://new.root.gov.uk"
+    end
+  end
+
   describe "with no local authority homepage url" do
     it "renders the local authority services page successfully" do
       ni_local_authority = create(:district_council)


### PR DESCRIPTION
Currently local authority homepage URLs are updated by running a rake task. This limits these changes to developers only and results in an unnecessary time consuming process to make such changes.

This adds a basic user interface so the changes can be made by anyone with access to the application.

After this has been deployed, the rake task and related documentation can be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/kA8Ezaap/1397-allow-la-homepage-links-to-be-editable-via-the-llm-ui