### PR TITLE
Usability Improvements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/components/breadcrumbs";
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/checkboxes";
+@import "govuk_publishing_components/components/error-alert";
 @import "govuk_publishing_components/components/file-upload";
 @import "govuk_publishing_components/components/heading";
 @import "govuk_publishing_components/components/input";
@@ -15,8 +16,10 @@ $govuk-page-width: 1140px;
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-for-admin";
 @import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/notice";
 @import "govuk_publishing_components/components/option-select";
 @import "govuk_publishing_components/components/table";
+@import "govuk_publishing_components/components/success-alert";
 @import "govuk_publishing_components/components/summary-list";
 
 // app specific sass

--- a/app/controllers/concerns/link_importer_utils.rb
+++ b/app/controllers/concerns/link_importer_utils.rb
@@ -22,13 +22,17 @@ module LinkImporterUtils
       update_count = links_importer.import_links(params[:csv].read)
       if links_importer.errors.any?
         flash[:danger] = clear_errors_from_links_importer(links_importer)
+        false
       elsif update_count.zero?
-        flash[:warning] = "No records updated. (If you were expecting updates, check the format of the uploaded file)"
+        flash[:info] = "No records updated. (If you were expecting updates, check the format of the uploaded file)"
+        false
       else
         flash[:success] = "#{update_count} #{'link has'.pluralize(update_count)} been updated"
+        true
       end
     else
       flash[:danger] = "A CSV file must be provided."
+      false
     end
   end
 end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -51,8 +51,9 @@ class LocalAuthoritiesController < ApplicationController
   end
 
   def upload_links_csv
-    attempt_import(:local_authority, @authority)
-    redirect_to local_authority_path(@authority)
+    redirect_to local_authority_path(@authority) if attempt_import(:local_authority, @authority)
+
+    redirect_to(upload_links_form_local_authority_path(@authority))
   end
 
   def bad_homepage_url_and_status_csv

--- a/app/presenters/links_table_presenter.rb
+++ b/app/presenters/links_table_presenter.rb
@@ -47,7 +47,6 @@ class LinksTablePresenter
       },
       {
         text: "",
-        format: "numeric",
       },
     ]
 

--- a/app/presenters/links_table_presenter.rb
+++ b/app/presenters/links_table_presenter.rb
@@ -46,7 +46,7 @@ class LinksTablePresenter
         text: "Status",
       },
       {
-        text: "",
+        text: "<span class=\"govuk-visually-hidden\">Edit</span>".html_safe,
       },
     ]
 

--- a/app/presenters/local_authorities_table_presenter.rb
+++ b/app/presenters/local_authorities_table_presenter.rb
@@ -10,10 +10,11 @@ class LocalAuthoritiesTablePresenter
 
       [
         { text: authority.links.sum { |l| l.analytics.to_i }, format: "numeric" },
-        { text: @view_context.link_to(authority.name, @view_context.local_authority_path(authority.slug, filter: "broken_links"), class: "govuk-link") },
+        { text: authority.name },
         { text: "<span class=\"govuk-tag govuk-tag--#{la_presenter.homepage_status_colour}\">#{la_presenter.homepage_status}</span>".html_safe },
         { text: authority.active? ? "Yes" : "No" },
         { text: authority.broken_link_count, format: "numeric" },
+        { text: @view_context.link_to("Edit <span class=\"govuk-visually-hidden\">#{authority.name}</span>".html_safe, @view_context.local_authority_path(authority.slug, filter: "broken_links"), class: "govuk-link") },
       ]
     end
   end
@@ -36,6 +37,9 @@ class LocalAuthoritiesTablePresenter
       {
         text: "Broken Links",
         format: "numeric",
+      },
+      {
+        text: "<span class=\"govuk-visually-hidden\">Edit</span>".html_safe,
       },
     ]
   end

--- a/app/presenters/service_presenter.rb
+++ b/app/presenters/service_presenter.rb
@@ -6,7 +6,7 @@ class ServicePresenter < SimpleDelegator
 
     summary_items = [
       { field: "Local Government Service List (LGSL) Code", value: lgsl_code },
-      { field: "GOV.UK Pages", value: govuk_links.compact.any? ? govuk_links.compact.join("</br>").html_safe : "Not used on GOV.UK" },
+      { field: "Page title(s) on GOV.UK", value: govuk_links.compact.any? ? govuk_links.compact.join("</br>").html_safe : "Not used on GOV.UK" },
     ]
 
     { items: summary_items }

--- a/app/presenters/services_table_presenter.rb
+++ b/app/presenters/services_table_presenter.rb
@@ -6,16 +6,15 @@ class ServicesTablePresenter
 
   def rows
     @services.map do |service|
-      govuk_links = ServiceInteraction.where(service:).map do |si|
-        si.govuk_title ? @view_context.link_to(si.govuk_title, "#{Plek.website_root}/#{si.govuk_slug}", class: "govuk-link") : nil
-      end
+      govuk_pages = ServiceInteraction.where(service:).map(&:govuk_title)
 
       [
         { text: service.links.sum { |l| l.analytics.to_i }, format: "numeric" },
-        { text: @view_context.link_to(service.label, @view_context.service_path(service, filter: "broken_links"), class: "govuk-link") },
-        { text: govuk_links.compact.any? ? govuk_links.compact.join("<br />").html_safe : "Not used on GOV.UK" },
+        { text: service.label },
+        { text: govuk_pages.compact.any? ? govuk_pages.compact.join("<br />").html_safe : "Not used on GOV.UK" },
         { text: service.lgsl_code },
         { text: service.broken_link_count, format: "numeric" },
+        { text: @view_context.link_to("Edit <span class=\"govuk-visually-hidden\">#{service.label}</span>".html_safe, @view_context.service_path(service, filter: "broken_links"), class: "govuk-link") },
       ]
     end
   end
@@ -30,7 +29,7 @@ class ServicesTablePresenter
         text: "Service Name",
       },
       {
-        text: "GOV.UK Pages",
+        text: "Page title(s) on GOV.UK",
       },
       {
         text: "LGSL Code",
@@ -38,6 +37,9 @@ class ServicesTablePresenter
       {
         text: "Broken Links",
         format: "numeric",
+      },
+      {
+        text: "<span class=\"govuk-visually-hidden\">Edit</span>".html_safe,
       },
     ]
   end

--- a/app/views/local_authorities/upload_links_form.html.erb
+++ b/app/views/local_authorities/upload_links_form.html.erb
@@ -3,4 +3,6 @@
 
 <% content_for :page_title, title %>
 
+<%= render partial: "shared/flash" %>
+
 <%= render partial: "shared/upload_links_form", locals: { form_path:, title: } %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,11 @@
+<% if flash[:danger].present? %>
+  <%= render "govuk_publishing_components/components/error_alert", { message: sanitize(flash[:danger]) } %>
+<% end %>
+
+<% if flash[:info].present? %>
+  <%= render "govuk_publishing_components/components/notice", { description: sanitize(flash[:info]) } %>
+<% end %>
+
+<% if flash[:success].present? %>
+  <%= render "govuk_publishing_components/components/success_alert", { message: sanitize(flash[:success]) } %>
+<% end %>

--- a/spec/controllers/local_authorities_controller_spec.rb
+++ b/spec/controllers/local_authorities_controller_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe LocalAuthoritiesController, type: :controller do
         expect(flash[:danger].first).to eq("2 Errors detected. Please ensure a valid entry in the New URL column for lines:")
       end
 
-      it "shows the nothing to import warning if it didn't import anything" do
+      it "shows the nothing to import info if it didn't import anything" do
         csv = Rack::Test::UploadedFile.new(Rails.root.join(fixture_path, "imported_links_nothing_to_import.csv"), "text/csv", true)
         post(:upload_links_csv, params: { local_authority_slug: local_authority.slug, csv: })
-        expect(flash[:warning]).to eq("No records updated. (If you were expecting updates, check the format of the uploaded file)")
+        expect(flash[:info]).to eq("No records updated. (If you were expecting updates, check the format of the uploaded file)")
       end
     end
   end

--- a/spec/features/local_authorities/local_authority_index_spec.rb
+++ b/spec/features/local_authorities/local_authority_index_spec.rb
@@ -21,8 +21,8 @@ feature "The local authorities index page" do
   end
 
   it "shows links to each local authority page" do
-    expect(page).to have_link("Angus", href: local_authority_path(@angus.slug, filter: "broken_links"))
-    expect(page).to have_link("Zorro Council", href: local_authority_path(@zorro.slug, filter: "broken_links"))
+    expect(page).to have_link("Edit Angus", href: local_authority_path(@angus.slug, filter: "broken_links"), exact: true)
+    expect(page).to have_link("Edit Zorro Council", href: local_authority_path(@zorro.slug, filter: "broken_links"), exact: true)
   end
 
   it "shows the count of broken links for each local authority" do
@@ -34,10 +34,10 @@ feature "The local authorities index page" do
     expect(page).not_to have_content "Hidden Council Not checked No 0"
   end
 
-  describe "clicking on the LA name on the index page" do
+  describe "clicking on the Edit link on the index page" do
     it "takes you to the show page for that LA" do
-      click_link("Angus")
-      expect(current_path).to eq(local_authority_path(@angus.slug))
+      first("tbody").first("tr").click_link("Edit")
+      expect(current_path).to eq(local_authority_path(@zorro.slug))
     end
   end
 

--- a/spec/features/local_authorities/local_authority_upload_links_spec.rb
+++ b/spec/features/local_authorities/local_authority_upload_links_spec.rb
@@ -1,0 +1,28 @@
+feature "The local authority upload CSV page" do
+  let!(:local_authority) { create(:district_council) }
+  let(:test_authority_path) { local_authority_path(local_authority_slug: local_authority.slug) }
+
+  before do
+    User.create!(email: "user@example.com", name: "Test User", permissions: %w[signin])
+    visit test_authority_path
+
+    service = create(:service, :all_tiers, label: "OK Service")
+    service_interaction = create(:service_interaction, service:)
+    create(:link, local_authority:, service_interaction:, status: :ok)
+
+    service = create(:service, :all_tiers, label: "Broken Service")
+    service_interaction = create(:service_interaction, service:)
+    create(:link, local_authority:, service_interaction:, status: :broken)
+
+    click_on "Upload Links"
+  end
+
+  describe "Empty upload" do
+    it "returns to the local authority page" do
+      find("#content").click_on "Upload Links"
+
+      expect(page.current_path).to eq(upload_links_form_local_authority_path(local_authority))
+      expect(page.body).to include("A CSV file must be provided.")
+    end
+  end
+end


### PR DESCRIPTION
Usability improvements to tables (moving edit links to a dedicated column at the end, removing additional links and renaming column), and to the local authorities upload links page (errors now appear in a flash, rather than being swallowed and redirected to the local authority page)

## Screenshots:

### Services table

#### Before (Multiple confusing calls to action)
<img width="1213" alt="Screenshot 2024-08-06 at 09 55 42" src="https://github.com/user-attachments/assets/b45ec95d-809a-4313-9992-928035129ebf">

#### After (Single call to action link, page title column renamed)
<img width="1246" alt="Screenshot 2024-08-06 at 09 55 48" src="https://github.com/user-attachments/assets/6e5e83f8-21cc-4abf-a022-92680418f567">

#### Before (Call to action link hidden in authority name )
<img width="916" alt="Screenshot 2024-08-06 at 09 55 19" src="https://github.com/user-attachments/assets/3f0814c6-904b-48fb-933f-daad48351669">

#### After (Single call to action link)
<img width="901" alt="Screenshot 2024-08-06 at 09 55 30" src="https://github.com/user-attachments/assets/b3bf854c-7d9d-434f-b29c-c4428a448c84">

### Flashes on local authority uploads:
<img width="1174" alt="Screenshot 2024-08-06 at 09 52 25" src="https://github.com/user-attachments/assets/1a66b64e-0f98-4bfa-8398-2d35a44b236d">
