### PR TITLE
Remove dependency on uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem "plek"
 gem "redis"
 gem "rubocop-govuk"
 gem "sprockets-rails"
-gem "uglifier"
 gem "whenever", require: false
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,6 @@ GEM
       rubocop
       smart_properties
     erubi (1.13.0)
-    execjs (2.8.1)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -741,8 +740,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -808,7 +805,6 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   timecop
-  uglifier
   web-console
   webmock
   whenever


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Remove dependency on uglifier for asset compression.

- needed to be swapped out for terser ahead of the govuk-frontend v5 upgrade, but doesn't appear to be in use
- assets.compile is false, where it would normally use uglifier

## Visual changes
None.

Trello card: https://trello.com/c/qc60GqSG/195-changes-to-applications-for-the-govuk-frontend-v5-upgrade, [Jira issue PNP-8309](https://gov-uk.atlassian.net/browse/PNP-8309)