### PR TITLE
Expose 'snac' in API response for local authority presenter

### DIFF
--- a/app/presenters/local_authority_api_response_presenter.rb
+++ b/app/presenters/local_authority_api_response_presenter.rb
@@ -25,6 +25,7 @@ private
       "country_name" => local_authority.country_name,
       "tier" => local_authority.tier,
       "slug" => local_authority.slug,
+      "snac" => local_authority.snac,
     }
   end
 

--- a/spec/presenters/local_authority_api_response_presenter_spec.rb
+++ b/spec/presenters/local_authority_api_response_presenter_spec.rb
@@ -13,6 +13,7 @@ describe LocalAuthorityApiResponsePresenter do
               "country_name" => authority.country_name,
               "tier" => "district",
               "slug" => authority.slug,
+              "snac" => authority.snac,
             },
             {
               "name" => parent_local_authority.name,
@@ -20,6 +21,7 @@ describe LocalAuthorityApiResponsePresenter do
               "country_name" => parent_local_authority.country_name,
               "tier" => "county",
               "slug" => parent_local_authority.slug,
+              "snac" => parent_local_authority.snac,
             },
           ],
         }
@@ -41,6 +43,7 @@ describe LocalAuthorityApiResponsePresenter do
               "country_name" => authority.country_name,
               "tier" => "unitary",
               "slug" => authority.slug,
+              "snac" => authority.snac,
             },
           ],
         }

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "find local authority", type: :request do
         :county_council,
         name: "Rochester",
         slug: "rochester",
+        snac: "00LC",
         homepage_url: "http://rochester.example.com",
         country_name: "England",
         local_custodian_code: "2265",
@@ -15,6 +16,7 @@ RSpec.describe "find local authority", type: :request do
         :district_council,
         name: "Blackburn",
         slug: "blackburn",
+        snac: "00AG",
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
         parent_local_authority: parent_local_authority,
@@ -31,6 +33,7 @@ RSpec.describe "find local authority", type: :request do
             "country_name" => "England",
             "tier" => "district",
             "slug" => "blackburn",
+            "snac" => "00AG",
           },
           {
             "name" => "Rochester",
@@ -38,6 +41,7 @@ RSpec.describe "find local authority", type: :request do
             "country_name" => "England",
             "tier" => "county",
             "slug" => "rochester",
+            "snac" => "00LC",
           },
         ],
       }
@@ -64,6 +68,7 @@ RSpec.describe "find local authority", type: :request do
         :unitary_council,
         name: "Blackburn",
         slug: "blackburn",
+        snac: "00AG",
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
         local_custodian_code: "2372",
@@ -79,6 +84,7 @@ RSpec.describe "find local authority", type: :request do
             "country_name" => "England",
             "tier" => "unitary",
             "slug" => "blackburn",
+            "snac" => "00AG",
           },
         ],
       }


### PR DESCRIPTION
This is needed for getting the licence details for a local authority in frontend.
`snac` is currently returned in the API response for link presenter. `lgsl` and `lgil` codes are required for calling this, but are not available for licence content.

Trello card: https://trello.com/c/6TO6GDJM/2934-switch-frontend-to-use-locations-api-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️