### PR TITLE
Homepage problems report

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/table

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-for-admin";
 @import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/option-select";
 @import "govuk_publishing_components/components/table";
 @import "govuk_publishing_components/components/summary-list";
 

--- a/app/assets/stylesheets/components/app-labels.scss
+++ b/app/assets/stylesheets/components/app-labels.scss
@@ -1,5 +1,0 @@
-.app-interaction-label {
-  display: block;
-  color: govuk-colour("dark-grey");
-  @include govuk-font(16);
-}

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -5,15 +5,15 @@ class LocalAuthoritiesController < ApplicationController
   before_action :set_authority, except: %i[index bad_homepage_url_and_status_csv]
 
   def index
-    @show_retired = params[:retired] == "true"
+    Rails.logger.info(params)
 
-    @authorities = if @show_retired
-                     LocalAuthority.order(broken_link_count: :desc)
-                   else
+    @authorities = if params[:filter]&.include?("only_active")
                      LocalAuthority.active.order(broken_link_count: :desc)
+                   else
+                     LocalAuthority.order(broken_link_count: :desc)
                    end
 
-    raise "Missing Data" if @authorities.empty?
+    @authorities = @authorities.where.not(status: "ok") if params[:filter]&.include?("only_homepage_problems")
 
     @breadcrumbs = index_breadcrumbs
   end
@@ -67,7 +67,7 @@ private
   end
 
   def index_breadcrumbs
-    [{ title: "Home", url: root_path }, { title: "Councils", url: local_authorities_path }]
+    [{ title: "Home", url: root_path }, { title: "Councils", url: local_authorities_path(filter: %w[only_active]) }]
   end
 
   def local_authority_breadcrumbs(local_authority)

--- a/app/presenters/local_authorities_table_presenter.rb
+++ b/app/presenters/local_authorities_table_presenter.rb
@@ -6,8 +6,10 @@ class LocalAuthoritiesTablePresenter
 
   def rows
     @local_authorities.map do |authority|
+      la_presenter = LocalAuthorityPresenter.new(authority)
       [
         { text: @view_context.link_to(authority.name, @view_context.local_authority_path(authority.slug, filter: "broken_links"), class: "govuk-link") },
+        { text: "<span class=\"govuk-tag govuk-tag--#{la_presenter.homepage_status_colour}\">#{la_presenter.homepage_status}</span>".html_safe },
         { text: authority.active? ? "Yes" : "No" },
         { text: authority.broken_link_count, format: "numeric" },
       ]
@@ -18,6 +20,9 @@ class LocalAuthoritiesTablePresenter
     [
       {
         text: "Council Name",
+      },
+      {
+        text: "Homepage Status",
       },
       {
         text: "Active?",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     },
     {
       text: "Councils",
-      href: local_authorities_path,
+      href: local_authorities_path(filter: %w[only_active]),
       active: current_page?(local_authorities_path),
     },
     {

--- a/app/views/local_authorities/_filter.html.erb
+++ b/app/views/local_authorities/_filter.html.erb
@@ -1,0 +1,32 @@
+
+
+<%= form_with url: local_authorities_path, method: :get do |form| %>
+  <%= render "govuk_publishing_components/components/option_select", {
+    options_container_id: "list_of_vegetables",
+    title: "Only show",
+    key: "filter",
+    options: [
+      {
+        value: "only_active",
+        label: "Active councils",
+        checked: params[:filter]&.include?("only_active"),
+      },
+      {
+        value: "only_homepage_problems",
+        label: "Homepage problems",
+        checked: params[:filter]&.include?("only_homepage_problems"),
+      },
+    ],
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Update",
+    margin_bottom: 4,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "form-button",
+      "track-action": "local-authority-filter-button",
+      "track-label": "Update",
+    },
+  } %>
+<% end %>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -9,11 +9,18 @@
   margin_bottom: 5,
 } %>
 
-<% local_authorities_table_presenter = LocalAuthoritiesTablePresenter.new(@authorities, self) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "filter" %>
+  </div>
 
-<%= render "govuk_publishing_components/components/table", {
-  filterable: true,
-  label: "Filter Council Names",
-  head: local_authorities_table_presenter.headers,
-  rows:  local_authorities_table_presenter.rows,
-} %>
+  <div class="govuk-grid-column-three-quarters">
+    <% local_authorities_table_presenter = LocalAuthoritiesTablePresenter.new(@authorities, self) %>
+    <%= render "govuk_publishing_components/components/table", {
+      filterable: true,
+      label: "Filter Council Names",
+      head: local_authorities_table_presenter.headers,
+      rows:  local_authorities_table_presenter.rows,
+    } %>
+  </div>
+</div>

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -1,12 +1,5 @@
 RSpec.describe LocalAuthoritiesController, type: :controller do
   describe "GET #index" do
-    context "when there is missing data" do
-      it "returns http server error" do
-        login_as_stub_user
-        expect { get :index }.to raise_error "Missing Data"
-      end
-    end
-
     context "when there is sufficient data" do
       it "returns http succcess" do
         login_as_stub_user

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -3,8 +3,9 @@ feature "The local authorities index page" do
     User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
 
     @angus = create(:local_authority, name: "Angus")
-    @zorro = create(:local_authority, name: "Zorro Council", broken_link_count: 1)
-    visit local_authorities_path
+    @zorro = create(:local_authority, name: "Zorro Council", status: "caution", problem_summary: "Redirect", broken_link_count: 1)
+    @hidden = create(:local_authority, name: "Hidden Council", active_end_date: Time.zone.now - 1.day)
+    visit local_authorities_path(filter: %w[only_active])
   end
 
   it "has a breadcrumb trail" do
@@ -15,21 +16,49 @@ feature "The local authorities index page" do
     expect(page).to have_selector(".js-gem-c-table__filter")
   end
 
-  it "shows the available local authorities with links to their respective pages" do
+  it "shows the available local authorities" do
     expect(page).to have_content "Councils (2)"
+  end
+
+  it "shows links to each local authority page" do
     expect(page).to have_link("Angus", href: local_authority_path(@angus.slug, filter: "broken_links"))
     expect(page).to have_link("Zorro Council", href: local_authority_path(@zorro.slug, filter: "broken_links"))
   end
 
   it "shows the count of broken links for each local authority" do
-    expect(page).to have_content "Angus Yes 0"
-    expect(page).to have_content "Zorro Council Yes 1"
+    expect(page).to have_content "Angus Not checked Yes 0"
+    expect(page).to have_content "Zorro Council Note: Redirect Yes 1"
+  end
+
+  it "does not show retired authorities by default" do
+    expect(page).not_to have_content "Hidden Council Not checked No 0"
   end
 
   describe "clicking on the LA name on the index page" do
     it "takes you to the show page for that LA" do
       click_link("Angus")
       expect(current_path).to eq(local_authority_path(@angus.slug))
+    end
+  end
+
+  describe "clicking the filter box to show only broken homepages" do
+    it "filters out the working councils" do
+      check("Homepage problems")
+      click_on("Update")
+      expect(page).to have_content "Councils (1)"
+      expect(page).not_to have_content "Angus Not checked Yes 0"
+      expect(page).to have_content "Zorro Council Note: Redirect Yes 1"
+    end
+  end
+
+  describe "clicking the filter box to include retired councils" do
+    it "shows the retired councils" do
+      uncheck("Active councils")
+      click_on("Update")
+      expect(page).to have_content "Councils (3)"
+      expect(page).to have_content "Angus Not checked Yes 0"
+      expect(page).to have_content "Zorro Council Note: Redirect Yes 1"
+      expect(page).to have_content "Hidden Council Not checked No 0"
     end
   end
 end

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -9,7 +9,7 @@ feature "The local authority show page" do
   it "has a list of breadcrumbs pointing back to the authority that lead us here" do
     within ".govuk-breadcrumbs__list" do
       expect(page).to have_link "Home", href: root_path
-      expect(page).to have_link "Councils", href: local_authorities_path
+      expect(page).to have_link "Councils", href: local_authorities_path(filter: %w[only_active])
       expect(page).to have_text local_authority.name
     end
   end


### PR DESCRIPTION
- Add a column to the local authorities index to show homepage status.
- Add filters to the local authorities index to allow toggling only active councils (on by default) and only councils with homepage problems.

https://trello.com/c/zoxV3oIw/2376-report-on-la-homepage-warnings

We can use this filter pattern on the other listings pages.

Search filter is still the one used by specialist finders and signon (which is nice and snappy). It does mean that there's a slight behaviour difference (in page filter works as you type, the two checkbox filters only work when you click Update), but this is probably fine for a govuk-only facing application?

## BEFORE

<img width="1200" alt="Screenshot 2024-02-28 at 13 12 53" src="https://github.com/alphagov/local-links-manager/assets/4225737/dd8fd642-e782-4321-9d92-8bc57756a813">

## AFTER

<img width="1175" alt="Screenshot 2024-02-29 at 15 24 21" src="https://github.com/alphagov/local-links-manager/assets/4225737/9c3ac2a8-870b-4015-8319-78148bc59fbf">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
