### PR TITLE
Add full links status to download links CSV

### DIFF
--- a/app/lib/local_links_manager/export/links_exporter.rb
+++ b/app/lib/local_links_manager/export/links_exporter.rb
@@ -14,6 +14,9 @@ module LocalLinksManager
         :url,
         :title,
         :enabled,
+        :problem_summary,
+        :link_errors,
+        :link_warnings,
       ].freeze
       COMMON_HEADINGS = [
         "Authority Name",
@@ -25,7 +28,7 @@ module LocalLinksManager
         "Title",
         "Supported by GOV.UK",
       ].freeze
-      EXTRA_HEADINGS = ["Status", "New URL", "New Title"].freeze
+      EXTRA_HEADINGS = ["Status", "Problem summary", "Status error", "Status warning", "New URL", "New Title"].freeze
 
       def self.export_links
         path = Rails.root.join("public/data/links_to_services_provided_by_local_authorities.csv")
@@ -50,7 +53,7 @@ module LocalLinksManager
           csv << COMMON_HEADINGS + EXTRA_HEADINGS
           statuses.each do |status|
             links(object_id, status).each do |link|
-              csv << format(link).push(link.status)
+              csv << format(link).push(link.status, link.problem_summary, link.link_errors.first, link.link_warnings.first)
             end
           end
         end

--- a/app/lib/local_links_manager/export/links_exporter.rb
+++ b/app/lib/local_links_manager/export/links_exporter.rb
@@ -30,14 +30,6 @@ module LocalLinksManager
       ].freeze
       EXTRA_HEADINGS = ["Status", "Problem summary", "Status error", "Status warning", "New URL", "New Title"].freeze
 
-      def self.export_links
-        path = Rails.root.join("public/data/links_to_services_provided_by_local_authorities.csv")
-
-        File.open(path, "w") do |file|
-          new.export(file)
-        end
-      end
-
       def export(io)
         output = CSV.generate do |csv|
           csv << COMMON_HEADINGS

--- a/spec/factories/links.rb
+++ b/spec/factories/links.rb
@@ -16,10 +16,14 @@ FactoryBot.define do
   factory :broken_link, parent: :link do
     sequence(:url) { |n| "hhhttttttppp://www.example.com/broken-#{n}" }
     status { "broken" }
+    problem_summary { "Website unvailable" }
+    link_errors { ["This redirects to a page not found (404)."] }
   end
 
   factory :caution_link, parent: :link do
     status { "caution" }
+    problem_summary { "Bad redirect" }
+    link_warnings { ["This redirects too many times and will open slowly."] }
   end
 
   factory :missing_link, parent: :link do

--- a/spec/lib/local-links-manager/export/local_authority_links_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/local_authority_links_exporter_spec.rb
@@ -86,18 +86,18 @@ describe LocalLinksManager::Export::LocalAuthorityLinksExporter do
         it "exports #{status} links for enabled services for a given local authority to CSV format with headings" do
           expect(csv).to include(headings)
           links.slice(status).each_value do |link|
-            expect(csv).to include("#{la.name},#{la.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status}")
+            expect(csv).to include("#{la.name},#{la.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status},#{link.problem_summary},#{link.link_errors.first},#{link.link_warnings.first}")
           end
         end
 
         it "does not export links for disabled services" do
-          expect(csv).to_not include("#{la.name},#{la.gss},#{disabled_link.service.label}: #{disabled_link.interaction.label},#{disabled_link.service.lgsl_code},#{disabled_link.interaction.lgil_code},#{disabled_link.url},#{disabled_link.title},#{disabled_link.service.enabled},#{disabled_link.status}")
+          expect(csv).to_not include("#{la.name},#{la.gss},#{disabled_link.service.label}: #{disabled_link.interaction.label},#{disabled_link.service.lgsl_code},#{disabled_link.interaction.lgil_code},#{disabled_link.url},#{disabled_link.title},#{disabled_link.service.enabled},#{disabled_link.status},#{disabled_link.problem_summary},#{disabled_link.link_errors.first},#{disabled_link.link_warnings.first}")
         end
 
         (%w[ok broken caution missing pending] - [status]).each do |status_not_in_params|
           it "does not export #{status_not_in_params} links" do
             links.except(status).each_value do |link|
-              expect(csv).to_not include("#{la.name},#{la.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status}")
+              expect(csv).to_not include("#{la.name},#{la.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status},#{link.problem_summary},#{link.link_errors.first},#{link.link_warnings.first}")
             end
           end
         end

--- a/spec/lib/local-links-manager/export/service_links_exporter_spec.rb
+++ b/spec/lib/local-links-manager/export/service_links_exporter_spec.rb
@@ -36,18 +36,18 @@ describe LocalLinksManager::Export::LocalAuthorityLinksExporter do
         it "exports #{status} links for enabled services for a given local authority to CSV format with headings" do
           expect(csv).to include(headings)
           links.slice(status).each_value do |link|
-            expect(csv).to include("#{link.local_authority.name},#{link.local_authority.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status}")
+            expect(csv).to include("#{link.local_authority.name},#{link.local_authority.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status},#{link.problem_summary},#{link.link_errors.first},#{link.link_warnings.first}")
           end
         end
 
         it "does not export links for disabled services" do
-          expect(csv).to_not include("#{local_authority.name},#{local_authority.gss},#{disabled_link.service.label}: #{disabled_link.interaction.label},#{disabled_link.service.lgsl_code},#{disabled_link.interaction.lgil_code},#{disabled_link.url},#{disabled_link.title},#{disabled_link.service.enabled},#{disabled_link.status}")
+          expect(csv).to_not include("#{local_authority.name},#{local_authority.gss},#{disabled_link.service.label}: #{disabled_link.interaction.label},#{disabled_link.service.lgsl_code},#{disabled_link.interaction.lgil_code},#{disabled_link.url},#{disabled_link.title},#{disabled_link.service.enabled},#{disabled_link.status},#{disabled_link.problem_summary},#{disabled_link.link_errors.first},#{disabled_link.link_warnings.first}")
         end
 
         (%w[ok broken caution missing pending] - [status]).each do |status_not_in_params|
           it "does not export #{status_not_in_params} links" do
             links.except(status).each_value do |link|
-              expect(csv).to_not include("#{link.local_authority.name},#{link.local_authority.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status}")
+              expect(csv).to_not include("#{link.local_authority.name},#{link.local_authority.gss},#{link.service.label}: #{link.interaction.label},#{link.service.lgsl_code},#{link.interaction.lgil_code},#{link.url},#{link.title},#{link.service.enabled},#{link.status},#{link.problem_summary},#{link.link_errors.first},#{link.link_warnings.first}")
             end
           end
         end


### PR DESCRIPTION
## What

When we send out CSVs for local authorities to fill in, the status is currently limited to four options: `broken`, `warning`, `missing`, or `ok`. But the UI has more details on why things might be broken or what the warning is (for instance, if the page blocks bots).

## Why

Including this information in the output CSV gives more guidance to local authority staff trying to fill them in.

https://govuk.zendesk.com/agent/tickets/5859791

[Trello card](https://trello.com/c/VrZpTuv6/756-add-full-link-status-to-csv), [Jira issue PNP-5863](https://gov-uk.atlassian.net/browse/PNP-5863)

## Before:
<img width="218" height="146" alt="Screenshot 2025-07-18 at 14 20 37" src="https://github.com/user-attachments/assets/aca54986-c91f-42bd-ac4a-bb2ba523443b" />

## After:
<img width="888" height="130" alt="Screenshot 2025-07-18 at 14 19 29" src="https://github.com/user-attachments/assets/79789a55-90e0-4e7a-8423-0b9bae9788d0" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
