### PR TITLE
Add service traffic column to service index

### DIFF
--- a/app/presenters/services_table_presenter.rb
+++ b/app/presenters/services_table_presenter.rb
@@ -11,6 +11,7 @@ class ServicesTablePresenter
       end
 
       [
+        { text: service.links.sum { |l| l.analytics.to_i }, format: "numeric" },
         { text: @view_context.link_to(service.label, @view_context.service_path(service, filter: "broken_links"), class: "govuk-link") },
         { text: govuk_links.compact.any? ? govuk_links.compact.join("<br />").html_safe : "Not used on GOV.UK" },
         { text: service.lgsl_code },
@@ -21,6 +22,10 @@ class ServicesTablePresenter
 
   def headers
     [
+      {
+        text: "Visits this week",
+        format: "numeric",
+      },
       {
         text: "Service Name",
       },

--- a/spec/features/services/service_index_spec.rb
+++ b/spec/features/services/service_index_spec.rb
@@ -4,6 +4,10 @@ feature "The services index page" do
 
     @aardvark = create(:service, label: "Aardvark Wardens")
     @zebra = create(:service, label: "Zebra Fouling", broken_link_count: 1)
+    si = create(:service_interaction, service: @aardvark, govuk_title: "SI1")
+    create(:link, service_interaction: si, analytics: 30)
+    si2 = create(:service_interaction, service: @aardvark, govuk_title: "SI2")
+    create(:link, service_interaction: si2, analytics: 25)
     create(:disabled_service)
     visit services_path
   end
@@ -18,8 +22,8 @@ feature "The services index page" do
 
   it "shows enabled services sorted by broken link count" do
     expect(page).to have_content("Services (2)")
-    expect(page).to have_content("Zebra Fouling Not used on GOV.UK #{@zebra.lgsl_code} 1")
-    expect(page).to have_content("Aardvark Wardens Not used on GOV.UK #{@aardvark.lgsl_code} 0")
+    expect(page).to have_content("0 Zebra Fouling Not used on GOV.UK #{@zebra.lgsl_code} 1")
+    expect(page).to have_content("55 Aardvark Wardens SI1SI2 #{@aardvark.lgsl_code} 0")
     expect("Zebra Fouling").to appear_before("Aardvark Wardens")
   end
 end


### PR DESCRIPTION
Add traffic column to services index so we can see traffic volume by service.

We're still sorting by broken links by default for the moment, we will investigate sortable tables in a later piece of work.

https://trello.com/c/EUhai1BB/2377-add-traffic-counts-to-services-listing

## BEFORE

<img width="1201" alt="Screenshot 2024-02-28 at 16 39 21" src="https://github.com/alphagov/local-links-manager/assets/4225737/56c81948-746f-4351-bc40-64d4f95ac8ad">

## AFTER

<img width="1233" alt="Screenshot 2024-02-28 at 16 48 49" src="https://github.com/alphagov/local-links-manager/assets/4225737/3aa057a3-97ad-48bc-84fa-a2f30ce9ef1d">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
