### PR TITLE
Add required permissions for integrating snyk with code scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     name: SNYK security analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
     secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
   codeql-sast:
     name: CodeQL SAST scan


### PR DESCRIPTION
Trello: https://trello.com/c/srqkwMUh/3430-spike-integrating-snyk-findings-with-github-code-scanning

Adds required permissions for integrating snyk with code scanning. 