### PR TITLE
add somerset_merge rake file

### DIFF
--- a/lib/tasks/once-off/somerset_merge.rake
+++ b/lib/tasks/once-off/somerset_merge.rake
@@ -1,0 +1,20 @@
+namespace :once_off do
+  desc "Set merged counties to inactive as of 1/Apr/2020, ensure parent_local_authority valid"
+  task somerset_merge: :environment do
+    slugs = %i[mendip somerset-west-taunton south-somerset sedgemoor]
+    parent = LocalAuthority.find_by(slug: "somerset")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != parent
+        puts("Warning: parent local authority for #{slug} is not as expected (somerset)")
+        next
+      end
+
+      la.active_end_date = Time.parse("01-Apr-2023")
+      la.active_note = "Merged into the unitary authority Somerset Council on 1 April 2023"
+      la.succeeded_by_local_authority = parent
+      la.save!
+    end
+  end
+end


### PR DESCRIPTION
## What

Mark the 4 merged district councils as retired as of 1st April, ensure that they point to the correct parent council, and that it is marked as a unitary body.

## Why

https://govuk.zendesk.com/agent/tickets/5176591

The following district councils are merging into Somerset County Council:

Somerset West & Taunton

Mendip

South Somerset

Sedgemoor

Trello: https://trello.com/c/NyIDiB39/1844-merge-somerset-west-taunton-council

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
