### PR TITLE
Update Southend-on-Sea City Council name

### DIFF
--- a/data/local-authorities.csv
+++ b/data/local-authorities.csv
@@ -296,7 +296,7 @@ id,gss,snac,local_custodian_code,tier_id,parent_local_authority_id,slug,country_
 314,S12000028,00RE,9076,3,,south-ayrshire,Scotland,https://www.south-ayrshire.gov.uk/,"South Ayrshire Council"
 316,E07000012,12UG,530,2,56,south-cambridgeshire,England,http://www.scambs.gov.uk/,"South Cambridgeshire District Council"
 317,E07000039,17UK,1040,2,101,south-derbyshire,England,https://www.southderbyshire.gov.uk,"South Derbyshire District Council"
-318,E06000033,00KF,1590,3,,southend-on-sea,England,http://www.southend.gov.uk/,"Southend-on-Sea Borough Council"
+318,E06000033,00KF,1590,3,,southend-on-sea,England,http://www.southend.gov.uk/,"Southend-on-Sea City Council"
 319,E06000025,00HD,119,3,,south-gloucestershire,England,http://www.southglos.gov.uk/,"South Gloucestershire Council"
 320,E07000044,18UG,1125,2,104,south-hams,England,http://www.southhams.gov.uk/,"South Hams District Council"
 321,E07000140,32UF,2525,2,205,south-holland,England,https://www.sholland.gov.uk/,"South Holland District Council"


### PR DESCRIPTION
...was Southend-on-Sea Borough Council.

https://trello.com/c/S2X0iTYL/367-update-southend-on-sea-borough-council-to-be-southend-on-sea-city-council, [Jira issue PNP-8570](https://gov-uk.atlassian.net/browse/PNP-8570)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
