### PR TITLE
Fix active/inactive council behaviour

### DIFF
--- a/app/lib/local_links_manager/check_links/link_status_requester.rb
+++ b/app/lib/local_links_manager/check_links/link_status_requester.rb
@@ -9,7 +9,8 @@ module LocalLinksManager
         ServiceInteraction.includes(:service)
           .where(services: { enabled: true })
           .find_each do |service|
-          urls = service.links.with_url.order(analytics: :asc).map(&:url).uniq
+          links = service.links.with_url.order(analytics: :asc)
+          urls = links.select { |link| link.local_authority.active? }.map(&:url).uniq
           check_urls(urls) unless urls.empty?
         end
 
@@ -28,7 +29,7 @@ module LocalLinksManager
       end
 
       def homepage_urls
-        LocalAuthority.all.map(&:homepage_url).sort
+        LocalAuthority.active.map(&:homepage_url).sort
       end
 
       def check_urls(urls)

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -72,10 +72,14 @@ class LocalAuthority < ApplicationRecord
 private
 
   def update_external_content
-    if active? && (saved_change_to_name? || saved_change_to_homepage_url?)
-      LocalAuthorityExternalContentPublisher.new(self).publish
+    if active?
+      LocalAuthorityExternalContentPublisher.new(self).publish if publishable_changes?
     else
       LocalAuthorityExternalContentPublisher.new(self).unpublish
     end
+  end
+
+  def publishable_changes?
+    saved_change_to_name? || saved_change_to_homepage_url?
   end
 end

--- a/lib/tasks/check-links/link_checker.rake
+++ b/lib/tasks/check-links/link_checker.rake
@@ -28,12 +28,12 @@ namespace :"check-links" do
   end
 
   desc <<~DESC
-    Check links & update link status for all local authorities.
+    Check links & update link status for all active local authorities.
     This will run in the background as a queue of Sidekiq jobs.
     The jobs will take a long time to complete, even a few hours.
   DESC
   task all_local_authorities: :environment do
     checker = LocalLinksManager::CheckLinks::LinkStatusRequester.new
-    LocalAuthority.all.find_each { |la| checker.check_authority_urls(la.slug) }
+    LocalAuthority.active.find_each { |la| checker.check_authority_urls(la.slug) }
   end
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe LocalAuthority, type: :model do
       before do
         WebMock.reset!
         @subject = build(:local_authority, content_id: SecureRandom.uuid)
-        stub_publishing_api_subject_published(subject)
+        stub_publishing_api_subject_published(@subject)
         stub_publishing_api_for_subject(@subject)
         @subject.save!
         WebMock.reset!
@@ -176,7 +176,7 @@ RSpec.describe LocalAuthority, type: :model do
         expect(stubs.last).to have_been_requested.once
       end
 
-      it "should do nothing if other attributes are altered" do
+      it "should not publish if other attributes are altered" do
         stub_publishing_api_subject_missing(@subject)
         @subject.broken_link_count = 999
         stubs = stub_publishing_api_for_subject(@subject)
@@ -184,6 +184,15 @@ RSpec.describe LocalAuthority, type: :model do
 
         expect(stubs.first).not_to have_been_requested
         expect(stubs.last).not_to have_been_requested
+      end
+
+      it "should not unpublish if other attributes are altered" do
+        stub_publishing_api_subject_published(@subject)
+        @subject.broken_link_count = 998
+        stub = stub_unpublish_for_subject(@subject)
+        @subject.save!
+
+        expect(stub).not_to have_been_requested
       end
 
       it "should unpublish the external content when the council is retired" do


### PR DESCRIPTION
Fixes two things noticed as a result of service decommissioning in this card: https://trello.com/c/YDkfN7A3/638-delete-dataset-from-local-links-manager, [Jira issue PNP-6407](https://gov-uk.atlassian.net/browse/PNP-6407)

1) Improves link checking by restricting it to homepages/links from active local authorities, reducing the load on the link checker.
2) Fixes a logic error in publishing behaviour. Local authorities should be republished if their name or url changes, unpublished if they pass their active end date. The existing code was republishing correctly, but would unpublish if it did not
republish (ie it would unpublish not only local authorities becoming inactive,  but also any which changed where the change did not include a change to homepage or title, which in effect would unpublish any council whose broken link count changed during the nightly link checker run).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
