### PR TITLE
add cumberland and westmorland and furness rake task

### DIFF
--- a/lib/tasks/once-off/cumberland_merge.rake
+++ b/lib/tasks/once-off/cumberland_merge.rake
@@ -1,0 +1,49 @@
+namespace :once_off do
+  desc "Set merged counties to inactive as of 1/Apr/2020, ensure parent_local_authority valid"
+  task cumberland_merge: :environment do
+    LocalAuthority.create!(name: "Cumberland Council", gss: "E06000063", local_custodian_code: "940", snac: "FAKE", slug: "cumberland", tier_id: Tier.unitary, homepage_url: "https://www.cumberland.gov.uk/")
+    slugs = %i[allerdale carlisle copeland]
+    successor = LocalAuthority.find_by(slug: "cumberland")
+    parent = LocalAuthority.find_by(slug: "cumbria")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != parent
+        puts("Warning: parent local authority for #{slug} is not as expected (cumbria)")
+        next
+      end
+
+      la.active_end_date = Time.zone.parse("01-Apr-2023")
+      la.active_note = "Merged into the unitary authority Cumberland Council on 1 April 2023"
+      la.succeeded_by_local_authority = successor
+      la.save!
+    end
+
+    LocalAuthority.create!(name: "Westmorland and Furness Council", gss: "E06000064", local_custodian_code: "935", snac: "FAKE2", slug: "westmorland-and-furness", tier_id: Tier.unitary, homepage_url: "https://www.westmorlandandfurness.gov.uk/")
+    slugs = %i[barrow-in-furness eden south-lakeland]
+    successor = LocalAuthority.find_by(slug: "westmorland-and-furness")
+    parent = LocalAuthority.find_by(slug: "cumbria")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != parent
+        puts("Warning: parent local authority for #{slug} is not as expected (cumbria)")
+        next
+      end
+
+      la.active_end_date = Time.zone.parse("01-Apr-2023")
+      la.active_note = "Merged into the unitary authority Westmorland and Furness Council on 1 April 2023"
+      la.succeeded_by_local_authority = successor
+      la.save!
+    end
+
+    successor = LocalAuthority.find_by(slug: "cumberland")
+
+    la = LocalAuthority.find_by(slug: "cumbria")
+
+    la.active_end_date = Time.zone.parse("01-Apr-2023")
+    la.active_note = "Merged into the unitary authorities of Cumberland Council and Westmorland and Furness Council on 1 April 2023"
+    la.succeeded_by_local_authority = successor
+    la.save!
+  end
+end


### PR DESCRIPTION
## What

Mark the 7 district councils that are to be merged into the two new unitary authorities as retired, ensure that they are pointing to their new parent authorities.

There’s a PR here for this approach when support was added for Somerset: https://github.com/alphagov/local-links-manager/pull/1049

For this merge we would also need to make the records for the two new unitary authorities before we pointed the district/city/borough councils at them.

## Why

https://govuk.zendesk.com/agent/tickets/5135757

Cumbria County council is going to split into 2 unitary authorities: Cumberland Council and Westmorland & Furness Council.

Each unitary authority will have 3 district councils, and Cumbria County Council will be in both.

Cumberland Council will replace:
- Allerdale Borough Council 
- Carlisle City Council 
- Copeland Borough Council
- Cumbria County Council

Westmorland and Furness Council will replace:
- Barrow in Furness Borough Council
- Eden District Council
- South Lakeland District Council
- Cumbria County Council


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

https://trello.com/c/vvUazI9R/1876-merge-cumberland-council-and-westmorland-furness-council
