### PR TITLE
Fix publishing api errors

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -76,10 +76,10 @@ class LocalAuthority < ApplicationRecord
 private
 
   def update_external_content
-    if active?
-      LocalAuthorityExternalContentPublisher.publish(self)
+    if active? && (saved_change_to_name? || saved_change_to_homepage_url?)
+      LocalAuthorityExternalContentPublisher.new(self).publish
     else
-      LocalAuthorityExternalContentPublisher.unpublish(self)
+      LocalAuthorityExternalContentPublisher.new(self).unpublish
     end
   end
 end

--- a/app/services/local_authority_external_content_publisher.rb
+++ b/app/services/local_authority_external_content_publisher.rb
@@ -1,15 +1,36 @@
 class LocalAuthorityExternalContentPublisher
-  def self.publish(local_authority)
+  attr_reader :local_authority, :publishing_api
+
+  def initialize(local_authority)
+    @local_authority = local_authority
+    @publishing_api = GdsApi.publishing_api
+  end
+
+  def publish
     payload = LocalAuthorityExternalContentPresenter.new(local_authority)
       .present_for_publishing_api
 
-    publishing_api = GdsApi.publishing_api
-
-    publishing_api.put_content(local_authority.content_id, payload)
-    publishing_api.publish(local_authority.content_id)
+    publishing_api.put_content(content_id, payload)
+    publishing_api.publish(content_id)
   end
 
-  def self.unpublish(local_authority)
-    GdsApi.publishing_api.unpublish(local_authority.content_id, type: "gone")
+  def unpublish
+    return unless published?
+
+    publishing_api.unpublish(content_id, type: "gone")
+  end
+
+private
+
+  def content_id
+    local_authority.content_id
+  end
+
+  def published?
+    content = publishing_api.get_live_content(content_id)
+    content.to_hash["publication_state"] == "published"
+  rescue GdsApi::HTTPNotFound
+    # Not present, so definitely not published
+    false
   end
 end

--- a/spec/services/local_authority_external_content_publisher_spec.rb
+++ b/spec/services/local_authority_external_content_publisher_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe LocalAuthorityExternalContentPublisher do
+  before do
+    WebMock.reset!
+    @authority = build(:local_authority, content_id: SecureRandom.uuid)
+    stub_publishing_api_subject_published(@authority)
+    stub_publishing_api_for_subject(@authority)
+    @authority.save!
+    WebMock.reset!
+  end
+
+  describe "#publish" do
+    before do
+      @stubs = stub_publishing_api_for_subject(@authority)
+    end
+
+    context "with a published local authority link" do
+      it "calls the publishing api to update and publish" do
+        stub_publishing_api_subject_published(@authority)
+        described_class.new(@authority).publish
+        expect(@stubs.first).to have_been_requested.once
+        expect(@stubs.last).to have_been_requested
+      end
+    end
+  end
+
+  describe "#unpublish" do
+    before do
+      @stub = stub_unpublish_for_subject(@authority)
+    end
+
+    context "with a published local authority link" do
+      it "calls the publishing api to unpublish" do
+        stub_publishing_api_subject_published(@authority)
+        described_class.new(@authority).unpublish
+        expect(@stub).to have_been_requested.once
+      end
+    end
+
+    context "with a non-published local authority link" do
+      it "does nothing" do
+        stub_publishing_api_subject_unpublished(@authority)
+        described_class.new(@authority).unpublish
+        expect(@stub).not_to have_been_requested
+      end
+    end
+
+    context "with a missing local authority link" do
+      it "does nothing" do
+        stub_publishing_api_subject_missing(@authority)
+        described_class.new(@authority).unpublish
+        expect(@stub).not_to have_been_requested
+      end
+    end
+  end
+end

--- a/spec/support/gds_api_adapters.rb
+++ b/spec/support/gds_api_adapters.rb
@@ -7,6 +7,8 @@ module LocalAuthoritiesExternalContentHelpers
     stub_any_publishing_api_put_content
     stub_any_publishing_api_unpublish
     stub_any_publishing_api_publish
+    stub_request(:get, %r{\A#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}})
+      .to_return(status: 404, headers: { "Content-Type" => "application/json; charset=utf-8" })
   end
 
   def stub_publishing_api_for_subject(local_authority, body_merge: {})
@@ -16,6 +18,24 @@ module LocalAuthoritiesExternalContentHelpers
 
   def stub_unpublish_for_subject(local_authority)
     stub_publishing_api_unpublish(local_authority.content_id, { body: { type: "gone" } })
+  end
+
+  def stub_publishing_api_subject_published(local_authority)
+    stub_publishing_api_has_item({
+      content_id: local_authority.content_id,
+      publication_state: "published",
+    })
+  end
+
+  def stub_publishing_api_subject_unpublished(local_authority)
+    stub_publishing_api_has_item({
+      content_id: local_authority.content_id,
+      publication_state: "unpublished",
+    })
+  end
+
+  def stub_publishing_api_subject_missing(local_authority)
+    stub_publishing_api_does_not_have_item(local_authority.content_id)
   end
 end
 RSpec.configuration.include LocalAuthoritiesExternalContentHelpers


### PR DESCRIPTION
The publish/unpublish code for Local Authorities is getting failures because it tries to unpublish missing documents. This causes errors when the link checker updates the records nightly, so add code to check before calling.

Also, change the behaviour to only publish if the homepage_url or name are changed. It currently publishes when unrelated changes are made to a local authority model, which creates a bunch of spam editions given that the link checker updates each authority once a day. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
