### PR TITLE
JavaScript changes for govuk-frontend v5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.4)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link application.js
+//= link es6-components.js
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/table

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,10 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/layout-header

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,9 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
 
+<% content_for :head do %>
+  <%= javascript_include_tag "es6-components", type: "module" %>
+<% end %>
+
 <% content_for :body do %>
   <main id="content">
     <%= yield %>


### PR DESCRIPTION
# **DO NOT MERGE**

This PR contains changes that will only work properly with an updated version of `govuk_publishing_components` containing `govuk-frontend` v5, which is still being prepared. This PR is to make the application ready for when the new version of the gem is available. The code on this branch will error without it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- updates the application JavaScript to reflect required changes coming with the govuk-frontend v5 upgrade
- moves some of the JavaScript into a separate script file that will not be opened by legacy browsers, because it contains modern JS that they will not recognise and error on

## Why
Preparing for the v5 upgrade.

## Visual changes
None.

Trello card: https://trello.com/c/HtDe2B36/196-create-new-js-bundles-in-applications-for-v5-upgrade, [Jira issue PNP-8316](https://gov-uk.atlassian.net/browse/PNP-8316)