### PR TITLE
add north yorkshire merge rake file

### DIFF
--- a/lib/tasks/once-off/north_yorkshire_merge.rake
+++ b/lib/tasks/once-off/north_yorkshire_merge.rake
@@ -1,0 +1,20 @@
+namespace :once_off do
+  desc "Set merged counties to inactive as of 1/Apr/2020, ensure parent_local_authority valid"
+  task north_yorkshire_merge: :environment do
+    slugs = %i[craven hambleton harrogate richmondshire ryedale scarborough selby]
+    parent = LocalAuthority.find_by(slug: "north-yorkshire")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != parent
+        puts("Warning: parent local authority for #{slug} is not as expected (north-yorkshire)")
+        next
+      end
+
+      la.active_end_date = Time.parse("01-Apr-2023")
+      la.active_note = "Merged into the unitary authority North Yorkshire Council on 1 April 2023"
+      la.succeeded_by_local_authority = parent
+      la.save!
+    end
+  end
+end


### PR DESCRIPTION
## What

Mark 7 district councils as retired, ensure that their records in LLM point to North Yorkshire County Council.

There’s a PR here for this approach when support was added for Somerset: https://github.com/alphagov/local-links-manager/pull/1049

## Why

https://govuk.zendesk.com/agent/tickets/5106191

The following district councils are merging into North Yorkshire County Council

Craven District Council
Hambleton District Council
Harrogate Borough Council
Richmondshire District Council
Ryedale District Council
Scarborough Borough Council
Selby District Council

https://trello.com/c/dZeTS5YN/1877-merge-north-yorkshire-county-council

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
