### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/app/lib/local_links_manager/distributed_lock.rb
+++ b/app/lib/local_links_manager/distributed_lock.rb
@@ -9,7 +9,7 @@ module LocalLinksManager
 
     def initialize(lock_name)
       @lock_name = lock_name
-      @redis_lock = Redis::Lock.new(Redis.current, "#{APP}:#{lock_name}", owner: APP, life: LIFETIME)
+      @redis_lock = Redis::Lock.new(Redis.new, "#{APP}:#{lock_name}", owner: APP, life: LIFETIME)
     end
 
     def lock(lock_obtained:, lock_not_obtained:)


### PR DESCRIPTION
Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

Running link checker rake task with fix in integration: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/304968/console

[1]: https://github.com/alphagov/local-links-manager/pull/956
[2]: https://www.rubydoc.info/github/redis/redis-rb/Redis.current

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️