### PR TITLE
Allow authorities to not provide services

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -21,6 +21,7 @@ class LinksController < ApplicationController
 
   def update
     @link.url = link_url
+    @link.not_provided_by_authority = link_not_provided_by_authority
 
     if @link.save
       @link.local_authority.update_broken_link_count
@@ -73,6 +74,10 @@ private
 
   def link_url
     params[:url].strip
+  end
+
+  def link_not_provided_by_authority
+    params[:not_provided_by_authority].present? && params[:not_provided_by_authority] == "on"
   end
 
   def redirect_back

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -42,7 +42,8 @@ class LocalAuthoritiesController < ApplicationController
   def download_links_csv
     authority_name = @authority.name.parameterize.underscore
     statuses = params[:links_status_checkbox] & %w[ok broken caution missing pending]
-    data = LocalLinksManager::Export::LocalAuthorityLinksExporter.new.export_links(@authority.id, statuses)
+    not_provided_by_authority = params[:not_provided_by_authority_checkbox] & %w[not_provided_by_authority]
+    data = LocalLinksManager::Export::LocalAuthorityLinksExporter.new.export_links(@authority.id, statuses, not_provided_by_authority)
     send_data data, filename: "#{authority_name}_links.csv"
   end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -25,7 +25,8 @@ class ServicesController < ApplicationController
   def download_links_csv
     service_name = @service.label.parameterize.underscore
     statuses = params[:links_status_checkbox] & %w[ok broken caution missing pending]
-    data = LocalLinksManager::Export::ServiceLinksExporter.new.export_links(@service.id, statuses)
+    not_provided_by_authority = params[:not_provided_by_authority_checkbox] & %w[not_provided_by_authority]
+    data = LocalLinksManager::Export::ServiceLinksExporter.new.export_links(@service.id, statuses, not_provided_by_authority)
     send_data data, filename: "#{service_name}_links.csv"
   end
 

--- a/app/lib/local_links_manager/export/links_exporter.rb
+++ b/app/lib/local_links_manager/export/links_exporter.rb
@@ -13,6 +13,7 @@ module LocalLinksManager
         :lgil_code,
         :url,
         :enabled,
+        :not_provided_by_authority,
       ].freeze
       COMMON_HEADINGS = [
         "Authority Name",
@@ -22,6 +23,7 @@ module LocalLinksManager
         "LGIL",
         "URL",
         "Supported by GOV.UK",
+        "Not Provided by Authority",
       ].freeze
       EXTRA_HEADINGS = ["Status", "New URL"].freeze
 
@@ -43,11 +45,11 @@ module LocalLinksManager
         io.write(output)
       end
 
-      def export_links(object_id, statuses)
+      def export_links(object_id, statuses, not_provided_by_authority)
         CSV.generate do |csv|
           csv << COMMON_HEADINGS + EXTRA_HEADINGS
           statuses.each do |status|
-            links(object_id, status).each do |link|
+            links(object_id, status, not_provided_by_authority).each do |link|
               csv << format(link).push(link.status)
             end
           end
@@ -71,6 +73,7 @@ module LocalLinksManager
           record.lgil_code,
           record.url,
           record.enabled,
+          record.not_provided_by_authority,
         ]
       end
 

--- a/app/lib/local_links_manager/export/local_authority_links_exporter.rb
+++ b/app/lib/local_links_manager/export/local_authority_links_exporter.rb
@@ -1,9 +1,9 @@
 module LocalLinksManager
   module Export
     class LocalAuthorityLinksExporter < LocalLinksManager::Export::LinksExporter
-      def links(local_authority_id, status)
+      def links(local_authority_id, status, not_provided_by_authority)
         Link.enabled_links
-          .where(local_authority_id:, status:)
+          .where(local_authority_id:, status:, not_provided_by_authority:)
           .joins(:local_authority, :service, :interaction)
           .select(*SELECTION)
           .order("services.lgsl_code", "interactions.lgil_code").all

--- a/app/lib/local_links_manager/export/service_links_exporter.rb
+++ b/app/lib/local_links_manager/export/service_links_exporter.rb
@@ -1,8 +1,8 @@
 module LocalLinksManager
   module Export
     class ServiceLinksExporter < LocalLinksManager::Export::LinksExporter
-      def links(service_id, status)
-        Link.joins(:service).where(services: { id: service_id }, status:)
+      def links(service_id, status, not_provided_by_authority)
+        Link.joins(:service).where(services: { id: service_id }, status:, not_provided_by_authority:)
           .joins(:local_authority, :interaction)
           .select(*SELECTION)
           .order("local_authorities.name", "interactions.lgil_code").all

--- a/app/lib/local_links_manager/import/links.rb
+++ b/app/lib/local_links_manager/import/links.rb
@@ -20,6 +20,7 @@ module LocalLinksManager
           @total_rows += 1
           index += 1
           new_url = row["New URL"]
+          not_provided_by_authority = row["Not Provided by Authority"]
           next if new_url.blank?
 
           local_authority = LocalAuthority.find_by(gss: row["GSS"])
@@ -38,6 +39,7 @@ module LocalLinksManager
 
           begin
             link.update!(url: new_url)
+            link.update!(not_provided_by_authority:) if not_provided_by_authority
             updated += 1
           rescue ActiveRecord::RecordInvalid => e
             Rails.logger.warn("#{e.message} (#{slugs.merge(link_id: link.id)})")

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -29,6 +29,13 @@
         value: @link.url,
       } %>
 
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "not_provided_by_authority",
+        heading: "Is this provided by the local authority",
+        hint_text: "Check this if the link is NOT provided by the local authority",
+        items: [{ checked: @link.not_provided_by_authority }],
+      } %>
+
       <%= render "govuk_publishing_components/components/button", { text: "Update" } %>
     <% end %>
 

--- a/app/views/shared/_download_links_form.html.erb
+++ b/app/views/shared/_download_links_form.html.erb
@@ -21,6 +21,15 @@
     ],
   } %>
 
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "not_provided_by_authority_checkbox[]",
+      heading: "Include links where link is not provided by authority:",
+      hint_text: "",
+      items: [
+        { label: "Service not provided", value: "not_provided_by_authority", checked: false },
+      ],
+  } %>
+
   <%= render "govuk_publishing_components/components/button", { text: "Download Links" } %>
 
 <% end %>

--- a/db/migrate/20240523070623_add_not_provided_by_authority_for_links.rb
+++ b/db/migrate/20240523070623_add_not_provided_by_authority_for_links.rb
@@ -1,0 +1,5 @@
+class AddNotProvidedByAuthorityForLinks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :links, :not_provided_by_authority, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_105241) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_23_070623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_105241) do
     t.string "link_warnings", default: [], null: false, array: true
     t.string "problem_summary"
     t.string "suggested_fix"
+    t.boolean "not_provided_by_authority", default: false, null: false
     t.index ["analytics"], name: "index_links_on_analytics"
     t.index ["local_authority_id", "service_interaction_id"], name: "index_links_on_local_authority_id_and_service_interaction_id", unique: true
     t.index ["local_authority_id"], name: "index_links_on_local_authority_id"

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe LinksController, type: :controller do
 
   describe "POST edit" do
     it "updates valid links" do
-      post :update, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug, url: "http://www.example.com/new" }
+      post :update, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug, interaction_slug: @interaction.slug, url: "http://www.example.com/new", not_provided_by_authority: "on" }
       expect(response).to have_http_status(302)
       expect(Link.last.url).to eq("http://www.example.com/new")
+      expect(Link.last.not_provided_by_authority).to eq(true)
       expect(flash[:danger]).to be nil
     end
 

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     status { nil }
     link_last_checked { nil }
     analytics { 0 }
+    not_provided_by_authority { false }
+  end
+
+  factory :not_provided_by_authority_link, parent: :link do
+    status { "ok" }
+    not_provided_by_authority { true }
   end
 
   factory :ok_link, parent: :link do

--- a/spec/lib/local-links-manager/export/fixtures/exported_links.csv
+++ b/spec/lib/local-links-manager/export/fixtures/exported_links.csv
@@ -1,6 +1,6 @@
-Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK
-Exeter,456,Service 123: Interaction 0,123,0,http://www.example.com/456/0,true
-Exeter,456,Service 123: Interaction 1,123,1,http://www.example.com/456/1,true
-Exeter,456,Service 666: Interaction 0,666,0,http://www.example.com/456/0,false
-London,123,Service 123: Interaction 0,123,0,http://www.example.com/123/0,true
-London,123,Service 123: Interaction 1,123,1,http://www.example.com/123/1,true
+Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Not Provided by Authority
+Exeter,456,Service 123: Interaction 0,123,0,http://www.example.com/456/0,true,false
+Exeter,456,Service 123: Interaction 1,123,1,http://www.example.com/456/1,true,false
+Exeter,456,Service 666: Interaction 0,666,0,http://www.example.com/456/0,false,false
+London,123,Service 123: Interaction 0,123,0,http://www.example.com/123/0,true,false
+London,123,Service 123: Interaction 1,123,1,http://www.example.com/123/1,true,false

--- a/spec/lib/local-links-manager/export/fixtures/ni_link.csv
+++ b/spec/lib/local-links-manager/export/fixtures/ni_link.csv
@@ -1,2 +1,2 @@
-Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK
-Belfast,456,Service 123: Interaction 1,123,1,http://www.example.com/456/1,true
+Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Not Provided by Authority
+Belfast,456,Service 123: Interaction 1,123,1,http://www.example.com/456/1,true,false

--- a/spec/lib/local-links-manager/import/links_spec.rb
+++ b/spec/lib/local-links-manager/import/links_spec.rb
@@ -7,19 +7,24 @@ RSpec.describe LocalLinksManager::Import::Links do
   let(:missing_link) { create(:missing_link, local_authority:) }
   let(:pending_link) { create(:pending_link, local_authority:) }
   let(:links) { [ok_link, broken_link, caution_link, missing_link, pending_link] }
-  let!(:csv) { create_csv(local_authority, links, new_url) }
+  let!(:csv) { create_csv(local_authority, links, new_url, not_provided_by_authority) }
 
   describe "#import_links(csv)" do
     context "when a new URL is provided" do
       let(:new_url) { "http://example.com/new-url" }
+      let(:not_provided_by_authority) { "true" }
 
-      it "updates the existing links with the new URLs" do
+      it "updates the existing links with the new URLs and not_provided_by_authority from false to true" do
         old_urls = links.map(&:url)
+        old_not_provided_by_authority_values = links.map(&:not_provided_by_authority)
 
         expect { links_importer.import_links(csv) }
           .to change { links.map(&:reload).map(&:url) }
           .from(old_urls)
           .to([new_url] * links.count)
+          .and change { links.map(&:reload).map(&:not_provided_by_authority) }
+          .from(old_not_provided_by_authority_values)
+          .to([true] * links.count)
       end
 
       it "returns the number of updated links" do
@@ -31,6 +36,7 @@ RSpec.describe LocalLinksManager::Import::Links do
 
     context "when a new URL is provided but isn't valid" do
       let(:new_url) { "closed" }
+      let(:not_provided_by_authority) { "true" }
 
       it "does not update the existing link" do
         expect { links_importer.import_links(csv) }.to_not(change { links.map(&:reload).map(&:url) })
@@ -59,6 +65,7 @@ RSpec.describe LocalLinksManager::Import::Links do
 
     context "when no new URL is provided" do
       let(:new_url) { nil }
+      let(:not_provided_by_authority) { "true" }
 
       it "does not update the existing links" do
         expect { links_importer.import_links(csv) }.to_not(change { links.map(&:reload).map(&:url) })
@@ -68,14 +75,29 @@ RSpec.describe LocalLinksManager::Import::Links do
         expect(links_importer.import_links(csv)).to eq(0)
       end
     end
+
+    context "when no 'Not Provided by Authority' is provided" do
+      let(:new_url) { "http://example.com/new-url" }
+      let(:not_provided_by_authority) { "" }
+
+      it "does not update the existing links not_provided_by_authority field" do
+        expect { links_importer.import_links(csv) }.to_not(change { links.map(&:reload).map(&:not_provided_by_authority) })
+      end
+
+      it "returns the number of updated links" do
+        links_count = csv.split("\n").count - 1 # the number of rows minus the headings
+
+        expect(links_importer.import_links(csv)).to eq(links_count)
+      end
+    end
   end
 
-  def create_csv(local_authority, links, new_url)
+  def create_csv(local_authority, links, new_url, not_provided_by_authority)
     links_as_csv_rows = links.map do |link|
-      "blah,blah,#{local_authority.gss},blah,#{link.service.lgsl_code},#{link.interaction.lgil_code},blah,blah,blah,#{new_url}"
+      "blah,blah,#{local_authority.gss},blah,#{link.service.lgsl_code},#{link.interaction.lgil_code},blah,blah,#{not_provided_by_authority},blah,#{new_url}"
     end
     <<~CSV
-      Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Status,New URL
+      Authority Name,SNAC,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Not Provided by Authority,Status,New URL
       #{links_as_csv_rows.join("\n")}
     CSV
   end

--- a/spec/lib/tasks/export/link_exporter_spec.rb
+++ b/spec/lib/tasks/export/link_exporter_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "Export tasks" do
       la = LocalAuthority.last
       interaction = service_interaction.interaction
       expected_body = <<~EXPECTED_BODY_TEXT
-        Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK
-        #{la.name},#{la.gss},#{service.label}: #{interaction.label},#{service.lgsl_code},#{interaction.lgil_code},#{link.url},true
+        Authority Name,GSS,Description,LGSL,LGIL,URL,Supported by GOV.UK,Not Provided by Authority
+        #{la.name},#{la.gss},#{service.label}: #{interaction.label},#{service.lgsl_code},#{interaction.lgil_code},#{link.url},true,false
       EXPECTED_BODY_TEXT
 
       s3 = double


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


https://trello.com/c/ZTIGibPy/155-allow-authorities-to-not-provide-services, [Jira issue PNP-5488](https://gov-uk.atlassian.net/browse/PNP-5488)



BEFORE:
<img width="1722" alt="Screenshot 2024-05-28 at 13 34 31" src="https://github.com/alphagov/local-links-manager/assets/40758489/04ebd86f-0ae2-4928-b20c-785a043d2644">


AFTER:
<img width="1728" alt="Screenshot 2024-05-28 at 13 34 03" src="https://github.com/alphagov/local-links-manager/assets/40758489/4ac2670a-855c-4c30-927a-74c8b64229ff">
