### PR TITLE
Dockerfile fixes and cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,11 @@
 Dockerfile
 Jenkinsfile
 README.md
+coverage
 docs
+log
+node_modules
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,26 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    rm -fr /app/log
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=local-links-manager
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD bundle exec puma
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.4"
 
 gem "addressable"
+gem "bootsnap", require: false
 gem "dalli"
 gem "gds-api-adapters"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -237,6 +239,7 @@ GEM
     minitest (5.17.0)
     mlanett-redis-lock (0.2.7)
       redis
+    msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
@@ -488,6 +491,7 @@ DEPENDENCIES
   addressable
   better_errors
   binding_of_caller
+  bootsnap
   capistrano-rails
   capybara
   dalli

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -2,9 +2,11 @@ require "redis"
 require "gds_api/publishing_api"
 
 module Services
+  # TODO: icinga_check once local-links-manager is hosted on Kubernetes.
   def self.icinga_check(service_desc, code, message)
-    if Rails.env.production?
-      `/usr/local/bin/notify_passive_check #{service_desc.shellescape} #{code.shellescape} #{message.shellescape}`
+    notify_command = "/usr/local/bin/notify_passive_check".freeze
+    if Rails.env.production? && File.exist?(notify_command)
+      `#{notify_command} #{service_desc.shellescape} #{code.shellescape} #{message.shellescape}`
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module LocalLinksManager
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/local-links-manager"
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Fix Rails assets deployment to S3 by including the app name in the Rails assets path.
- Fix the cron jobs so that they don't fail if Icinga `notify_passive_check` isn't installed.
- Parameterise the Ruby version.
- Enable [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-).
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.