### PR TITLE
Add local authority traffic column to local authority index

### DIFF
--- a/app/presenters/local_authorities_table_presenter.rb
+++ b/app/presenters/local_authorities_table_presenter.rb
@@ -7,7 +7,9 @@ class LocalAuthoritiesTablePresenter
   def rows
     @local_authorities.map do |authority|
       la_presenter = LocalAuthorityPresenter.new(authority)
+
       [
+        { text: authority.links.sum { |l| l.analytics.to_i }, format: "numeric" },
         { text: @view_context.link_to(authority.name, @view_context.local_authority_path(authority.slug, filter: "broken_links"), class: "govuk-link") },
         { text: "<span class=\"govuk-tag govuk-tag--#{la_presenter.homepage_status_colour}\">#{la_presenter.homepage_status}</span>".html_safe },
         { text: authority.active? ? "Yes" : "No" },
@@ -18,6 +20,10 @@ class LocalAuthoritiesTablePresenter
 
   def headers
     [
+      {
+        text: "Visits this week",
+        format: "numeric",
+      },
       {
         text: "Council Name",
       },


### PR DESCRIPTION
Add traffic column to local authorities index so we can see traffic volume by local authority.

We're still sorting by broken links by default for the moment, we will investigate sortable tables in a later piece of work.

https://trello.com/c/ySbAJMor/2378-add-traffic-counts-to-local-authorities-list

## BEFORE

<img width="1209" alt="Screenshot 2024-03-04 at 15 38 49" src="https://github.com/alphagov/local-links-manager/assets/4225737/886b4d49-6bab-40a8-b751-77fb1a825d48">

## AFTER

<img width="1198" alt="Screenshot 2024-03-04 at 15 42 05" src="https://github.com/alphagov/local-links-manager/assets/4225737/2e2f9f61-8f6d-4e85-8f22-e9d1a4927fb8">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
