### PR TITLE
Add export links CSV to S3 task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.4.1"
 
 gem "addressable"
+gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "dalli"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,22 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.693.0)
+    aws-sdk-core (3.168.4)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.61.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.117.2)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -212,6 +228,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -494,6 +511,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap

--- a/lib/tasks/export/link_exporter.rake
+++ b/lib/tasks/export/link_exporter.rake
@@ -1,6 +1,8 @@
 require_relative "../../../app/lib/local_links_manager/distributed_lock"
 require_relative "../../../app/lib/local_links_manager/export/links_exporter"
 
+require "aws-sdk-s3"
+
 namespace :export do
   namespace :links do
     desc "Export links to CSV"
@@ -17,6 +19,25 @@ namespace :export do
         Rails.logger.error("Error while running link exporter\n#{e}")
         Services.icinga_check(service_desc, "false", e.to_s)
         raise e
+      end
+    end
+
+    # This task duplicates functionality in `export:links:all`, except uploads
+    # the file to S3 instead of storing it locally. This task is to be used by
+    # the cronjob in Kubernetes environments instead.
+    desc "Export links to CSV and upload to S3"
+    task "s3": :environment do
+      filename = "links_to_services_provided_by_local_authorities.csv"
+
+      bucket = ENV["AWS_S3_ASSET_BUCKET_NAME"]
+      key = "data/local-links-manager/#{filename}"
+
+      s3 = Aws::S3::Client.new
+
+      StringIO.open do |body|
+        LocalLinksManager::Export::LinksExporter.new.export(body)
+
+        s3.put_object({ body: body.string, bucket:, key: })
       end
     end
   end


### PR DESCRIPTION
This is task is to replace the functionality of the export:links:all task, except to upload the CSV to an S3 bucket instead of storing it locally. This is needed as we migrate the application to Kubernetes. The static file is generated by separate pod during a cronjob task, which doesn't have a shared volume with the main server pod. Therefore the generated file cannot be served if stored locally and we need to upload the file to S3. Ngnix configuration in EKS will also be updated to serve the file from S3.

Tested it by running it locally and uploading the file to integration.
