### PR TITLE
Remove unused data

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,4 @@ Rails.application.routes.draw do
   get "/api/local-authority", to: "api#local_authority"
 
   post "/link-check-callback", to: "webhooks#link_check_callback", as: :link_checker_webhook
-
-  # Serve the static CSV using NGINX instead of a controller
-  get "/links-export", to: redirect("data/links_to_services_provided_by_local_authorities.csv")
 end

--- a/lib/tasks/export/link_exporter.rake
+++ b/lib/tasks/export/link_exporter.rake
@@ -1,23 +1,9 @@
-require_relative "../../../app/lib/local_links_manager/distributed_lock"
 require_relative "../../../app/lib/local_links_manager/export/links_exporter"
 
 require "aws-sdk-s3"
 
 namespace :export do
   namespace :links do
-    desc "Export links to CSV"
-    task "all": :environment do
-      Rails.logger.info("Starting link exporter")
-      LocalLinksManager::Export::LinksExporter.export_links
-      Rails.logger.info("Link export to CSV completed")
-    rescue StandardError => e
-      Rails.logger.error("Error while running link exporter\n#{e}")
-      raise e
-    end
-
-    # This task duplicates functionality in `export:links:all`, except uploads
-    # the file to S3 instead of storing it locally. This task is to be used by
-    # the cronjob in Kubernetes environments instead.
     desc "Export links to CSV and upload to S3"
     task "s3": :environment do
       filename = "links_to_services_provided_by_local_authorities.csv"

--- a/lib/tasks/once_off/remove_unused_data.rake
+++ b/lib/tasks/once_off/remove_unused_data.rake
@@ -1,0 +1,30 @@
+namespace :once_off do
+  desc "Remove services, service_tiers, service_interactions and links for all services that aren't enabled"
+  task remove_unused_services: :environment do
+    services = Service.where(enabled: false)
+
+    total_services = 0
+    total_service_interactions = 0
+    total_links = 0
+
+    services.find_each do |service|
+      puts("Deleting: #{service.label}")
+      puts("   - #{service.service_interactions.count} service interactions")
+      puts("   - #{service.links.count} links")
+      total_services += 1
+      total_service_interactions += service.service_interactions.count
+      total_links += service.links.count
+
+      service.service_interactions.each do |si|
+        si.links.delete_all
+      end
+      service.service_interactions.delete_all
+      service.delete
+    end
+
+    puts("Totals: ")
+    puts("Services: #{total_services}")
+    puts("Service Interactions: #{total_service_interactions}")
+    puts("Links: #{total_links}")
+  end
+end


### PR DESCRIPTION
- Add rake task to delete data that isn't used on GOV.UK
- Remove unused link export task as s3 Task is now the only way to do this export.
- Remove the redirect to /link-export which requires specific nginx configuration for LLM and is only used to prettify a dataset link in data.gov.uk

https://trello.com/c/8QRAzl8N/2379-remove-bad-data-from-local-links-manager

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
