### PR TITLE
Remove obsolete Jenkinsfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .gitignore
 .github
 Dockerfile
-Jenkinsfile
 README.md
 coverage
 docs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  // Run against the Postgres 13 Docker instance on GOV.UK CI
-  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/local-links-manager-test")
-  govuk.buildProject()
-}


### PR DESCRIPTION
This is a bulk change and will be bulk-approved.

There is no need to review individually.
