### PR TITLE
Add succeeded_by field to local authorities

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -11,6 +11,7 @@ class LocalAuthority < ApplicationRecord
 
   has_many :links, dependent: :destroy
   belongs_to :parent_local_authority, class_name: "LocalAuthority", inverse_of: false
+  belongs_to :succeeded_by_local_authority, class_name: "LocalAuthority", inverse_of: false
   has_many :service_tiers, foreign_key: :tier_id, primary_key: :tier_id, inverse_of: :local_authority, dependent: :restrict_with_error
   has_many :services, through: :service_tiers
 
@@ -56,7 +57,7 @@ class LocalAuthority < ApplicationRecord
     return nil unless la
     return la if la.active?
 
-    la.parent_local_authority
+    la.succeeded_by_local_authority
   end
 
   def self.find_current_by_local_custodian_code(local_custodian_code)
@@ -64,6 +65,6 @@ class LocalAuthority < ApplicationRecord
     return nil unless la
     return la if la.active?
 
-    la.parent_local_authority
+    la.succeeded_by_local_authority
   end
 end

--- a/app/presenters/local_authority_presenter.rb
+++ b/app/presenters/local_authority_presenter.rb
@@ -8,4 +8,22 @@ class LocalAuthorityPresenter < SimpleDelegator
   def homepage_link_last_checked
     homepage_url.blank? ? "" : last_checked
   end
+
+  def authority_status
+    return "inactive" unless active?
+    return "active, but being retired" if active_end_date
+
+    "active"
+  end
+
+  def should_display_end_notes?
+    return true unless active?
+    return true if active? && active_end_date
+
+    false
+  end
+
+  def active_end_date_title
+    active? ? "Date authority is due to become inactive" : "Date authority became inactive"
+  end
 end

--- a/app/views/shared/_local_authority_details.html.erb
+++ b/app/views/shared/_local_authority_details.html.erb
@@ -15,12 +15,15 @@
 
     <div>
       <h3>Status</h3>
-      <div>Current status: <%= authority.active? ? 'active' : 'inactive' %></div>
-      <% unless authority.active? %>
-        <div>Date authority became inactive: <%= authority.active_end_date %></div>
-      <% end %>
-      <% unless authority.active_note.blank? %>
-        <div>Inactive reason: <%= authority.active_note %></div>
+      <div>Current status: <%= authority.authority_status %></div>
+      <% if authority.should_display_end_notes? %>
+        <div><%= authority.active_end_date_title %>: <%= authority.active_end_date.strftime("%F") %></div>
+        <% unless authority.active_note.blank? %>
+          <div>Reason: <%= authority.active_note %></div>
+        <% end %>
+        <% if authority.succeeded_by_local_authority %>
+          <div>Succeeding authority: <%= link_to(authority.succeeded_by_local_authority.name, local_authority_path(authority.succeeded_by_local_authority)) %></div>
+        <% end %>
       <% end %>
       <% if authority.parent_local_authority %>
         <div>Parent authority: <%= link_to(authority.parent_local_authority.name, local_authority_path(authority.parent_local_authority)) %></div>

--- a/db/migrate/20230307103144_add_succeeded_by_local_authority_id_to_local_authority.rb
+++ b/db/migrate/20230307103144_add_succeeded_by_local_authority_id_to_local_authority.rb
@@ -1,0 +1,5 @@
+class AddSucceededByLocalAuthorityIdToLocalAuthority < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :local_authorities, :succeeded_by_local_authority, type: :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_103144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "interactions", id: :serial, force: :cascade do |t|
     t.integer "lgil_code", null: false
     t.string "label", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug", null: false
     t.index ["label"], name: "index_interactions_on_label", unique: true
     t.index ["lgil_code"], name: "index_interactions_on_lgil_code", unique: true
@@ -28,13 +28,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
     t.integer "local_authority_id", null: false
     t.integer "service_interaction_id", null: false
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "status"
-    t.datetime "link_last_checked"
+    t.datetime "link_last_checked", precision: nil
+    t.integer "analytics", default: 0, null: false
     t.string "link_errors", default: [], null: false, array: true
     t.string "link_warnings", default: [], null: false, array: true
-    t.integer "analytics", default: 0, null: false
     t.string "problem_summary"
     t.string "suggested_fix"
     t.index ["analytics"], name: "index_links_on_analytics"
@@ -51,10 +51,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
     t.string "name", null: false
     t.string "slug", null: false
     t.string "snac", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "status"
-    t.datetime "link_last_checked"
+    t.datetime "link_last_checked", precision: nil
     t.integer "parent_local_authority_id"
     t.integer "broken_link_count", default: 0
     t.integer "tier_id"
@@ -66,17 +66,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
     t.string "local_custodian_code"
     t.datetime "active_end_date", precision: nil
     t.string "active_note"
+    t.integer "succeeded_by_local_authority_id"
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true
     t.index ["homepage_url"], name: "index_local_authorities_on_homepage_url"
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true
     t.index ["snac"], name: "index_local_authorities_on_snac", unique: true
+    t.index ["succeeded_by_local_authority_id"], name: "index_local_authorities_on_succeeded_by_local_authority_id"
   end
 
   create_table "service_interactions", id: :serial, force: :cascade do |t|
     t.integer "service_id"
     t.integer "interaction_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "govuk_slug"
     t.string "govuk_title"
     t.boolean "live"
@@ -87,7 +89,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
   create_table "service_tiers", id: :serial, force: :cascade do |t|
     t.integer "tier_id", null: false
     t.integer "service_id", null: false
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["service_id", "tier_id"], name: "index_service_tiers_on_service_id_and_tier_id", unique: true
     t.index ["service_id"], name: "index_service_tiers_on_service_id"
     t.index ["tier_id"], name: "index_service_tiers_on_tier_id"
@@ -96,8 +98,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
   create_table "services", id: :serial, force: :cascade do |t|
     t.integer "lgsl_code", null: false
     t.string "label", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug", null: false
     t.boolean "enabled", default: false, null: false
     t.integer "broken_link_count", default: 0
@@ -114,8 +116,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_155322) do
     t.text "permissions"
     t.boolean "remotely_signed_out", default: false
     t.boolean "disabled", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   add_foreign_key "links", "local_authorities"

--- a/lib/tasks/once-off/buckinghamshire_merge.rake
+++ b/lib/tasks/once-off/buckinghamshire_merge.rake
@@ -13,6 +13,7 @@ namespace :once_off do
 
       la.active_end_date = Time.parse("01-Apr-2020")
       la.active_note = "Merged into the unitary authority Buckinghamshire Council on 1 April 2020"
+      la.succeeded_by_local_authority = parent
       la.save!
     end
   end

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -55,6 +55,38 @@ feature "The local authority show page" do
     end
   end
 
+  describe "with an inactive council" do
+    it "renders the end information successfully" do
+      succeeded_by = create(:county_council)
+      ni_local_authority = create(:district_council, active_end_date: Time.zone.now - 1.year, active_note: "Merged", succeeded_by_local_authority: succeeded_by)
+      visit local_authority_path(local_authority_slug: ni_local_authority.slug)
+      expect(page.status_code).to eq(200)
+
+      within(:css, ".page-title") do
+        expect(page).to have_content("Current status: inactive")
+        expect(page).to have_content("Date authority became inactive:")
+        expect(page).to have_content("Reason: Merged")
+        expect(page).to have_link(succeeded_by.name, href: "/local_authorities/#{succeeded_by.slug}")
+      end
+    end
+  end
+
+  describe "with a to-be inactive council" do
+    it "renders the end information successfully" do
+      succeeded_by = create(:county_council)
+      ni_local_authority = create(:district_council, active_end_date: Time.zone.now + 1.year, active_note: "Will be merged", succeeded_by_local_authority: succeeded_by)
+      visit local_authority_path(local_authority_slug: ni_local_authority.slug)
+      expect(page.status_code).to eq(200)
+
+      within(:css, ".page-title") do
+        expect(page).to have_content("Current status: active, but being retired")
+        expect(page).to have_content("Date authority is due to become inactive:")
+        expect(page).to have_content("Reason: Will be merged")
+        expect(page).to have_link(succeeded_by.name, href: "/local_authorities/#{succeeded_by.slug}")
+      end
+    end
+  end
+
   describe "with services present" do
     let(:service) { create(:service, :all_tiers) }
     let(:disabled_service) { create(:disabled_service) }

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe LocalAuthority, type: :model do
       expect(LocalAuthority.find_current_by_slug(local_authority.slug)).to eq local_authority
     end
 
-    it "returns the parent authority if the authority is inactive" do
-      parent_authority = create(:county_council)
-      local_authority = create(:district_council, parent_local_authority: parent_authority, active_end_date: Time.zone.now - 1.year)
-      expect(LocalAuthority.find_current_by_slug(local_authority.slug)).to eq parent_authority
+    it "returns the succeeded_by authority if the authority is inactive" do
+      succeeded_by_authority = create(:county_council)
+      local_authority = create(:district_council, succeeded_by_local_authority: succeeded_by_authority, active_end_date: Time.zone.now - 1.year)
+      expect(LocalAuthority.find_current_by_slug(local_authority.slug)).to eq succeeded_by_authority
     end
   end
 
@@ -112,10 +112,10 @@ RSpec.describe LocalAuthority, type: :model do
       expect(LocalAuthority.find_current_by_local_custodian_code(local_authority.local_custodian_code)).to eq local_authority
     end
 
-    it "returns the parent authority if the authority is inactive" do
-      parent_authority = create(:county_council)
-      local_authority = create(:district_council, parent_local_authority: parent_authority, active_end_date: Time.zone.now - 1.year)
-      expect(LocalAuthority.find_current_by_local_custodian_code(local_authority.local_custodian_code)).to eq parent_authority
+    it "returns the succeeded_by authority if the authority is inactive" do
+      succeeded_by_authority = create(:county_council)
+      local_authority = create(:district_council, succeeded_by_local_authority: succeeded_by_authority, active_end_date: Time.zone.now - 1.year)
+      expect(LocalAuthority.find_current_by_local_custodian_code(local_authority.local_custodian_code)).to eq succeeded_by_authority
     end
   end
 

--- a/spec/presenters/local_authority_presenter_spec.rb
+++ b/spec/presenters/local_authority_presenter_spec.rb
@@ -3,10 +3,10 @@ require "support/url_status_presentation"
 describe LocalAuthorityPresenter do
   it_behaves_like "a UrlStatusPresentation module"
 
-  describe "#homepage_status" do
-    let(:local_authority) { double(:local_authority) }
-    let(:presenter) { described_class.new(local_authority) }
+  let(:local_authority) { double(:local_authority) }
+  let(:presenter) { described_class.new(local_authority) }
 
+  describe "#homepage_status" do
     it "returns the homepage URL's status description if a URL is present" do
       allow(local_authority).to receive(:homepage_url).and_return("http://example.com")
       allow(local_authority).to receive(:status).and_return("ok")
@@ -25,9 +25,6 @@ describe LocalAuthorityPresenter do
   end
 
   describe "#homepage_link_last_checked" do
-    let(:local_authority) { double(:local_authority) }
-    let(:presenter) { described_class.new(local_authority) }
-
     it "returns the time the URL was last checked if a URL is present" do
       time = Timecop.freeze(Time.zone.now)
       allow(local_authority).to receive(:homepage_url).and_return("http://example.com")
@@ -44,6 +41,56 @@ describe LocalAuthorityPresenter do
     it "returns an empty string if the homepage URL is set to an empty string" do
       allow(local_authority).to receive(:homepage_url).and_return("")
       expect(presenter.homepage_link_last_checked).to be_empty
+    end
+  end
+
+  describe "#authority_status" do
+    it "returns active if currently active and no end date specified" do
+      allow(local_authority).to receive(:active?).and_return(true)
+      allow(local_authority).to receive(:active_end_date).and_return(nil)
+      expect(presenter.authority_status).to eq("active")
+    end
+
+    it "returns active but... if currently active but has an end date" do
+      allow(local_authority).to receive(:active?).and_return(true)
+      allow(local_authority).to receive(:active_end_date).and_return(Time.zone.now + 1.year)
+      expect(presenter.authority_status).to eq("active, but being retired")
+    end
+
+    it "returns inactive if currently inactive" do
+      allow(local_authority).to receive(:active?).and_return(false)
+      expect(presenter.authority_status).to eq("inactive")
+    end
+  end
+
+  describe "#should_display_end_notes?" do
+    it "returns false if currently active and no end date specified" do
+      allow(local_authority).to receive(:active?).and_return(true)
+      allow(local_authority).to receive(:active_end_date).and_return(nil)
+      expect(presenter.should_display_end_notes?).to be false
+    end
+
+    it "returns true if currently active but has an end date" do
+      allow(local_authority).to receive(:active?).and_return(true)
+      allow(local_authority).to receive(:active_end_date).and_return(Time.zone.now + 1.year)
+      expect(presenter.should_display_end_notes?).to be true
+    end
+
+    it "returns true if currently inactive" do
+      allow(local_authority).to receive(:active?).and_return(false)
+      expect(presenter.should_display_end_notes?).to be true
+    end
+  end
+
+  describe "#active_end_date_title" do
+    it "returns due-to-become message if authority is not yet inactive" do
+      allow(local_authority).to receive(:active?).and_return(true)
+      expect(presenter.active_end_date_title).to eq("Date authority is due to become inactive")
+    end
+
+    it "returns became message if authority is now inactive" do
+      allow(local_authority).to receive(:active?).and_return(false)
+      expect(presenter.active_end_date_title).to eq("Date authority became inactive")
     end
   end
 end

--- a/spec/requests/api/local_authority_spec.rb
+++ b/spec/requests/api/local_authority_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe "find local authority", type: :request do
     end
   end
 
-  context "for councils that have been merged into a parent authority" do
-    let(:parent_local_authority) do
+  context "for councils that have been merged into a succeeded by authority" do
+    let(:succeeded_by_local_authority) do
       create(
         :county_council,
         name: "Rochester",
@@ -125,7 +125,7 @@ RSpec.describe "find local authority", type: :request do
         snac: "00AG",
         homepage_url: "http://blackburn.example.com",
         country_name: "England",
-        parent_local_authority:,
+        succeeded_by_local_authority:,
         local_custodian_code: "2372",
         active_end_date: Time.zone.now - 1.year,
       )
@@ -146,14 +146,14 @@ RSpec.describe "find local authority", type: :request do
       }
     end
 
-    it "returns details of the parent council in the api response when searching by slug" do
+    it "returns details of the succeeded by council in the api response when searching by slug" do
       get "/api/local-authority?authority_slug=blackburn"
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response)
     end
 
-    it "returns details of the parent council in the api response when searching by local custodian code" do
+    it "returns details of the succeeded by council in the api response when searching by local custodian code" do
       get "/api/local-authority?local_custodian_code=2372"
 
       expect(response.status).to eq(200)


### PR DESCRIPTION
This change is needed to handle the situation where future merges are recorded but they're into a council that isn't the current parent (for instance Cumbria, which is being split into two Unitary Authorities in April 2023 and the District Councils shared between them. They'll now show Cumbria up to the switch point, and the relevant Unitary Authorities after that.

Doing this at this point so that the Somerset merge can follow this pattern and be a simpler PR reference for the following merges.

https://trello.com/c/NyIDiB39/1844-merge-somerset-west-taunton-council

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
