### PR TITLE
Allow Per-department permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
+  include ServicePermissions
+
+  helper_method :gds_editor?
+
   before_action :authenticate_user!
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/concerns/service_permissions.rb
+++ b/app/controllers/concerns/service_permissions.rb
@@ -2,4 +2,24 @@ module ServicePermissions
   def gds_editor?
     current_user.permissions.include?("GDS Editor")
   end
+
+  def service_owner?(service)
+    service.organisation_slugs.include?(current_user.organisation_slug)
+  end
+
+  def permission_for_service?(service)
+    gds_editor? || service_owner?(service)
+  end
+
+  def redirect_unless_gds_editor
+    redirect_to services_path unless gds_editor?
+  end
+
+  def forbid_unless_permission
+    raise GDS::SSO::PermissionDeniedError, "You do not have permission to view this page" unless permission_for_service?(@service)
+  end
+
+  def forbid_unless_gds_editor
+    raise GDS::SSO::PermissionDeniedError, "You do not have permission to view this page" unless gds_editor?
+  end
 end

--- a/app/controllers/concerns/service_permissions.rb
+++ b/app/controllers/concerns/service_permissions.rb
@@ -11,6 +11,12 @@ module ServicePermissions
     gds_editor? || service_owner?(service)
   end
 
+  def org_name_for_current_user
+    GdsApi.organisations.organisation(current_user.organisation_slug).to_hash["title"]
+  rescue GdsApi::HTTPUnavailable
+    current_user.organisation_slug
+  end
+
   def redirect_unless_gds_editor
     redirect_to services_path unless gds_editor?
   end

--- a/app/controllers/concerns/service_permissions.rb
+++ b/app/controllers/concerns/service_permissions.rb
@@ -1,0 +1,5 @@
+module ServicePermissions
+  def gds_editor?
+    current_user.permissions.include?("GDS Editor")
+  end
+end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,6 +1,11 @@
 class LinksController < ApplicationController
   before_action :load_dependencies, only: %i[edit update destroy]
   before_action :set_back_url_before_post_request, only: %i[edit update destroy]
+
+  before_action :forbid_unless_permission, only: %i[edit update]
+  before_action :forbid_unless_gds_editor, only: %i[destroy homepage_links_status_csv links_status_csv bad_links_url_and_status_csv]
+  before_action :redirect_unless_gds_editor, only: %i[index]
+
   helper_method :back_url
 
   def index

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -4,6 +4,9 @@ class LocalAuthoritiesController < ApplicationController
 
   before_action :set_authority, except: %i[index bad_homepage_url_and_status_csv]
 
+  before_action :forbid_unless_gds_editor, only: %i[update download_links_csv upload_links_csv bad_homepage_url_and_status_csv]
+  before_action :redirect_unless_gds_editor, only: %i[index show edit_url download_links_form upload_links_form]
+
   def index
     Rails.logger.info(params)
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -6,6 +6,8 @@ class ServicesController < ApplicationController
 
   before_action :forbid_unless_permission, except: %i[index]
 
+  helper_method :org_name_for_current_user
+
   def index
     @services = services_for_user(current_user).enabled.order(broken_link_count: :desc)
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,7 +4,8 @@ class ServicesController < ApplicationController
 
   before_action :set_service, except: :index
 
-  before_action :forbid_unless_permission, except: %i[index]
+  before_action :forbid_unless_permission, only: %i[show download_links_form download_links_csv upload_links_form upload_links_csv]
+  before_action :forbid_unless_gds_editor, only: %i[update_owner_form update_owner]
 
   helper_method :org_name_for_current_user
 
@@ -19,6 +20,16 @@ class ServicesController < ApplicationController
     @link_filter = params[:filter]
     @links = links_for_service
     @breadcrumbs = service_breadcrumbs(@service)
+  end
+
+  def update_owner_form
+    @breadcrumbs = service_breadcrumbs(@service) + [{ title: "Update Owner", url: update_owner_form_service_path(@service) }]
+  end
+
+  def update_owner
+    @service.update!(organisation_slugs: params["service"]["organisation_slugs"].split(" "))
+
+    redirect_to service_path(@service, filter: "broken_links")
   end
 
   def download_links_form

--- a/app/presenters/links_table_presenter.rb
+++ b/app/presenters/links_table_presenter.rb
@@ -15,7 +15,7 @@ class LinksTablePresenter
         { text: link.analytics.to_i, format: "numeric" },
         { text: "<span class=\"app-service-label\">#{title}</span>".html_safe },
         { text: "<span class=\"app-interaction-label\">#{link.interaction.label}</span>".html_safe },
-        { text: @view_context.link_to(link.local_authority.name, @view_context.local_authority_path(link.local_authority), class: "govuk-link") },
+        { text: link.local_authority.name },
         { text: "<span class=\"govuk-tag govuk-tag--#{pres.status_tag_colour}\">#{pres.status_description}</span>".html_safe },
         { text: @view_context.link_to("Edit <span class=\"govuk-visually-hidden\">#{link.local_authority.name} - #{si.service.label} - #{si.interaction.label}</span>".html_safe, @view_context.edit_link_path(link.local_authority, link.service, link.interaction), class: "govuk-link") },
       ]

--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -6,6 +6,7 @@ class ServicePresenter < SimpleDelegator
 
     summary_items = [
       { field: "Local Government Service List (LGSL) Code", value: lgsl_code },
+      { field: "Owning Departments", value: organisation_slugs.join(", ") },
       { field: "Page title(s) on GOV.UK", value: govuk_links.compact.any? ? govuk_links.compact.join("</br>").html_safe : "Not used on GOV.UK" },
     ]
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,11 +16,11 @@
   browser_title: (yield :page_title),
 } do %>
 
-<%= render "govuk_publishing_components/components/layout_header", {
-  product_name: "Local Links Manager",
-  environment:,
-  navigation_items: [
-    {
+<%
+  menu_option = []
+
+  if gds_editor?
+    menu_option += [{
       text: "Broken Links",
       href: root_path,
       active: current_page?(root_path),
@@ -29,13 +29,25 @@
       text: "Councils",
       href: local_authorities_path(filter: %w[only_active]),
       active: current_page?(local_authorities_path),
-    },
-    {
-      text: "Services",
-      href: services_path,
-      active: current_page?(services_path),
-    },
-  ],
+    }]
+  end
+
+  menu_option << {
+    text: "Services",
+    href: services_path,
+    active: current_page?(services_path),
+  }
+
+  menu_option << {
+    text: "Switch app",
+    href: Plek.external_url_for("signon"),
+  }
+%>
+
+<%= render "govuk_publishing_components/components/layout_header", {
+  product_name: "Local Links Manager",
+  environment:,
+  navigation_items: menu_option,
   } %>
 
 <div class="govuk-width-container">

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -32,7 +32,7 @@
       <%= render "govuk_publishing_components/components/button", { text: "Update" } %>
     <% end %>
 
-    <% if @link.url %>
+    <% if @link.url && gds_editor? %>
       <div class="app-danger-block">
         <%= form_for @link, url: link_path(@local_authority.slug, @service.slug, @interaction.slug), method: "delete", data: { confirm: "Are you sure you wish to delete this link?" } do |f| %>
         <p class="govuk-body">You can also delete this link if you are certain it is no longer necessary (NB: this cannot be undone)</p>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,9 +1,10 @@
-<% content_for :page_title, "Services" %>
+<% title = gds_editor? ? "Services" : "Services for #{org_name_for_current_user}" %>
+<% content_for :page_title, title %>
 
 <% breadcrumb :services %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: "Services (#{@services.count})",
+  text: "#{title} (#{@services.count})",
   heading_level: 1,
   font_size: "l",
   margin_bottom: 5,

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -15,12 +15,15 @@
     <aside class="app-side__wrapper">
       <div class="app-side">
         <div class="app-side__actions">
+          <%
+            items = []
+            items << link_to("Update Owner", update_owner_form_service_path(@service), class: "govuk-link") if gds_editor?
+            items << link_to("Download Links", download_links_form_service_path(@service), class: "govuk-link")
+            items << link_to("Upload Links", upload_links_form_service_path(@service), class: "govuk-link")
+            items << link_to(@filter_var == "broken_links" ? "Show only broken links" : "Show all links", service_path(@service.slug, filter: @filter_var), class: "govuk-link")
+          %>
           <%= render "govuk_publishing_components/components/list", {
-            items: [
-              link_to("Download Links", download_links_form_service_path(@service), class: "govuk-link"),
-              link_to("Upload Links", upload_links_form_service_path(@service), class: "govuk-link"),
-              link_to(@filter_var == "broken_links" ? "Show only broken links" : "Show all links", service_path(@service.slug, filter: @filter_var), class: "govuk-link"),
-            ],
+            items:,
             margin_bottom: 0,
           } %>
         </div>

--- a/app/views/services/update_owner_form.html.erb
+++ b/app/views/services/update_owner_form.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, "Update Owner" %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Update Owner",
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 5,
+} %>
+
+<%= form_for(@service, url: update_owner_service_path(@service)) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: { text: "Organisation Slugs" },
+    hint: "For multiple owning organisations, list slugs separated by spaces",
+    name: "service[organisation_slugs]",
+    value: @service&.organisation_slugs,
+  } %>
+  <%= render "govuk_publishing_components/components/button", { text: "Submit" } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Cancel",
+    secondary_quiet: true,
+    href: service_path(@service, filter: "broken_links"),
+  } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
       post "download_links_csv"
       get "upload_links_form"
       post "upload_links_csv"
+      get "update-owner-form"
+      patch "update-owner"
     end
   end
 

--- a/db/migrate/20240730142812_modify_services_add_organisation_slug.rb
+++ b/db/migrate/20240730142812_modify_services_add_organisation_slug.rb
@@ -1,0 +1,5 @@
+class ModifyServicesAddOrganisationSlug < ActiveRecord::Migration[7.1]
+  def change
+    add_column :services, :organisation_slugs, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_105241) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_30_142812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_105241) do
     t.string "slug", null: false
     t.boolean "enabled", default: false, null: false
     t.integer "broken_link_count", default: 0
+    t.string "organisation_slugs", default: [], array: true
     t.index ["label"], name: "index_services_on_label", unique: true
     t.index ["lgsl_code"], name: "index_services_on_lgsl_code", unique: true
   end

--- a/docs/adr/adr-001-department-permissions.md
+++ b/docs/adr/adr-001-department-permissions.md
@@ -1,0 +1,41 @@
+# Decision Record: Department Permissions
+
+## Introduction
+
+In July 2024 Places Manager was opened up to departments to allow them to
+directly control their own datasets. It had long been suggested that the
+same openness should be a feature of Local Links Manager, since departments
+often have more information about particular services than GDS. This would form
+part of a future possible three-way access system in which GDS Editors could
+edit any link, departments could edit links in particular services, and local
+authorities could edit links in their authority. This ADR moves towards this
+by opening up the second of these three ways.
+
+## Requirements
+
+Each service would need to be owned by zero, one, or more than one
+departments. Only editors with Local Links Managers access permission in
+Signon should be allowed to view and edit those services, with GDS editors
+allowed to access all services for troubleshooting and incident response.
+
+We followed the pattern from Places Manager, which was itself based on the
+style of permission in Whitehall and other publishing apps, where Signon
+provides the current user's organisational slug and access can be limited
+based on that. A "GDS Editor" special permission is also typical of these
+apps.
+
+## Resulting changes
+
+- Add an `organisational_slugs` field to each service, to be filled in by
+  us for existing services before departments are given access.
+- Add a `GDS Editor` permission. Anyone with this permission can see and
+  edit links for all services. Anyone without this permission can
+  only edit links in services whose organisational_slugs field contains
+  the same slug as reported for them by Signon.
+- Add a UI to edit the organisational slugs. Like Places Manager, this
+  will be a simple string field, with space separation for multiple owners,
+  editable only by someone with the `GDS Editor` permission. We will not at
+  the moment add in an organisational drop-down, so any GDS Editor
+  making changes to the organisation slug will need to know the correct one,
+  but it is assumed that people with this permission will know how to find
+  that out.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,17 @@
+# Permissions
+
+## Named Permissions
+
+- `GDS Editor`: gives the user permission to do all actions in the app.
+
+## Department Permissions
+
+Other permissions are based on the organisation_slug of the current user. If a user does not have the `GDS Editor` permission they will be able to:
+
+- visit the Services page `/services`, which will only show services where the current user's organisation slug is contained in the service's organisation_slugs array.
+- visit the specific service pages of those services
+- download a csv of links for those services
+- download a csv of new links for those services
+- edit links in those services.
+
+The organisation slugs array is editable only by people with the `GDS Editor` permission.

--- a/docs/service-owners.md
+++ b/docs/service-owners.md
@@ -1,0 +1,5 @@
+# Service Owners
+
+Most services currently do not have an owner, but a service can be assigned one or more owning organisations by a user with the `GDS Editor` [permission](/docs/permissions.md). Visit the service, and select the "Update Owner" action from the sidebar. You can then enter one or more organisations by their organisation slug (the final part of their organisation URL on gov.uk, eg: 'government-digital-service' from https://www.gov.uk/government/organisations/government-digital-service), separating organisations with a space if there are more than one.
+
+This allows users from that department with access to Local Links Manager to edit the service as detailed in the [Permissions page](/docs/permissions.md)

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe LinksController, type: :controller do
   before do
-    login_as_stub_user
+    login_as_gds_editor
     @local_authority = create(:local_authority)
     @service = create(:service)
     @interaction = create(:interaction)

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
   describe "GET #index" do
     context "when there is sufficient data" do
       it "returns http succcess" do
-        login_as_stub_user
+        login_as_gds_editor
         create(:local_authority)
         get :index
         expect(response).to have_http_status(200)
@@ -17,7 +17,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     end
 
     it "returns http success" do
-      login_as_stub_user
+      login_as_gds_editor
       get :show, params: { local_authority_slug: @local_authority.slug, service_slug: @service.slug }
       expect(response).to have_http_status(200)
     end
@@ -30,7 +30,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     end
 
     it "returns http success" do
-      login_as_stub_user
+      login_as_gds_editor
       get :edit_url, params: { local_authority_slug: @local_authority.slug }
       expect(response).to have_http_status(200)
     end
@@ -43,7 +43,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     end
 
     it "returns http redirect" do
-      login_as_stub_user
+      login_as_gds_editor
       post :update, params: { local_authority_slug: @local_authority.slug, homepage_url: "http://www.example.com/new-homepage" }
       expect(response).to have_http_status(302)
       @local_authority.reload
@@ -53,7 +53,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
 
   describe "GET bad_homepage_url_and_status_csv" do
     it "retrieves HTTP success" do
-      login_as_stub_user
+      login_as_gds_editor
       get :bad_homepage_url_and_status_csv
       expect(response).to have_http_status(200)
       expect(response.headers["Content-Type"]).to eq("text/csv")
@@ -66,7 +66,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
     end
 
     it "retrieves HTTP success" do
-      login_as_stub_user
+      login_as_gds_editor
       get(
         :download_links_csv,
         params: {
@@ -87,7 +87,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
       let(:url_regex) { /http:\/\/.+\/local_authorities\/#{@local_authority.slug}/ }
 
       it "retrieves HTTP found" do
-        login_as_stub_user
+        login_as_gds_editor
         post(:upload_links_csv, params: { local_authority_slug: @local_authority.slug, csv: })
 
         expect(response.status).to eq(302)
@@ -98,7 +98,7 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
 
     context "with errors in the CSV" do
       before do
-        login_as_stub_user
+        login_as_gds_editor
         interaction = create(:interaction, lgil_code: 1)
         6.times do |i|
           service = create(:service, lgsl_code: i + 1)

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,19 +1,10 @@
 RSpec.describe ServicesController, type: :controller do
   describe "GET #index" do
-    context "when there is missing data" do
-      it "returns http server error" do
-        login_as_stub_user
-        expect { get :index }.to raise_error "Missing Data"
-      end
-    end
-
-    context "when there is sufficient data" do
-      it "returns http succcess" do
-        login_as_stub_user
-        create(:service)
-        get :index
-        expect(response).to have_http_status(200)
-      end
+    it "returns http succcess" do
+      login_as_stub_user
+      create(:service)
+      get :index
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe ServicesController, type: :controller do
+  before { login_as_gds_editor }
+
   describe "GET #index" do
     it "returns http succcess" do
-      login_as_stub_user
       create(:service)
       get :index
       expect(response).to have_http_status(200)
@@ -10,7 +11,6 @@ RSpec.describe ServicesController, type: :controller do
 
   describe "GET #show" do
     it "returns http success" do
-      login_as_stub_user
       service = create(:service)
       get :show, params: { service_slug: service.slug }
       expect(response).to have_http_status(200)
@@ -19,7 +19,6 @@ RSpec.describe ServicesController, type: :controller do
 
   describe "GET #download_links_form" do
     it "returns a success response" do
-      login_as_stub_user
       service = create(:service)
       get :download_links_form, params: { service_slug: service.slug }
       expect(response).to be_successful
@@ -35,7 +34,6 @@ RSpec.describe ServicesController, type: :controller do
     end
 
     it "returns a success response" do
-      login_as_stub_user
       post :download_links_csv, params: { service_slug: service.slug }
       expect(response).to be_successful
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :user do
     name { "New User" }
     email { "user@email.com" }
+    organisation_slug { "test-department" }
     permissions { %w[signin] }
   end
 end

--- a/spec/features/links/index_spec.rb
+++ b/spec/features/links/index_spec.rb
@@ -1,6 +1,6 @@
 feature "The broken links page" do
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
 
     @service = create(:service, :all_tiers)
     @service_interaction = create(:service_interaction, service: @service)

--- a/spec/features/links/links_spec.rb
+++ b/spec/features/links/links_spec.rb
@@ -1,6 +1,6 @@
 feature "The links for a local authority" do
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
     @time = Timecop.freeze("2016-07-14 11:34:09 +0100")
     @local_authority = create(:local_authority, status: "ok", link_last_checked: @time - (60 * 60))
     @service = create(:service)

--- a/spec/features/local_authorities/local_authority_download_links_spec.rb
+++ b/spec/features/local_authorities/local_authority_download_links_spec.rb
@@ -2,7 +2,7 @@ feature "The local authority download CSV page" do
   let!(:local_authority) { create(:district_council) }
 
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
     visit local_authority_path(local_authority_slug: local_authority.slug)
 
     service = create(:service, :all_tiers, label: "OK Service")

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -1,6 +1,6 @@
 feature "The local authorities index page" do
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
 
     @angus = create(:local_authority, name: "Angus")
     @zorro = create(:local_authority, name: "Zorro Council", status: "caution", problem_summary: "Redirect", broken_link_count: 1)

--- a/spec/features/local_authorities/local_authority_show_spec.rb
+++ b/spec/features/local_authorities/local_authority_show_spec.rb
@@ -2,7 +2,7 @@ feature "The local authority show page" do
   let!(:local_authority) { create(:district_council) }
 
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
     visit local_authority_path(local_authority_slug: local_authority.slug)
   end
 

--- a/spec/features/local_authorities/local_authority_upload_links_spec.rb
+++ b/spec/features/local_authorities/local_authority_upload_links_spec.rb
@@ -3,7 +3,8 @@ feature "The local authority upload CSV page" do
   let(:test_authority_path) { local_authority_path(local_authority_slug: local_authority.slug) }
 
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
+
     visit test_authority_path
 
     service = create(:service, :all_tiers, label: "OK Service")

--- a/spec/features/services/service_index_spec.rb
+++ b/spec/features/services/service_index_spec.rb
@@ -1,6 +1,6 @@
 feature "The services index page" do
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
 
     @aardvark = create(:service, label: "Aardvark Wardens")
     @zebra = create(:service, label: "Zebra Fouling", broken_link_count: 1)

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -1,6 +1,6 @@
 feature "The services show page" do
   before do
-    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    login_as_gds_editor
 
     @service = create(:service, :all_tiers)
     service_interaction = create(:service_interaction, service: @service)

--- a/spec/features/services/service_show_spec.rb
+++ b/spec/features/services/service_show_spec.rb
@@ -43,10 +43,6 @@ feature "The services show page" do
   end
 
   describe "for each local authority" do
-    it "the Local Authority name is linked to the council specific page" do
-      expect(page).to have_link @council_a.name, href: local_authority_path(@council_a)
-    end
-
     it "an edit link points to the edit form for that council/interaction" do
       expect(page).to have_link "Edit", href: edit_link_path(@council_a, @service, @link1.service_interaction.interaction)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,10 @@ ActiveRecord::Migration.maintain_test_schema!
 Rails.application.load_tasks
 
 RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [Rails.root.join("spec/fixtures")]
 
@@ -66,6 +70,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include AuthenticationControllerHelpers
 
   config.before do
     stub_publishing_api_for_external_content

--- a/spec/requests/bad_homepage_csv_spec.rb
+++ b/spec/requests/bad_homepage_csv_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe "Bad homepage CSV" do
+  it_behaves_like "it is forbidden to non-GDS Editors", "/bad_homepage_url_status.csv"
+end

--- a/spec/requests/broken_links_page_spec.rb
+++ b/spec/requests/broken_links_page_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe "Broken links page" do
+  it_behaves_like "redirects non-GDS Editors to services page", "/"
+end

--- a/spec/requests/council_page_spec.rb
+++ b/spec/requests/council_page_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe "Council page" do
+  let!(:local_authority) { create(:district_council, slug: "north-midlands") }
+
+  it_behaves_like "redirects non-GDS Editors to services page", "/local_authorities"
+  it_behaves_like "redirects non-GDS Editors to services page", "/local_authorities/north-midlands"
+  it_behaves_like "redirects non-GDS Editors to services page", "/local_authorities/north-midlands/edit_url"
+  it_behaves_like "redirects non-GDS Editors to services page", "/local_authorities/north-midlands/download_links_form"
+  it_behaves_like "redirects non-GDS Editors to services page", "/local_authorities/north-midlands/upload_links_form"
+
+  describe "PATCH local_authorities/:local_authority_slug" do
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "does the update and returns 200 OK" do
+        patch "/local_authorities/north-midlands", params: { homepage_url: "https://www.changed.com" }
+
+        expect(response).to redirect_to("/local_authorities/north-midlands")
+        expect(local_authority.reload.homepage_url).to eq("https://www.changed.com")
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "does not update and returns 403 Forbidden " do
+        patch "/local_authorities/north-midlands", params: { homepage_url: "https://www.changed.com" }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(local_authority.reload.homepage_url).to eq("http://www.angus.gov.uk")
+      end
+    end
+  end
+
+  describe "POST local_authorities/:local_authority_slug/download_links_csv" do
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "returns 200 OK" do
+        post "/local_authorities/north-midlands/download_links_csv", params: { links_status_checkbox: %w[ok] }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "returns 403 Forbidden " do
+        post "/local_authorities/north-midlands/download_links_csv", params: { links_status_checkbox: %w[ok] }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST local_authorities/:local_authority_slug/upload_links_csv" do
+    context "with an empty upload" do
+      context "as a GDS Editor" do
+        before { login_as_gds_editor }
+
+        it "returns 302 found" do
+          post "/local_authorities/north-midlands/upload_links_csv", params: {}
+
+          expect(response).to have_http_status(:found)
+        end
+      end
+
+      context "as a department user" do
+        before { login_as_department_user }
+
+        it "returns 403 Forbidden" do
+          post "/local_authorities/north-midlands/upload_links_csv", params: {}
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/edit_link_page_spec.rb
+++ b/spec/requests/edit_link_page_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe "Edit link page" do
+  let(:owning_department) { "department-of-aardvarks" }
+  let!(:service) { create(:service, label: "Aardvark Wardens", organisation_slugs: [owning_department]) }
+  let!(:interaction) { create(:interaction, label: "reporting") }
+  let!(:service_interaction) { create(:service_interaction, service:, interaction:) }
+  let!(:local_authority) { create(:district_council, slug: "north-midlands") }
+  let!(:link) { create(:link, local_authority:, service_interaction:) }
+
+  describe "GET /local_authorities/:local_authority_slug/services/:service_slug/:interaction_slug/edit" do
+    it_behaves_like "it is forbidden to non-owners", "/local_authorities/north-midlands/services/aardvark-wardens/reporting/edit", "department-of-aardvarks"
+  end
+
+  describe "PUT /local_authorities/:local_authority_slug/services/:service_slug/:interaction_slug" do
+    let(:path) { "/local_authorities/north-midlands/services/aardvark-wardens/reporting" }
+    let(:url) { "http://www.example.com/new" }
+
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "returns 302 Found" do
+        put path, params: { url: }
+
+        expect(response).to have_http_status(:found)
+      end
+
+      it "updates the link" do
+        put path, params: { url: }
+
+        expect(link.reload.url).to eq(url)
+      end
+    end
+
+    context "as a department user from the owning department" do
+      before { login_as_department_user(organisation_slug: owning_department) }
+
+      it "returns 302 Found" do
+        put path, params: { url: }
+
+        expect(response).to have_http_status(:found)
+      end
+
+      it "updates the link" do
+        put path, params: { url: }
+
+        expect(link.reload.url).to eq(url)
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "returns 403 Forbidden" do
+        put path, params: { url: }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the link" do
+        original_link = link.url
+        put path, params: { url: }
+
+        expect(link.reload.url).to eq(original_link)
+      end
+    end
+  end
+
+  describe "DELETE /local_authorities/:local_authority_slug/services/:service_slug/:interaction_slug" do
+    let(:path) { "/local_authorities/north-midlands/services/aardvark-wardens/reporting" }
+
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "returns 302 Found" do
+        delete path
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "as a department user from the owning department" do
+      before { login_as_department_user(organisation_slug: owning_department) }
+
+      it "returns 403 Forbidden" do
+        delete path
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "returns 403 Forbidden" do
+        delete path
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/link_status_csv_spec.rb
+++ b/spec/requests/link_status_csv_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe "Link Status CSV" do
+  it_behaves_like "it is forbidden to non-GDS Editors", "/check_homepage_links_status.csv"
+  it_behaves_like "it is forbidden to non-GDS Editors", "/check_links_status.csv"
+  it_behaves_like "it is forbidden to non-GDS Editors", "/bad_links_url_status.csv"
+end

--- a/spec/requests/services_page_spec.rb
+++ b/spec/requests/services_page_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe "Services page" do
+  let(:owning_department) { "department-of-aardvarks" }
+  let!(:service) { create(:service, label: "Aardvark Wardens", organisation_slugs: [owning_department]) }
+
+  describe "GET /services/:service_slug" do
+    it_behaves_like "it is forbidden to non-owners", "/services/aardvark-wardens", "department-of-aardvarks"
+  end
+
+  describe "GET /services/:service_slug/download_links_form" do
+    it_behaves_like "it is forbidden to non-owners", "/services/aardvark-wardens/download_links_form", "department-of-aardvarks"
+  end
+
+  describe "GET /services/:service_slug/upload_links_form" do
+    it_behaves_like "it is forbidden to non-owners", "/services/aardvark-wardens/upload_links_form", "department-of-aardvarks"
+  end
+
+  describe "POST /services/:service_slug/download_links_csv" do
+    let(:exported_data) { "some_data" }
+
+    before do
+      allow_any_instance_of(LocalLinksManager::Export::ServiceLinksExporter).to receive(:export_links).and_return(exported_data)
+    end
+
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "returns 200 OK" do
+        post "/services/aardvark-wardens/download_links_csv"
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "as a department user from the owning department" do
+      before { login_as_department_user(organisation_slug: owning_department) }
+
+      it "returns 200 OK" do
+        post "/services/aardvark-wardens/download_links_csv"
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "returns 403 Forbidden" do
+        post "/services/aardvark-wardens/download_links_csv"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST /services/:service_slug/upload_links_csv" do
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "returns 302 Found" do
+        post "/services/aardvark-wardens/upload_links_csv"
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "as a department user from the owning department" do
+      before { login_as_department_user(organisation_slug: owning_department) }
+
+      it "returns 302 Found" do
+        post "/services/aardvark-wardens/upload_links_csv"
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "as a department user" do
+      before { login_as_department_user }
+
+      it "returns 403 Forbidden" do
+        post "/services/aardvark-wardens/upload_links_csv"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -13,3 +13,79 @@ module AuthenticationControllerHelpers
     login_as(create(:user, permissions: ["GDS Editor"], organisation_slug: "government-digital-service"))
   end
 end
+
+RSpec.shared_examples "redirects non-GDS Editors to services page" do |path|
+  context "as a GDS Editor" do
+    before { login_as_gds_editor }
+
+    it "shows the page" do
+      get path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "as a department user" do
+    before { login_as_department_user }
+
+    it "does not show the page" do
+      get path
+
+      expect(response).to redirect_to(services_path)
+    end
+  end
+end
+
+RSpec.shared_examples "it is forbidden to non-GDS Editors" do |path|
+  context "as a GDS Editor" do
+    before { login_as_gds_editor }
+
+    it "shows the page" do
+      get path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "as a department user" do
+    before { login_as_department_user }
+
+    it "does not show the page" do
+      get path
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end
+
+RSpec.shared_examples "it is forbidden to non-owners" do |path, owning_department|
+  context "as a GDS Editor" do
+    before { login_as_gds_editor }
+
+    it "returns 200 OK" do
+      get path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "as a department user from the owning department" do
+    before { login_as_department_user(organisation_slug: owning_department) }
+
+    it "returns 200 OK" do
+      get path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "as a department user" do
+    before { login_as_department_user }
+
+    it "returns 403 Forbidden" do
+      get path
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,18 +1,15 @@
 module AuthenticationControllerHelpers
   def login_as(user)
-    request.env["warden"] = double(
-      authenticate!: true,
-      authenticated?: true,
-      user:,
-    )
+    allow_any_instance_of(ApplicationController).to receive(:authenticate_user!).and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:user_signed_in?).and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
   end
 
-  def stub_user
-    create(:user)
+  def login_as_department_user(organisation_slug: "random-department")
+    login_as(create(:user, organisation_slug:))
   end
 
-  def login_as_stub_user
-    login_as stub_user
+  def login_as_gds_editor
+    login_as(create(:user, permissions: ["GDS Editor"], organisation_slug: "government-digital-service"))
   end
 end
-RSpec.configuration.include AuthenticationControllerHelpers, type: :controller

--- a/spec/system/edit_link_page_spec.rb
+++ b/spec/system/edit_link_page_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Edit link page" do
+  let(:owning_department) { "department-of-aardvarks" }
+  let!(:service) { create(:service, label: "Aardvark Wardens", organisation_slugs: [owning_department]) }
+  let!(:interaction) { create(:interaction, label: "reporting") }
+  let!(:service_interaction) { create(:service_interaction, service:, interaction:) }
+  let!(:local_authority) { create(:district_council, slug: "north-midlands") }
+  let!(:link) { create(:link, local_authority:, service_interaction:) }
+
+  context "as an owning user" do
+    before { login_as_department_user(organisation_slug: owning_department) }
+
+    it "doesn't show the delete link" do
+      visit "/local_authorities/north-midlands/services/aardvark-wardens/reporting/edit"
+
+      expect(page).not_to have_button("Delete")
+    end
+  end
+
+  context "as a GDS Editor" do
+    before { login_as_gds_editor }
+
+    it "shows the delete link" do
+      visit "/local_authorities/north-midlands/services/aardvark-wardens/reporting/edit"
+
+      expect(page).to have_button("Delete")
+    end
+  end
+end

--- a/spec/system/main_menu_spec.rb
+++ b/spec/system/main_menu_spec.rb
@@ -1,0 +1,38 @@
+require "gds_api/test_helpers/organisations"
+
+RSpec.describe "Main menu" do
+  include GdsApi::TestHelpers::Organisations
+
+  context "as a normal user" do
+    before do
+      login_as_department_user
+      stub_organisations_api_has_organisations_with_bodies([{ "title" => "Department of Randomness", "details" => { "slug" => "random-department" } }])
+    end
+
+    it "shows only the Services/Switch app menu items" do
+      visit "/"
+
+      within(".govuk-header__container") do
+        expect(page).not_to have_link("Broken Links")
+        expect(page).not_to have_link("Councils")
+        expect(page).to have_link("Services")
+        expect(page).to have_link("Switch app")
+      end
+    end
+  end
+
+  context "as a GDS Editor" do
+    before { login_as_gds_editor }
+
+    it "shows all four menu options" do
+      visit "/"
+
+      within(".govuk-header__container") do
+        expect(page).to have_link("Broken Links")
+        expect(page).to have_link("Councils")
+        expect(page).to have_link("Services")
+        expect(page).to have_link("Switch app")
+      end
+    end
+  end
+end

--- a/spec/system/service_page_spec.rb
+++ b/spec/system/service_page_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe "Service page" do
+  before do
+    create(:service, label: "Aardvark Wardens", organisation_slugs: %w[department-of-aardvarks])
+  end
+
+  describe "Visiting the page" do
+    context "as an owning department user" do
+      before { login_as_department_user(organisation_slug: "department-of-aardvarks") }
+
+      it "does not show the Update Owner link" do
+        visit "/services/aardvark-wardens"
+
+        expect(page).not_to have_content("Update Owner")
+      end
+    end
+
+    context "as a GDS Editor" do
+      before { login_as_gds_editor }
+
+      it "shows the Update Owner link" do
+        visit "/services/aardvark-wardens"
+
+        expect(page).to have_content("Update Owner")
+      end
+    end
+  end
+
+  describe "Updating the owner" do
+    before { login_as_gds_editor }
+
+    it "allows us to update the owner" do
+      visit "/services/aardvark-wardens"
+
+      expect(page).to have_content("department-of-aardvarks")
+      expect(page).not_to have_content("government-digital-service")
+
+      click_on "Update Owner"
+      fill_in "Organisation Slug", with: "government-digital-service"
+      click_on "Submit"
+
+      expect(page).not_to have_content("department-of-aardvarks")
+      expect(page).to have_content("government-digital-service")
+    end
+
+    it "allows us to cancel updating the owner" do
+      visit "/services/aardvark-wardens"
+
+      expect(page).to have_content("department-of-aardvarks")
+      expect(page).not_to have_content("government-digital-service")
+
+      click_on "Update Owner"
+      fill_in "Organisation Slug", with: "government-digital-service"
+      click_on "Cancel"
+
+      expect(page).to have_content("department-of-aardvarks")
+      expect(page).not_to have_content("government-digital-service")
+    end
+  end
+end

--- a/spec/system/services_page_spec.rb
+++ b/spec/system/services_page_spec.rb
@@ -1,0 +1,77 @@
+require "gds_api/test_helpers/organisations"
+
+RSpec.describe "Services page" do
+  include GdsApi::TestHelpers::Organisations
+
+  before do
+    create(:service, label: "Aardvark Wardens", organisation_slugs: %w[department-of-aardvarks])
+  end
+
+  context "as a gds editor" do
+    before { login_as_gds_editor }
+
+    it "shows all the services" do
+      visit "/services"
+
+      expect(page).to have_content("Aardvark Wardens")
+    end
+
+    it "shows a generic title" do
+      visit "/services"
+
+      expect(page).to have_content("Services (1)")
+    end
+  end
+
+  context "as a department user" do
+    before do
+      stub_organisations_api_has_organisations_with_bodies([{ "title" => "Department of Randomness", "details" => { "slug" => "random-department" } }])
+      login_as_department_user
+    end
+
+    it "does not show Aardvark Wardens service" do
+      visit "/services"
+
+      expect(page).not_to have_content("Aardvark Wardens")
+    end
+
+    it "shows a department title" do
+      visit "/services"
+
+      expect(page).to have_content("Services for Department of Randomness (0)")
+    end
+
+    context "if the Organisations API fails" do
+      before do
+        stub_request(:get, "#{Plek.new.website_root}/api/organisations/random-department").to_raise(GdsApi::HTTPUnavailable)
+      end
+
+      it "shows a generic title" do
+        visit "/services"
+
+        expect(page).to have_content("Services for random-department (0)")
+      end
+    end
+  end
+
+  context "as a user from an owning department" do
+    before do
+      stub_organisations_api_has_organisations_with_bodies([{ "title" => "Department of Aardvarks", "details" => { "slug" => "department-of-aardvarks" } }])
+      login_as_department_user(organisation_slug: "department-of-aardvarks")
+    end
+
+    before { login_as_department_user(organisation_slug: "department-of-aardvarks") }
+
+    it "shows the related services only" do
+      visit "/services"
+
+      expect(page).to have_content("Aardvark Wardens")
+    end
+
+    it "shows a department title" do
+      visit "/services"
+
+      expect(page).to have_content("Services for Department of Aardvarks (1)")
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to mark a service as owned by one or more organisations, allowing users from those organisations that have been granted access to Local Links Manager in signon to view and edit links for those services. Other existing actions, and the ability to set owners, now only available with the new `GDS Editor` permission.

A menu option to Switch app has been added, consistent with Whitehall.

New tests are Request/System specs - we have not updated old Controller/Feature tests in this app, that has been captured as technical debt for updating later.

⚠️ **WARNING: merging PR without first updating existing GDS users of LLM with the new permission will result in them losing the ability to view local authorities and services. Update their permissions before merging!** ⚠️

- [x] Update permissions

https://trello.com/c/1eUXHHBz/22-restrict-access-to-a-specific-service, [Jira issue PNP-8560](https://gov-uk.atlassian.net/browse/PNP-8560)

## Screenshots

### View of the services page when logged in as a user (note main menu does not offer the broken links or council options)

![Screenshot 2024-08-14 at 11 24 26](https://github.com/user-attachments/assets/20e41b82-0c6e-437a-b192-8c85fac5736b)

### View of an owned service page when logged in as a user (note main menu does not offer the broken links or council options, update owners link is not available in sidebar)

![Screenshot 2024-08-14 at 11 24 34](https://github.com/user-attachments/assets/1692c82a-5ada-40d7-b03b-bd44a1082374)

### View of the edit link page for an owned service page when logged in as a user (note main menu does not offer the broken links or council options, delete option is not available)

![Screenshot 2024-08-14 at 11 24 43](https://github.com/user-attachments/assets/2cd65be1-dc32-42a2-a886-5c8326628057)

### View of an owned service page when logged in with GDS Editor permissions (update owners link is available in sidebar)

![Screenshot 2024-08-14 at 11 22 05](https://github.com/user-attachments/assets/3d402f83-6e9c-4bea-8b09-aafa0bf49240)

### New Update Owners form, available on when logged in with GDS Editor permissions 

![Screenshot 2024-08-14 at 11 22 19](https://github.com/user-attachments/assets/e43a36c2-6dac-490a-9fa4-a076ee72494a)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
