### PR TITLE
Add rake task - Export link status to csv

### DIFF
--- a/lib/tasks/export/links_status_csv_exporter.rake
+++ b/lib/tasks/export/links_status_csv_exporter.rake
@@ -1,0 +1,36 @@
+require "csv"
+require "aws-sdk-s3"
+
+namespace :export do
+  namespace :links do
+    desc "Generate links status to CSV and upload to S3"
+    task "status": :environment do
+      filename1 = "all_links_status_count.csv"
+      filename2 = "links_with_local_authority_service.csv"
+
+      bucket = ENV["AWS_S3_ASSET_BUCKET_NAME"]
+      key = "data/local-links-manager/#{filename2}"
+
+      s3 = Aws::S3::Client.new
+
+      CSV.open(filename1, "wb") do |csv|
+        csv << %w[Status Problem_Summary Count Percentage]
+        Link.group(:status, :problem_summary).count.each do |(status, problem_summary), count|
+          percentage = (count.to_f * 100 / Link.count).round(2)
+          csv << [status || "nil", problem_summary || "nil", count, percentage]
+        end
+      end
+
+      CSV.open(filename2, "wb") do |csv|
+        csv << ["Link", "Local Authority", "Service", "Status", "Problem Summary"]
+        Link.joins(:local_authority, :service)
+          .select("links.url AS link_url", "local_authorities.name AS local_authority_name", "services.label AS service_name", "links.status AS link_status", "links.problem_summary AS link_problem_summary")
+          .each do |link|
+            csv << [link.link_url, link.local_authority_name, link.service_name, link.link_status, link.link_problem_summary]
+          end
+      end
+
+      s3.put_object({ body: File.read(filename2), bucket: bucket, key: key })
+    end
+  end
+end

--- a/spec/lib/tasks/export/links_status_csv_exporter_spec.rb
+++ b/spec/lib/tasks/export/links_status_csv_exporter_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Export tasks" do
+  describe "export:links:status" do
+    it "should write the links to S3" do
+      service = create(:service, :all_tiers, lgsl_code: 1)
+      local_authority = create(:local_authority)
+      service_interaction = create(:service_interaction, service: service)
+      link = create(:link, service_interaction: service_interaction, local_authority: local_authority)
+
+      expected_body = <<~EXPECTED_BODY_TEXT
+        Link,Local Authority,Service,Status,Problem Summary
+        #{link.url},#{local_authority.name},#{service.label},#{link.status},#{link.problem_summary}
+      EXPECTED_BODY_TEXT
+
+      s3 = double
+      allow(Aws::S3::Client).to receive(:new).and_return(s3)
+      expect(s3).to receive(:put_object).with({
+        body: expected_body,
+        bucket: nil,
+        key: "data/local-links-manager/links_with_local_authority_service.csv",
+      })
+
+      Rake::Task["export:links:status"].execute
+    end
+  end
+end


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Command : govuk-docker-run bundle exec rake 'export:links:status' 
This will generate the csv with all the links and their status along with the local authority and service. It will also upload the csv to S3 bucket in AWS.

Trello card: https://trello.com/c/0zxhLxEC/485-csv-report-from-local-links-manager, [Jira issue PNP-6358](https://gov-uk.atlassian.net/browse/PNP-6358)
