### PR TITLE
Add Authority active end date and support for Buckinghamshire Council merge

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,10 @@
   padding-left: 0;
 }
 
+.authority-status-inactive {
+  text-decoration: line-through;
+}
+
 .nav.nav-tabs {
   *[role="presentation"] {
     a {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -47,9 +47,9 @@ private
 
   def authority
     @authority ||= if params[:authority_slug]
-                     LocalAuthority.find_by(slug: params[:authority_slug])
+                     LocalAuthority.find_current_by_slug(params[:authority_slug])
                    elsif params[:local_custodian_code]
-                     LocalAuthority.find_by(local_custodian_code: params[:local_custodian_code])
+                     LocalAuthority.find_current_by_local_custodian_code(params[:local_custodian_code])
                    end
   end
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -46,4 +46,24 @@ class LocalAuthority < ApplicationRecord
   def redirect(to:)
     LocalAuthorityRedirector.call(from: self, to:)
   end
+
+  def active?
+    active_end_date.nil? || (active_end_date > Time.zone.now)
+  end
+
+  def self.find_current_by_slug(slug)
+    la = find_by(slug:)
+    return nil unless la
+    return la if la.active?
+
+    la.parent_local_authority
+  end
+
+  def self.find_current_by_local_custodian_code(local_custodian_code)
+    la = find_by(local_custodian_code:)
+    return nil unless la
+    return la if la.active?
+
+    la.parent_local_authority
+  end
 end

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -26,10 +26,13 @@
     <% @authorities.each do |authority| %>
       <tr>
         <td>
-          <%= link_to authority.name, local_authority_path(authority.slug, filter: 'broken_links'), class: 'js-open-on-submit name' %>
+          <%= link_to authority.name, local_authority_path(authority.slug, filter: 'broken_links'), class: "js-open-on-submit name #{ "authority-status-inactive" if !authority.active? }" %>
           <div class="center count <%= singular_or_plural(authority.broken_link_count) %>">
             <span><%= authority.broken_link_count %></span>
           </div>
+          <% unless authority.active? %>
+            <div class="authority-active-note add-top-padding"><%= authority.active_note %></div>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -14,6 +14,22 @@
     <span class="text-muted"><%= authority.homepage_link_last_checked %></span>
 
     <div>
+      <h3>Status</h3>
+      <div>Current status: <%= authority.active? ? 'active' : 'inactive' %></div>
+      <% unless authority.active? %>
+        <div>Date authority became inactive: <%= authority.active_end_date %></div>
+      <% end %>
+      <% unless authority.active_note.blank? %>
+        <div>Inactive reason: <%= authority.active_note %></div>
+      <% end %>
+      <% if authority.parent_local_authority %>
+        <div>Parent authority: <%= link_to(authority.parent_local_authority.name, local_authority_path(authority.parent_local_authority)) %></div>
+      <% end %>
+      <div>
+    </div>
+
+
+    <div>
       <h3>Download links</h3>
       <p>Produces a CSV which can be altered and uploaded to update your links as a batch.</p>
       <p>

--- a/db/migrate/20230206155322_add_active_end_date_and_active_note_to_local_authority.rb
+++ b/db/migrate/20230206155322_add_active_end_date_and_active_note_to_local_authority.rb
@@ -1,0 +1,8 @@
+class AddActiveEndDateAndActiveNoteToLocalAuthority < ActiveRecord::Migration[7.0]
+  def change
+    change_table :local_authorities, bulk: true do |t|
+      t.datetime :active_end_date, null: true, default: nil
+      t.string :active_note
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_21_141118) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_21_141118) do
     t.string "suggested_fix"
     t.string "country_name"
     t.string "local_custodian_code"
+    t.datetime "active_end_date", precision: nil
+    t.string "active_note"
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true
     t.index ["homepage_url"], name: "index_local_authorities_on_homepage_url"
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true

--- a/lib/tasks/once-off/buckinghamshire_merge.rake
+++ b/lib/tasks/once-off/buckinghamshire_merge.rake
@@ -1,0 +1,19 @@
+namespace :once_off do
+  desc "Set merged counties to inactive as of 1/Apr/2020, ensure parent_local_authority valid"
+  task buckinghamshire_merge: :environment do
+    slugs = %i[aylesbury-vale chiltern south-bucks wycombe]
+    parent = LocalAuthority.find_by(slug: "buckinghamshire")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != parent
+        puts("Warning: parent local authority for #{slug} is not as expected (buckinghamshire)")
+        next
+      end
+
+      la.active_end_date = Time.parse("01-Apr-2020")
+      la.active_note = "Merged into the unitary authority Buckinghamshire Council on 1 April 2020"
+      la.save!
+    end
+  end
+end

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -105,6 +105,62 @@ RSpec.describe "find local authority", type: :request do
     end
   end
 
+  context "for councils that have been merged into a parent authority" do
+    let(:parent_local_authority) do
+      create(
+        :county_council,
+        name: "Rochester",
+        slug: "rochester",
+        snac: "00LC",
+        homepage_url: "http://rochester.example.com",
+        country_name: "England",
+        local_custodian_code: "2265",
+      )
+    end
+    let!(:local_authority) do
+      create(
+        :district_council,
+        name: "Blackburn",
+        slug: "blackburn",
+        snac: "00AG",
+        homepage_url: "http://blackburn.example.com",
+        country_name: "England",
+        parent_local_authority:,
+        local_custodian_code: "2372",
+        active_end_date: Time.zone.now - 1.year,
+      )
+    end
+
+    let(:expected_response) do
+      {
+        "local_authorities" => [
+          {
+            "name" => "Rochester",
+            "homepage_url" => "http://rochester.example.com",
+            "country_name" => "England",
+            "tier" => "county",
+            "slug" => "rochester",
+            "snac" => "00LC",
+          },
+        ],
+      }
+    end
+
+    it "returns details of the parent council in the api response when searching by slug" do
+      get "/api/local-authority?authority_slug=blackburn"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+
+    it "returns details of the parent council in the api response when searching by local custodian code" do
+      get "/api/local-authority?local_custodian_code=2372"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response)
+    end
+  end
+
   context "for requests with missing parameters" do
     it "returns a 400 status" do
       get "/api/local-authority"


### PR DESCRIPTION
Adds two new columns to the LocalAuthority DB: active_end_date and active_note. These support the requirement that certain councils have been and will be merged into new unitary authorities.

Local Authorities now have an `active?` method which allows easy decisions based on whether a particular local authority is now retired. It is assumed at the moment that all such authorities will have a parent authority. When a local authority is inactive, searches for the authority itself or for links in that authority will now return values from the parent authority instead. There are utility search methods `find_current_by_slug` and `find_current_by_local_custodian_code` which take care of the active check and otherwise behave the same as `find_by(slug:)` and `find_by(local_custodian_code:)`

Following on from this change we display the status in the admin UI - in the list of councils, inactive councils are marked with a strikethrough and include the inactive_note, and in the individual authority UI, all authorities now show their status and their parent (if any), and inactive ones show the date they became inactive and the note to show why.

https://trello.com/c/EFnqnTf3/1793-buckinghamshire-add-ability-to-retire-disable-councils-to-support-council-merges-in-april

## Screenshots:
(Please ignore link flags in council pages - one set of screenshots taken on Prod, one on Dev, so no link check report available)

### Before - List of Councils
<img width="1172" alt="index-before" src="https://user-images.githubusercontent.com/4225737/217303516-2bd75307-c056-4f3f-9c7d-fe644a95892c.png">

### After - List of Councils
<img width="1167" alt="index-after" src="https://user-images.githubusercontent.com/4225737/217303536-d97a4630-0833-4877-b7ab-399e01bc4bed.png">

### Before - Council Pages
<img width="894" alt="Wychavon-before" src="https://user-images.githubusercontent.com/4225737/217303586-9a7a8ec0-9a7b-4b0f-b033-d2cd6af831b6.png">
<img width="894" alt="Wycombe-before" src="https://user-images.githubusercontent.com/4225737/217303608-b3368ee1-e1ef-4abb-92f8-2b4f8d6a716f.png">

### After - Council Page (active)
<img width="882" alt="Wychavon-after" src="https://user-images.githubusercontent.com/4225737/217303649-f23bb5b3-3f75-4c1c-ba83-f480cf3b85e9.png">

### After - Council Page (inactive)
<img width="926" alt="Wycombe-after" src="https://user-images.githubusercontent.com/4225737/217303669-c00a961a-35e6-467c-a54b-d3efbd539ccb.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
