### PR TITLE
fix: Update Milton Keynes name

### DIFF
--- a/data/local-authorities.csv
+++ b/data/local-authorities.csv
@@ -216,7 +216,7 @@ id,gss,snac,local_custodian_code,tier_id,parent_local_authority_id,slug,country_
 223,E07000203,42UE,3520,2,348,mid-suffolk,England,https://www.midsuffolk.gov.uk/,"Mid Suffolk District Council"
 224,E07000228,45UG,3830,2,400,mid-sussex,England,http://www.midsussex.gov.uk/,"Mid Sussex District Council"
 225,N09000009,,8138,3,,mid-ulster,Northern Ireland,https://www.midulstercouncil.org/,"Mid Ulster District Council"
-226,E06000042,00MG,435,3,,milton-keynes,England,https://www.milton-keynes.gov.uk/,"Milton Keynes Council"
+226,E06000042,00MG,435,3,,milton-keynes,England,https://www.milton-keynes.gov.uk/,"Milton Keynes City Council"
 227,E07000210,43UE,3620,2,350,mole-valley,England,https://www.molevalley.gov.uk/,"Mole Valley District Council"
 228,W06000021,00PP,6840,3,,monmouthshire,Wales,https://www.monmouthshire.gov.uk/,"Monmouthshire County Council"
 231,W06000012,00NZ,6930,3,,neath-port-talbot,Wales,http://www.neath-porttalbot.gov.uk,"Neath Port Talbot County Borough Council"


### PR DESCRIPTION
- Milton Keynes Council changed its name to Milton Keynes City Council in 2022.
- Update the local-authorities.csv file. Name in production app will be updated via the rails console.

https://trello.com/c/Diygq0Fn/420-change-name-for-milton-keynes-in-local-links-manager, [Jira issue PNP-5861](https://gov-uk.atlassian.net/browse/PNP-5861)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
