### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,41 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Security updates
-      - dependency-name: brakeman
-        dependency-type: direct
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      - dependency-name: gds-api-adapters
-        dependency-type: direct
-      - dependency-name: gds-sso
-        dependency-type: direct
-      - dependency-name: plek
-        dependency-type: direct
-      - dependency-name: rubocop-govuk
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: factory_bot_rails
-        dependency-type: direct
-      - dependency-name: pg
-        dependency-type: direct
-      - dependency-name: rails
-        dependency-type: direct
-      - dependency-name: rspec-rails
-        dependency-type: direct
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Internal packages
-      - dependency-name: stylelint-config-gds
-        dependency-type: direct
-      # Framework packages
-      - dependency-name: standardx
-        dependency-type: direct
-      - dependency-name: stylelint
-        dependency-type: direct


### PR DESCRIPTION
In [RFC-153](https://github.com/alphagov/govuk-rfcs/pull/153), we proposed and agreed to remove 'allow lists' from all [GOV.UK](http://gov.uk/) Dependabot configs, in order to re-enable security updates.

Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️