### PR TITLE
Remove links for authorities at the wrong tier for the relevant service

### DIFF
--- a/lib/tasks/once_off/wrong_tier_links.rake
+++ b/lib/tasks/once_off/wrong_tier_links.rake
@@ -1,0 +1,10 @@
+namespace :once_off do
+  desc "Delete links that are for services at the wrong tier for the referenced authority"
+  task delete_wrong_tier_links: :environment do
+    wrong_tier_links = Link.enabled_links.all.reject do |link|
+      link.service.tiers.include?(link.local_authority.tier)
+    end
+
+    wrong_tier_links.delete_all
+  end
+end


### PR DESCRIPTION
https://trello.com/c/FpsaioTK/2340-ps6-llm-admin-ui-displays-a-list-of-provided-services-but-search-uses-all-services-for-an-la-not-just-the-provided-ones

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
