### PR TITLE
Fix double redirect_to when import works

### DIFF
--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -51,7 +51,7 @@ class LocalAuthoritiesController < ApplicationController
   end
 
   def upload_links_csv
-    redirect_to local_authority_path(@authority) if attempt_import(:local_authority, @authority)
+    return redirect_to local_authority_path(@authority) if attempt_import(:local_authority, @authority)
 
     redirect_to(upload_links_form_local_authority_path(@authority))
   end


### PR DESCRIPTION
A call to redirect_to in a guard clause without a return left us in a situation where we had two redirect_to calls in one action, which meant that although CSV uploads to the council page were successful, they returned a generic "we're sorry..." error page to the user.

https://trello.com/c/fSN5dTz4/27-problem-uploading-csv-from-local-authority, [Jira issue PNP-8546](https://gov-uk.atlassian.net/browse/PNP-8546)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
