### PR TITLE
Fix name of import method

### DIFF
--- a/lib/tasks/import/service_interactions.rake
+++ b/lib/tasks/import/service_interactions.rake
@@ -45,7 +45,7 @@ namespace :import do
 
     desc "Add tiers from local_services.csv in publisher to the list of Services imported by `import_services`"
     task add_service_tiers: :environment do
-      LocalLinksManager::Import::ServicesTierImporter.new.import_records
+      LocalLinksManager::Import::ServicesTierImporter.new.import_tiers
     end
 
     desc "Enable services used on Gov.uk"


### PR DESCRIPTION
In the code simplification PR https://github.com/alphagov/local-links-manager/pull/1242 I missed that ServicesTierImporter uses import_tiers and not import_records as its import method name, leading to Sentry errors. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
