### PR TITLE
Add cleanup tasks for missed Local Authority changes.

### DIFF
--- a/lib/tasks/once-off/northamptonshire_split.rake
+++ b/lib/tasks/once-off/northamptonshire_split.rake
@@ -1,0 +1,41 @@
+namespace :once_off do
+  desc "Set Northamptonshire county to inactive as of 1/Apr/2021"
+  task northamptonshire_split: :environment do
+    old_parent = LocalAuthority.find_by(slug: "northamptonshire")
+    old_parent.active_end_date = Time.parse("01-Apr-2021")
+    old_parent.active_note = "Split into the North Northamptonshire and West Northamptonshire unitary authorities on 1 April 2021"
+    old_parent.save!
+
+    slugs = %i[corby east-northamptonshire kettering wellingborough]
+    parent = LocalAuthority.find_by(slug: "north-northamptonshire")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != old_parent
+        puts("Warning: parent local authority for #{slug} is not as expected (northamptonshire)")
+        next
+      end
+
+      la.active_end_date = Time.parse("01-Apr-2021")
+      la.active_note = "Merged into the unitary authority North Northampshire on 1 April 2021"
+      la.succeeded_by_local_authority = parent
+      la.save!
+    end
+
+    slugs = %i[daventry northampton south-northamptonshire]
+    parent = LocalAuthority.find_by(slug: "west-northamptonshire")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+      if la.parent_local_authority != old_parent
+        puts("Warning: parent local authority for #{slug} is not as expected (northamptonshire)")
+        next
+      end
+
+      la.active_end_date = Time.parse("01-Apr-2021")
+      la.active_note = "Merged into the unitary authority West Northampshire on 1 April 2021"
+      la.succeeded_by_local_authority = parent
+      la.save!
+    end
+  end
+end

--- a/lib/tasks/once-off/somerset_cleanup.rake
+++ b/lib/tasks/once-off/somerset_cleanup.rake
@@ -1,0 +1,16 @@
+namespace :once_off do
+  desc "Point 2019 retired somerset districts to their successor"
+  task somerset_cleanup: :environment do
+    slugs = %i[taunton-deane west-somerset]
+    parent = LocalAuthority.find_by(slug: "somerset-west-taunton")
+
+    slugs.each do |slug|
+      la = LocalAuthority.find_by(slug:)
+
+      la.active_end_date = Time.parse("01-Apr-2019")
+      la.active_note = "Merged into the district authority Somerset West and Taunton District Council on 1 April 2019"
+      la.succeeded_by_local_authority = parent
+      la.save!
+    end
+  end
+end


### PR DESCRIPTION
Marks Taunton Deane and West Somerset as retired (this was missed when their succeeding authority was itself subsumed), and correctly marks Northamptonshire CC and its districts as subsumed into the new North Northamptonshire and West Northamptonshire unitary authorities.

https://trello.com/c/bU0zAwg4/2339-ps3-investigate-approach-in-local-links-manager-for-local-authorities-that-no-longer-exist

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
