### PR TITLE
Add 2019 merges that were missed

### DIFF
--- a/lib/tasks/once-off/dorset_merge.rake
+++ b/lib/tasks/once-off/dorset_merge.rake
@@ -1,0 +1,28 @@
+namespace :once_off do
+  desc "Set merged counties to inactive as of 1/Apr/2019, ensure parent_local_authority valid"
+  task dorset_merge: :environment do
+    bcp_slugs = %i[bournemouth christchurch poole]
+    bcp_parent = LocalAuthority.find_by(slug: "bournemouth-christchurch-poole")
+
+    bcp_slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+
+      la.active_end_date = Time.parse("01-Apr-2019")
+      la.active_note = "Merged into the unitary authority Bournemouth, Christchurch and Poole Council on 1 April 2019"
+      la.succeeded_by_local_authority = bcp_parent
+      la.save!
+    end
+
+    d_slugs = %i[east-dorset north-dorset purbeck west-dorset weymouth-and-portland]
+    d_parent = LocalAuthority.find_by(slug: "dorset")
+
+    d_slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+
+      la.active_end_date = Time.parse("01-Apr-2019")
+      la.active_note = "Merged into the unitary authority Dorset Council on 1 April 2019"
+      la.succeeded_by_local_authority = d_parent
+      la.save!
+    end
+  end
+end

--- a/lib/tasks/once-off/suffolk_merge.rake
+++ b/lib/tasks/once-off/suffolk_merge.rake
@@ -1,0 +1,28 @@
+namespace :once_off do
+  desc "Set merged districts to inactive as of 1/Apr/2019"
+  task suffolk_merge: :environment do
+    ws_slugs = %i[forest-heath st-edmundsbury]
+    ws_parent = LocalAuthority.find_by(slug: "west-suffolk")
+
+    ws_slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+
+      la.active_end_date = Time.parse("01-Apr-2019")
+      la.active_note = "Merged into the district council West Suffolk on 1 April 2019"
+      la.succeeded_by_local_authority = ws_parent
+      la.save!
+    end
+
+    es_slugs = %i[suffolk-coastal waveney]
+    es_parent = LocalAuthority.find_by(slug: "east-suffolk")
+
+    es_slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+
+      la.active_end_date = Time.parse("01-Apr-2019")
+      la.active_note = "Merged into the district council East Suffolk on 1 April 2019"
+      la.succeeded_by_local_authority = es_parent
+      la.save!
+    end
+  end
+end


### PR DESCRIPTION
When we added the code to mark LAs as retired, we missed the 2019 changes (the new councils were made at the time, so we've been serving accurate results to people, but we should have marked the retired LAs as such to remove them from the broken links count/crawler)

https://trello.com/c/AV0ODGdr/2326-bournemouth-christchurch-and-poole-council-merger

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
