### PR TITLE
[PNP-9916] Pin Dalli to 4.x in local links manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rails", "8.1.3"
 gem "addressable"
 gem "aws-sdk-s3"
 gem "bootsnap", require: false
-gem "dalli"
+gem "dalli", "~> 4"
 gem "dartsass-rails"
 gem "gds-api-adapters"
 gem "gds-sso"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    dalli (5.0.2)
+    dalli (4.3.3)
       logger
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
@@ -817,7 +817,7 @@ DEPENDENCIES
   bootsnap
   capistrano-rails
   capybara
-  dalli
+  dalli (~> 4)
   dartsass-rails
   erb_lint
   factory_bot_rails

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::RailsCache,
     GovukHealthcheck::Redis,
   )
 


### PR DESCRIPTION

- Pin Dalli to 4.x so caching will still work 
- Add RailsCache to /healthcheck/ready endpoint

JIRA Card: https://gov-uk.atlassian.net/browse/PNP-9916

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
