### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "govuk_admin_template"
 gem "govuk_app_config"
 gem "gretel"
 gem "jbuilder"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mlanett-redis-lock"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.3)
+    date (3.3.3)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     diff-lcs (1.5.0)
@@ -225,8 +226,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
@@ -242,11 +246,12 @@ GEM
     msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    net-imap (0.3.1)
+    net-imap (0.3.4)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -443,7 +448,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.6)
-    timeout (0.3.0)
+    timeout (0.3.1)
     trailblazer-option (0.1.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -505,7 +510,6 @@ DEPENDENCIES
   govuk_test
   gretel
   jbuilder
-  mail (~> 2.7.1)
   mlanett-redis-lock
   pg
   plek


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
