### PR TITLE
Modify link_status rake task - To upload in S3 bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -73,7 +73,7 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/lib/tasks/export/links_status_csv_exporter.rake
+++ b/lib/tasks/export/links_status_csv_exporter.rake
@@ -5,32 +5,26 @@ namespace :export do
   namespace :links do
     desc "Generate links status to CSV and upload to S3"
     task "status": :environment do
-      filename1 = "all_links_status_count.csv"
-      filename2 = "links_with_local_authority_service.csv"
+      filename = "links_with_local_authority_service.csv"
 
       bucket = ENV["AWS_S3_ASSET_BUCKET_NAME"]
-      key = "data/local-links-manager/#{filename2}"
+      key = "data/local-links-manager/#{filename}"
 
       s3 = Aws::S3::Client.new
 
-      CSV.open(filename1, "wb") do |csv|
-        csv << %w[Status Problem_Summary Count Percentage]
-        Link.group(:status, :problem_summary).count.each do |(status, problem_summary), count|
-          percentage = (count.to_f * 100 / Link.count).round(2)
-          csv << [status || "nil", problem_summary || "nil", count, percentage]
+      StringIO.open do |body|
+        output = CSV.generate do |csv|
+          csv << ["Link", "Local Authority", "Service", "Status", "Problem Summary"]
+          Link.joins(:local_authority, :service)
+            .select("links.url AS link_url", "local_authorities.name AS local_authority_name", "services.label AS service_name", "links.status AS link_status", "links.problem_summary AS link_problem_summary")
+            .each do |link|
+              csv << [link.link_url, link.local_authority_name, link.service_name, link.link_status, link.link_problem_summary]
+            end
         end
-      end
+        body.write(output)
 
-      CSV.open(filename2, "wb") do |csv|
-        csv << ["Link", "Local Authority", "Service", "Status", "Problem Summary"]
-        Link.joins(:local_authority, :service)
-          .select("links.url AS link_url", "local_authorities.name AS local_authority_name", "services.label AS service_name", "links.status AS link_status", "links.problem_summary AS link_problem_summary")
-          .each do |link|
-            csv << [link.link_url, link.local_authority_name, link.service_name, link.link_status, link.link_problem_summary]
-          end
+        s3.put_object({ body: body.string, bucket:, key: })
       end
-
-      s3.put_object({ body: File.read(filename2), bucket: bucket, key: key })
     end
   end
 end


### PR DESCRIPTION
This will generate the CSV with all the links and their status along with the local authority and service and upload the csv to S3 bucket in AWS.
This will modify the related PR which generates the CSV locally.
https://github.com/alphagov/local-links-manager/pull/1545

**Command:** govuk-docker-run bundle exec rake 'export:links:status'

**Trello card:** https://trello.com/c/0zxhLxEC/485-csv-report-from-local-links-manager, [Jira issue PNP-6358](https://gov-uk.atlassian.net/browse/PNP-6358)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

