### PR TITLE
Publish external content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem "whenever", require: false
 
 group :development do
   gem "better_errors"
-  gem "binding_of_caller"
   gem "capistrano-rails"
   gem "web-console" # Access an IRB console by using <%= console %> in views
 end
@@ -36,7 +35,7 @@ end
 group :development, :test do
   gem "erb_lint", require: false
   gem "factory_bot_rails"
-  gem "pry-rails"
+  gem "pry-byebug"
   gem "rspec-rails"
   gem "shoulda-matchers"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,12 +110,11 @@ GEM
       smart_properties
     bigdecimal (3.1.7)
     bindex (0.8.1)
-    binding_of_caller (1.0.1)
-      debug_inspector (>= 1.2.0)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     brakeman (6.1.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capistrano (3.17.3)
       airbrussh (>= 1.0.0)
       i18n
@@ -148,7 +147,6 @@ GEM
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
     date (3.3.4)
-    debug_inspector (1.2.0)
     declarative (0.0.20)
     diff-lcs (1.5.1)
     docile (1.4.0)
@@ -560,8 +558,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -783,7 +782,6 @@ DEPENDENCIES
   addressable
   aws-sdk-s3
   better_errors
-  binding_of_caller
   bootsnap
   capistrano-rails
   capybara
@@ -803,7 +801,7 @@ DEPENDENCIES
   mlanett-redis-lock
   pg
   plek
-  pry-rails
+  pry-byebug
   rails (= 7.1.3.2)
   redis
   rspec-rails

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,4 +1,6 @@
 class LocalAuthority < ApplicationRecord
+  after_commit :update_external_content, if: :persisted?
+
   validates :gss, :slug, uniqueness: true
   validates :snac, uniqueness: true, allow_nil: true
   validates :gss, :name, :slug, presence: true
@@ -69,5 +71,15 @@ class LocalAuthority < ApplicationRecord
     return la if la.active?
 
     la.succeeded_by_local_authority
+  end
+
+private
+
+  def update_external_content
+    if active?
+      LocalAuthorityExternalContentPublisher.publish(self)
+    else
+      LocalAuthorityExternalContentPublisher.unpublish(self)
+    end
   end
 end

--- a/app/presenters/local_authority_external_content_presenter.rb
+++ b/app/presenters/local_authority_external_content_presenter.rb
@@ -1,0 +1,19 @@
+class LocalAuthorityExternalContentPresenter
+  def initialize(local_authority)
+    @local_authority = local_authority
+  end
+
+  def present_for_publishing_api
+    {
+      description: "Website of #{@local_authority.name}",
+      details: {
+        url: @local_authority.homepage_url,
+      },
+      document_type: "external_content",
+      publishing_app: "local-links-manager",
+      schema_name: "external_content",
+      title: @local_authority.name,
+      update_type: "minor",
+    }
+  end
+end

--- a/app/services/local_authority_external_content_publisher.rb
+++ b/app/services/local_authority_external_content_publisher.rb
@@ -1,0 +1,15 @@
+class LocalAuthorityExternalContentPublisher
+  def self.publish(local_authority)
+    payload = LocalAuthorityExternalContentPresenter.new(local_authority)
+      .present_for_publishing_api
+
+    publishing_api = GdsApi.publishing_api
+
+    publishing_api.put_content(local_authority.content_id, payload)
+    publishing_api.publish(local_authority.content_id)
+  end
+
+  def self.unpublish(local_authority)
+    GdsApi.publishing_api.unpublish(local_authority.content_id, type: "gone")
+  end
+end

--- a/db/migrate/20240318105241_add_content_id_to_local_authorities.rb
+++ b/db/migrate/20240318105241_add_content_id_to_local_authorities.rb
@@ -1,0 +1,8 @@
+class AddContentIdToLocalAuthorities < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension "pgcrypto"
+
+    add_column :local_authorities, :content_id, :uuid, default: "gen_random_uuid()"
+    add_index :local_authorities, :content_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_04_115751) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_18_105241) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "interactions", id: :serial, force: :cascade do |t|
@@ -67,6 +68,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_04_115751) do
     t.datetime "active_end_date", precision: nil
     t.string "active_note"
     t.integer "succeeded_by_local_authority_id"
+    t.uuid "content_id", default: -> { "gen_random_uuid()" }
+    t.index ["content_id"], name: "index_local_authorities_on_content_id", unique: true
     t.index ["gss"], name: "index_local_authorities_on_gss", unique: true
     t.index ["homepage_url"], name: "index_local_authorities_on_homepage_url"
     t.index ["slug"], name: "index_local_authorities_on_slug", unique: true

--- a/lib/tasks/once_off/publish_external_content_items.rake
+++ b/lib/tasks/once_off/publish_external_content_items.rake
@@ -1,0 +1,8 @@
+namespace :once_off do
+  desc "Publish external links to all active council homepages so they appear in search"
+  task publish_external_content_items: :environment do
+    LocalAuthority.active.find_each do |la|
+      LocalAuthorityExternalContentPublisher.publish(la)
+    end
+  end
+end

--- a/spec/lib/local_authority_redirector_spec.rb
+++ b/spec/lib/local_authority_redirector_spec.rb
@@ -3,8 +3,11 @@ require "rails_helper"
 RSpec.describe LocalAuthorityRedirector do
   include GdsApi::TestHelpers::PublishingApi
 
-  let(:old_local_authority) { create(:county_council, slug: "old") }
-  let(:new_local_authority) { create(:county_council, slug: "new") }
+  # We have to explicitly set the content_id for external content here because
+  # later in the test we force SecureRandom.uuid to return a fixed value, and
+  # that would cause a uniqueness crash
+  let(:old_local_authority) { create(:county_council, slug: "old", content_id: "old-1") }
+  let(:new_local_authority) { create(:county_council, slug: "new", content_id: "new-2") }
 
   subject(:call) do
     described_class.call(from: old_local_authority, to: new_local_authority)

--- a/spec/presenters/local_authority_external_content_presenter_spec.rb
+++ b/spec/presenters/local_authority_external_content_presenter_spec.rb
@@ -1,0 +1,23 @@
+describe LocalAuthorityExternalContentPresenter do
+  describe "#present_for_publishing_api" do
+    let(:authority) { build(:county_council, name: "Angus County Council") }
+    let(:presenter) { described_class.new(authority) }
+    let(:expected_response) do
+      {
+        description: "Website of Angus County Council",
+        details: {
+          url: "http://www.angus.gov.uk",
+        },
+        document_type: "external_content",
+        publishing_app: "local-links-manager",
+        schema_name: "external_content",
+        title: "Angus County Council",
+        update_type: "minor",
+      }
+    end
+
+    it "returns a hash appropriate for an external content item in the Publishing API" do
+      expect(presenter.present_for_publishing_api).to eq(expected_response)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before do
+    stub_publishing_api_for_external_content
+  end
 end
 
 GovukTest.configure

--- a/spec/support/gds_api_adapters.rb
+++ b/spec/support/gds_api_adapters.rb
@@ -1,1 +1,21 @@
 require "gds_api/test_helpers/publishing_api"
+
+module LocalAuthoritiesExternalContentHelpers
+  include GdsApi::TestHelpers::PublishingApi
+
+  def stub_publishing_api_for_external_content
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_unpublish
+    stub_any_publishing_api_publish
+  end
+
+  def stub_publishing_api_for_subject(local_authority, body_merge: {})
+    body = LocalAuthorityExternalContentPresenter.new(local_authority).present_for_publishing_api
+    stub_publishing_api_put_content_links_and_publish(body.merge(body_merge), local_authority.content_id, { update_type: nil })
+  end
+
+  def stub_unpublish_for_subject(local_authority)
+    stub_publishing_api_unpublish(local_authority.content_id, { body: { type: "gone" } })
+  end
+end
+RSpec.configuration.include LocalAuthoritiesExternalContentHelpers


### PR DESCRIPTION
Local Links Manager should publish council homepages as External Content items to publishing API, to take over the work currently done by SearchAdmin (which currently has older data, and generally has worse support for automated link checking and maintenance).

- Add a content_id field to Local Authority records - this is the content_id of the external content item related to their homepage.
- Add callbacks so that when a Local Authority is updated, the external content item will be created / updated / unpublished (if council is retired).
- Add a rake task to do initial publishing of all items (all active council's homepages).

There's an equivalent search-admin task to remove all the council external links from Search Admin which should be run before the task in Local Links Manager.

https://trello.com/c/p6bYucUh/2404-local-links-manager-should-publish-council-homepages-to-the-search-api