### PR TITLE
Update .govuk_dependabot_merger config

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -8,11 +8,11 @@ auto_merge:
     allowed_semver_bumps:
       - patch
       - minor
-  - dependency: govuk_admin_template
+  - dependency: govuk_app_config
     allowed_semver_bumps:
       - patch
       - minor
-  - dependency: govuk_app_config
+  - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
       - minor


### PR DESCRIPTION
Now design system is merged, we no longer use govuk_admin_template, but do use govuk_publishing_components

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
